### PR TITLE
fix: clear URL test history when callback URLs change

### DIFF
--- a/protocol/group/mutableurltest.go
+++ b/protocol/group/mutableurltest.go
@@ -388,6 +388,13 @@ func (g *urlTestGroup) SetURLOverrides(overrides map[string]string) {
 	g.access.Lock()
 	defer g.access.Unlock()
 	g.urlOverrides = maps.Clone(overrides)
+	// Clear URL test history for overridden tags so the next test cycle
+	// re-tests them with the new callback URLs. Without this, outbounds
+	// tested recently (within the 3-min interval) with OLD URLs would be
+	// skipped, and the new bandit probe callbacks would never fire.
+	for tag := range overrides {
+		g.history.DeleteURLTestHistory(tag)
+	}
 }
 
 func (g *urlTestGroup) Remove(tags []string) (n int, err error) {

--- a/protocol/group/mutableurltest.go
+++ b/protocol/group/mutableurltest.go
@@ -390,7 +390,7 @@ func (g *urlTestGroup) SetURLOverrides(overrides map[string]string) {
 	g.urlOverrides = maps.Clone(overrides)
 	// Clear URL test history for overridden tags so the next test cycle
 	// re-tests them with the new callback URLs. Without this, outbounds
-	// tested recently (within the 3-min interval) with OLD URLs would be
+	// tested recently (within the configured interval) with OLD URLs would be
 	// skipped, and the new bandit probe callbacks would never fire.
 	for tag := range overrides {
 		g.history.DeleteURLTestHistory(tag)


### PR DESCRIPTION
## Summary
Clear URL test history for overridden tags in SetURLOverrides so they are re-tested with the new callback URLs.

## Root cause
When the checkLoop timer fires near a config refresh, it skips recently-tested outbounds via history check. Since SetURLOverrides didn't clear history, outbounds tested with OLD URLs were skipped, and new probe callbacks never fired. ~20% failure rate.

## Fix
Call DeleteURLTestHistory for each tag when SetURLOverrides is called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)