### PR TITLE
feat: route VPS OTel through Teleport endpoint

### DIFF
--- a/deploy/packer/otelcol.yaml
+++ b/deploy/packer/otelcol.yaml
@@ -1,7 +1,8 @@
 # OTel Collector config for VPS proxy instances.
 # Collects host metrics (CPU, memory, disk, network) and structured logs
-# (auto-update script, etc.) and ships to SigNoz.
-# The SIGNOZ_INGEST_KEY and OTEL_RESOURCE_ATTRIBUTES env vars are set by cloud-init.
+# (auto-update script, etc.) and ships to the Teleport telemetry endpoint
+# (same pipeline as http-proxy on phosts).
+# The OTEL_RESOURCE_ATTRIBUTES env var is set by cloud-init.
 
 receivers:
   # Host-level metrics: CPU, memory, disk, network, load, filesystem
@@ -57,12 +58,10 @@ processors:
     limit_mib: 50
 
 exporters:
-  otlp/signoz:
-    endpoint: "ingest.us.signoz.cloud:443"
+  otlphttp/teleport:
+    endpoint: "https://telemetry.iantem.io:443"
     tls:
       insecure: false
-    headers:
-      "signoz-access-token": "${env:SIGNOZ_INGEST_KEY}"
     retry_on_failure:
       enabled: true
       initial_interval: 5s
@@ -74,8 +73,8 @@ service:
     metrics:
       receivers: [hostmetrics]
       processors: [memory_limiter, resourcedetection, batch]
-      exporters: [otlp/signoz]
+      exporters: [otlphttp/teleport]
     logs:
       receivers: [filelog/lantern-box]
       processors: [memory_limiter, resourcedetection, batch]
-      exporters: [otlp/signoz]
+      exporters: [otlphttp/teleport]

--- a/deploy/packer/provision.sh
+++ b/deploy/packer/provision.sh
@@ -87,7 +87,7 @@ rm -f "/tmp/${otelcol_deb}"
 cp /tmp/otelcol.yaml /etc/otelcol-contrib/config.yaml
 
 # Create empty env file with restrictive permissions — cloud-init populates it
-# with SIGNOZ_INGEST_KEY and OTEL_RESOURCE_ATTRIBUTES before starting the service.
+# with OTEL_RESOURCE_ATTRIBUTES before starting the service.
 install -m 600 -o root -g root /dev/null /etc/otelcol-contrib/otelcol.env
 
 # Systemd drop-in to load the env file

--- a/deploy/packer/provision.sh
+++ b/deploy/packer/provision.sh
@@ -243,6 +243,18 @@ chmod 644 /etc/cron.d/lantern-box-update
 systemctl unmask unattended-upgrades.service 2>/dev/null || true
 systemctl enable unattended-upgrades.service 2>/dev/null || true
 
+echo "==> Installing Tailscale client (for Headscale VPN management)"
+# Add Tailscale apt repo — works on Ubuntu 24.04 (noble)
+curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg | \
+  tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
+curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.tailscale-keyring.list | \
+  tee /etc/apt/sources.list.d/tailscale.list
+apt-get "${APT_OPTS[@]}" update -q
+apt-get "${APT_OPTS[@]}" install -y -q tailscale
+systemctl enable tailscaled
+# Do NOT run 'tailscale up' here — cloud-init provides the auth key at runtime.
+echo "    tailscale installed at $(command -v tailscale)"
+
 echo "==> Verifying installation"
 if ! command -v lantern-box >/dev/null 2>&1; then
   echo "lantern-box not found on PATH" >&2


### PR DESCRIPTION
Change otelcol-contrib exporter from direct SigNoz to telemetry.iantem.io (same pipeline as http-proxy). Removes per-VPS SIGNOZ_INGEST_KEY dependency.