### PR TITLE
Check for nil func before calling onClose

### DIFF
--- a/protocol/group/selector.go
+++ b/protocol/group/selector.go
@@ -90,6 +90,8 @@ func (s *Selector) NewPacketConnectionEx(ctx context.Context, conn network.Packe
 
 	s.Selector.NewPacketConnectionEx(ctx, conn, metadata, func(it error) {
 		span.RecordError(it)
-		onClose(it)
+		if onClose != nil {
+			onClose(it)
+		}
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/getlantern/engineering/issues/2551

This pull request makes a minor improvement to the `NewPacketConnectionEx` function in `protocol/group/selector.go`. The change adds a safety check to ensure that the `onClose` callback is only called if it is not `nil`, preventing a possible runtime panic.

* Added a nil check before invoking the `onClose` callback in the `NewPacketConnectionEx` function to prevent potential panics. (`protocol/group/selector.go`, [protocol/group/selector.goR93-R95](diffhunk://#diff-e21590a0a71551bf5b3fa9545dadee4fed564ed430284c813dfa1fd45aa5daebR93-R95))