### PR TITLE
ci: trigger auto-tag on packer provisioning changes

### DIFF
--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -10,6 +10,7 @@ on:
       - 'Dockerfile'
       - 'Dockerfile.goreleaser'
       - 'cmd/release/*.service'
+      - 'deploy/packer/**'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add `deploy/packer/**` to the auto-tag workflow's path filter
- Previously, changes to packer provisioning scripts (like adding the `lantern` user for Tailscale SSH in #226) didn't trigger a release or packer image rebuild

## Test plan
- [ ] Merge this PR → should NOT auto-tag (only .yaml changed, not in paths)
- [ ] Future changes to `deploy/packer/provision.sh` should trigger auto-tag → release → image build

🤖 Generated with [Claude Code](https://claude.com/claude-code)