### PR TITLE
fix: install Lanternet CA cert so VPS metrics reach ops.lantr.net

### DIFF
--- a/deploy/packer/otelcol.yaml
+++ b/deploy/packer/otelcol.yaml
@@ -1,7 +1,7 @@
 # OTel Collector config for VPS proxy instances.
 # Collects host metrics (CPU, memory, disk, network) and structured logs
 # (auto-update script, etc.) and ships to the internal ops pipeline
-# (ops.lantr.net, reachable via Headscale VPN).
+# (ops.lantr.net, reachable via Headscale VPN relay with --accept-routes).
 # The OTEL_RESOURCE_ATTRIBUTES env var is set by cloud-init.
 
 receivers:

--- a/deploy/packer/provision.sh
+++ b/deploy/packer/provision.sh
@@ -278,6 +278,19 @@ systemctl enable tailscaled
 # Do NOT run 'tailscale up' here — cloud-init provides the auth key at runtime.
 echo "    tailscale installed at $(command -v tailscale)"
 
+echo "==> Installing Lanternet internal CA certificate"
+# The internal ops pipeline (ops.lantr.net) uses a cert signed by the Lanternet
+# private CA. Install the CA cert so OTel collectors and the datacap sidecar
+# can reach internal services via TLS.
+mkdir -p /usr/local/share/ca-certificates/lantern
+curl -fsSL -o /usr/local/share/ca-certificates/lantern/lanternet.crt \
+  "http://privateca-content-62724385-0000-2889-acf2-f403043a1bac.storage.googleapis.com/71406e3543f7e5be892e/ca.crt"
+# Verify checksum (cert expires 2032)
+echo "c9d283c11de3b7d38f1eb38fabcfbcff9b77f302d3eaf506ae691bb14cca792d  /usr/local/share/ca-certificates/lantern/lanternet.crt" \
+  | sha256sum -c -
+update-ca-certificates
+echo "    lanternet CA installed"
+
 echo "==> Verifying installation"
 if ! command -v lantern-box >/dev/null 2>&1; then
   echo "lantern-box not found on PATH" >&2

--- a/deploy/packer/provision.sh
+++ b/deploy/packer/provision.sh
@@ -283,8 +283,9 @@ echo "==> Installing Lanternet internal CA certificate"
 # private CA. Install the CA cert so OTel collectors and the datacap sidecar
 # can reach internal services via TLS.
 mkdir -p /usr/local/share/ca-certificates/lantern
-curl -fsSL -o /usr/local/share/ca-certificates/lantern/lanternet.crt \
-  "http://privateca-content-62724385-0000-2889-acf2-f403043a1bac.storage.googleapis.com/71406e3543f7e5be892e/ca.crt"
+curl -fsSL --retry 5 --connect-timeout 10 --max-time 60 \
+  -o /usr/local/share/ca-certificates/lantern/lanternet.crt \
+  "https://privateca-content-62724385-0000-2889-acf2-f403043a1bac.storage.googleapis.com/71406e3543f7e5be892e/ca.crt"
 # Verify checksum (cert expires 2032)
 echo "c9d283c11de3b7d38f1eb38fabcfbcff9b77f302d3eaf506ae691bb14cca792d  /usr/local/share/ca-certificates/lantern/lanternet.crt" \
   | sha256sum -c -


### PR DESCRIPTION
## Summary
- Install the Lanternet internal CA cert during packer provisioning so VPS instances trust `ops.lantr.net`
- Update otelcol.yaml comment to note Headscale relay + `--accept-routes` requirement

## Root cause
VPS OTel collectors and lantern-box couldn't verify the TLS cert for `ops.lantr.net` — it's signed by the Lanternet private CA which wasn't in the trust store. Error: `x509: certificate signed by unknown authority`. No VPS metrics (throughput, connections, host metrics) reached SigNoz.

## Fix
Download and install the same CA cert that Ansible installs on phosts (from `lantern-cloud/ans/tasks/install-lanternet-ca.yaml`). With the CA trusted + `--accept-routes` for Headscale relay routing, the internal `ops.lantr.net` endpoint works from VPS instances.

## Test plan
- [ ] Packer image build succeeds (checksum verification passes)
- [ ] New VPS: `curl https://ops.lantr.net` succeeds without TLS errors
- [ ] OTel collector logs show successful metric exports
- [ ] Dashboard tracks tab shows throughput data

🤖 Generated with [Claude Code](https://claude.com/claude-code)