### PR TITLE
fix: use public SigNoz endpoint for VPS OTel metrics

### DIFF
--- a/deploy/packer/otelcol.yaml
+++ b/deploy/packer/otelcol.yaml
@@ -1,7 +1,8 @@
 # OTel Collector config for VPS proxy instances.
 # Collects host metrics (CPU, memory, disk, network) and structured logs
-# (auto-update script, etc.) and ships to the internal ops pipeline
-# (ops.lantr.net, reachable via Headscale VPN).
+# (auto-update script, etc.) and ships to the public SigNoz ingest
+# endpoint (telemetry.iantem.io). VPS boxes are not on the GCP VPC,
+# so they can't reach the internal ops.lantr.net endpoint.
 # The OTEL_RESOURCE_ATTRIBUTES env var is set by cloud-init.
 
 receivers:
@@ -59,7 +60,7 @@ processors:
 
 exporters:
   otlphttp:
-    endpoint: "https://ops.lantr.net:443"
+    endpoint: "https://telemetry.iantem.io:443"
     tls:
       insecure: false
     retry_on_failure:


### PR DESCRIPTION
## Summary
Change the VPS OTel collector endpoint from `ops.lantr.net` (GCP internal) to `telemetry.iantem.io` (public SigNoz ingest).

## Root cause
VPS instances are on OCI/Alicloud/Linode and can't reach `ops.lantr.net` which resolves to `10.6.4.22` (GCP VPC internal IP). The OTel collector was failing with "context deadline exceeded" on every metrics export.

## Note
This changes the packer image config. Existing VPS instances will pick up the fix on next auto-update (the otelcol config is baked into the image, so a new image build + reprovisioning is needed for existing instances). New instances provisioned after the image rebuild will work immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)