### PR TITLE
fix: create lantern user in packer image for Tailscale SSH

### DIFF
--- a/deploy/packer/provision.sh
+++ b/deploy/packer/provision.sh
@@ -255,11 +255,16 @@ systemctl enable unattended-upgrades.service 2>/dev/null || true
 echo "==> Creating lantern management user (for Tailscale SSH via Headscale ACL)"
 # The Headscale ACL grants group:dev SSH access to tag:external nodes as user "lantern".
 # Tailscale SSH looks up the user locally, so it must exist in /etc/passwd.
-useradd --system --create-home --shell /bin/bash --comment "Lantern management" lantern
+if id -u lantern >/dev/null 2>&1; then
+  echo "    lantern user already exists"
+else
+  useradd --system --create-home --shell /bin/bash --comment "Lantern management" lantern
+fi
 # Grant passwordless sudo so operators can perform admin tasks after SSH.
 echo "lantern ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/lantern
 chmod 440 /etc/sudoers.d/lantern
-echo "    lantern user created at $(id lantern)"
+visudo -cf /etc/sudoers.d/lantern
+echo "    lantern user present at $(id lantern)"
 
 echo "==> Installing Tailscale client (for Headscale VPN management)"
 # Add Tailscale apt repo — works on Ubuntu 24.04 (noble)

--- a/deploy/packer/provision.sh
+++ b/deploy/packer/provision.sh
@@ -252,6 +252,15 @@ chmod 644 /etc/cron.d/lantern-box-update
 systemctl unmask unattended-upgrades.service 2>/dev/null || true
 systemctl enable unattended-upgrades.service 2>/dev/null || true
 
+echo "==> Creating lantern management user (for Tailscale SSH via Headscale ACL)"
+# The Headscale ACL grants group:dev SSH access to tag:external nodes as user "lantern".
+# Tailscale SSH looks up the user locally, so it must exist in /etc/passwd.
+useradd --system --create-home --shell /bin/bash --comment "Lantern management" lantern
+# Grant passwordless sudo so operators can perform admin tasks after SSH.
+echo "lantern ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/lantern
+chmod 440 /etc/sudoers.d/lantern
+echo "    lantern user created at $(id lantern)"
+
 echo "==> Installing Tailscale client (for Headscale VPN management)"
 # Add Tailscale apt repo — works on Ubuntu 24.04 (noble)
 curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg | \


### PR DESCRIPTION
## Summary

- Creates a `lantern` system user in the packer image during build
- Grants passwordless sudo so operators can administer the VPS after SSH

## Problem

The Headscale ACL policy allows `group:dev` to SSH to `tag:external` VPS nodes **as user `lantern`**. When connecting, Tailscale SSH defers user lookup to the local OS — but the `lantern` user never existed in the packer image.

**Result:** `tailscale: failed to look up local user "lantern"` on every SSH attempt, making Tailscale SSH unusable for all VPS management.

**Verified:** All ~80+ VPS nodes show up in `tailscale status` as `tag:external` on the tailnet, and the Tailscale SSH handshake reaches the server correctly. The only failure was the missing user.

## Fix

Add in `provision.sh` (baked into all future packer images):
```bash
useradd --system --create-home --shell /bin/bash lantern
echo "lantern ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/lantern
```

## Note on existing VPS nodes

Existing nodes need a new packer image to pick this up. After rebuilding images and rolling out new VPSes, Tailscale SSH will work. Existing nodes can still be accessed via the VPS provider console.

## Test plan

- [ ] Build new packer image with this change
- [ ] Launch a VPS from the new image
- [ ] Verify `ssh lantern@vps-XXXXXXXX` via Tailscale succeeds
- [ ] Verify `sudo` works as `lantern`

🤖 Generated with [Claude Code](https://claude.com/claude-code)