### PR TITLE
fix: route VPS otelcol-contrib to ops.lantr.net

### DIFF
--- a/deploy/packer/otelcol.yaml
+++ b/deploy/packer/otelcol.yaml
@@ -1,7 +1,7 @@
 # OTel Collector config for VPS proxy instances.
 # Collects host metrics (CPU, memory, disk, network) and structured logs
-# (auto-update script, etc.) and ships to the Teleport telemetry endpoint
-# (same pipeline as http-proxy on phosts).
+# (auto-update script, etc.) and ships to the internal ops pipeline
+# (ops.lantr.net, reachable via Headscale VPN).
 # The OTEL_RESOURCE_ATTRIBUTES env var is set by cloud-init.
 
 receivers:
@@ -58,8 +58,8 @@ processors:
     limit_mib: 50
 
 exporters:
-  otlphttp/teleport:
-    endpoint: "https://telemetry.iantem.io:443"
+  otlphttp:
+    endpoint: "https://ops.lantr.net:443"
     tls:
       insecure: false
     retry_on_failure:
@@ -73,8 +73,8 @@ service:
     metrics:
       receivers: [hostmetrics]
       processors: [memory_limiter, resourcedetection, batch]
-      exporters: [otlphttp/teleport]
+      exporters: [otlphttp]
     logs:
       receivers: [filelog/lantern-box]
       processors: [memory_limiter, resourcedetection, batch]
-      exporters: [otlphttp/teleport]
+      exporters: [otlphttp]


### PR DESCRIPTION
## Summary

- Change otelcol-contrib exporter from `telemetry.iantem.io` (public Teleport endpoint) to `ops.lantr.net` (internal ops pipeline)
- VPS proxies now join Headscale VPN at boot, so they can reach internal services
- Aligns with Reflog's feedback on lantern-cloud PR #2484

Requires packer image rebuild after merge.

## Test plan

- [ ] Merge and trigger packer image rebuild
- [ ] Provision a VPS, verify host metrics appear in SigNoz via ops pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)