### PR TITLE
fix: add apt acquire timeouts to prevent Packer build hangs

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -154,8 +154,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
-    # Alicloud copies images to 8 regions (up to 2h). Others are fast.
-    timeout-minutes: ${{ matrix.builder == 'alicloud-ecs' && 150 || 45 }}
+    # Alicloud copies images to 8 regions (up to 2h). OCI builds 36 regions
+    # in parallel — usually ~7min but a slow mirror can push past 45min.
+    timeout-minutes: ${{ matrix.builder == 'alicloud-ecs' && 150 || 60 }}
 
     steps:
       - name: Checkout

--- a/deploy/packer/provision.sh
+++ b/deploy/packer/provision.sh
@@ -43,7 +43,15 @@ fi
 
 # DPkg::Lock::Timeout makes apt-get wait for the dpkg lock instead of failing
 # immediately. This is a safety net in case a dpkg process is still finishing.
-APT_OPTS=(-o DPkg::Lock::Timeout=300)
+# Acquire timeouts prevent apt from hanging indefinitely when an OCI region's
+# local Ubuntu mirror is slow or unreachable (e.g., ca-toronto-1 mirror timeout
+# caused a 38-minute hang that exceeded the Packer job timeout).
+APT_OPTS=(
+  -o DPkg::Lock::Timeout=300
+  -o Acquire::http::Timeout=30
+  -o Acquire::https::Timeout=30
+  -o Acquire::Retries=3
+)
 
 echo "==> Installing runtime dependencies"
 apt-get "${APT_OPTS[@]}" update -q

--- a/deploy/packer/provision.sh
+++ b/deploy/packer/provision.sh
@@ -44,8 +44,9 @@ fi
 # DPkg::Lock::Timeout makes apt-get wait for the dpkg lock instead of failing
 # immediately. This is a safety net in case a dpkg process is still finishing.
 # Acquire timeouts prevent apt from hanging indefinitely when an OCI region's
-# local Ubuntu mirror is slow or unreachable (e.g., ca-toronto-1 mirror timeout
-# caused a 38-minute hang that exceeded the Packer job timeout).
+# local Ubuntu mirror is slow or unreachable (e.g., the ca-toronto-1 mirror
+# became unreachable and, without an acquire timeout, apt hung for 38 minutes
+# until the Packer job itself timed out).
 APT_OPTS=(
   -o DPkg::Lock::Timeout=300
   -o Acquire::http::Timeout=30


### PR DESCRIPTION
## Summary
The latest OCI Packer build timed out at 45 minutes because **ca-toronto-1 (YYZ)** hung during `apt-get update` — its local Ubuntu mirror was unreachable. All other 35 regions finished in ~7 minutes.

## Changes
- Add `Acquire::http::Timeout=30` and `Acquire::Retries=3` to `APT_OPTS` in `provision.sh` so a stuck mirror fails fast and retries instead of hanging indefinitely
- Bump non-Alicloud job timeout from 45 to 60 minutes for margin

## Context
The `debconf: delaying package configuration, since apt-utils is not installed` warnings in the logs are harmless — standard on Ubuntu Minimal images. The actual issue was YYZ's apt stuck with `Ign:1` on `ca-toronto-1-ad-1.clouds.ports.ubuntu.com` with no timeout configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)