### PR TITLE
feat: 6-worker pool + client delay reporting for URL tests

### DIFF
--- a/protocol/group/mutableurltest.go
+++ b/protocol/group/mutableurltest.go
@@ -13,7 +13,6 @@ import (
 	"net/url"
 	"slices"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -557,8 +556,8 @@ func (g *urlTestGroup) urlTest(ctx context.Context, force bool) (map[string]uint
 			// Append as &cd=<ms> so the server can subtract scheduling overhead
 			// from the callback latency to get true proxy roundtrip time.
 			queueDelay := time.Since(submitTime)
-			if queueDelay > 5*time.Millisecond && strings.Contains(testURL, "?") {
-				testURL += "&cd=" + strconv.FormatInt(queueDelay.Milliseconds(), 10)
+			if queueDelay > 5*time.Millisecond {
+				testURL = appendClientDelay(testURL, queueDelay)
 			}
 			testCtx, cancel := context.WithTimeout(ctx, C.TCPTimeout)
 			defer cancel()
@@ -736,4 +735,16 @@ func urlTestGET(ctx context.Context, link string, detour N.Dialer) (uint16, erro
 	io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 	return uint16(time.Since(start) / time.Millisecond), nil
+}
+
+// appendClientDelay adds a &cd=<ms> query parameter to the given URL.
+func appendClientDelay(rawURL string, delay time.Duration) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := u.Query()
+	q.Set("cd", strconv.FormatInt(delay.Milliseconds(), 10))
+	u.RawQuery = q.Encode()
+	return u.String()
 }

--- a/protocol/group/mutableurltest.go
+++ b/protocol/group/mutableurltest.go
@@ -12,6 +12,8 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -521,9 +523,10 @@ func (g *urlTestGroup) urlTest(ctx context.Context, force bool) (map[string]uint
 	}
 	g.logger.Trace("checking outbounds...")
 	defer g.checking.Store(false)
-	b, _ := batch.New(ctx, batch.WithConcurrencyNum[any](10))
+	b, _ := batch.New(ctx, batch.WithConcurrencyNum[any](6))
 	checked := make(map[string]bool)
 	var resultAccess sync.Mutex
+	submitTime := time.Now() // track when outbounds were queued for delay reporting
 	for tag, outbound := range g.outbounds.Iter() {
 		// if outbound is an urltest group, start its own url test and skip
 		if testGroup, isURLTestGroup := outbound.(A.URLTestGroup); isURLTestGroup {
@@ -550,6 +553,13 @@ func (g *urlTestGroup) urlTest(ctx context.Context, force bool) (map[string]uint
 		}
 		testURL := g.testURLForTag(tag)
 		b.Go(realTag, func() (any, error) {
+			// Compute how long this outbound waited in the worker pool queue.
+			// Append as &cd=<ms> so the server can subtract scheduling overhead
+			// from the callback latency to get true proxy roundtrip time.
+			queueDelay := time.Since(submitTime)
+			if queueDelay > 5*time.Millisecond && strings.Contains(testURL, "?") {
+				testURL += "&cd=" + strconv.FormatInt(queueDelay.Milliseconds(), 10)
+			}
 			testCtx, cancel := context.WithTimeout(ctx, C.TCPTimeout)
 			defer cancel()
 			g.logger.Trace("checking outbound", "tag", realTag)

--- a/protocol/group/mutableurltest_test.go
+++ b/protocol/group/mutableurltest_test.go
@@ -2,6 +2,7 @@ package group
 
 import (
 	"context"
+	"net/url"
 	"testing"
 	"time"
 
@@ -21,7 +22,7 @@ func TestURLTestGroup_CloseStopsCheckLoop(t *testing.T) {
 		sboxLog.NewNOPFactory().Logger(),
 		[]string{"test"},
 		"https://example.com",
-		nil, // no URL overrides
+		nil,                 // no URL overrides
 		10*time.Millisecond, // fast interval
 		time.Minute,
 		50,
@@ -331,4 +332,58 @@ func (m *mockPauseManager) RegisterCallback(callback pause.Callback) *list.Eleme
 }
 
 func (m *mockPauseManager) UnregisterCallback(element *list.Element[pause.Callback]) {
+}
+
+func TestAppendClientDelay(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawURL   string
+		delay    time.Duration
+		wantCD   string
+		wantPath string
+	}{
+		{
+			name:   "URL with existing query params",
+			rawURL: "https://example.com/callback?token=abc",
+			delay:  150 * time.Millisecond,
+			wantCD: "150",
+		},
+		{
+			name:   "URL without query params",
+			rawURL: "https://example.com/callback",
+			delay:  42 * time.Millisecond,
+			wantCD: "42",
+		},
+		{
+			name:   "URL with multiple params",
+			rawURL: "https://example.com/cb?a=1&b=2",
+			delay:  300 * time.Millisecond,
+			wantCD: "300",
+		},
+		{
+			name:   "sub-millisecond delay rounds to zero",
+			rawURL: "https://example.com/cb?x=1",
+			delay:  500 * time.Microsecond,
+			wantCD: "0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := appendClientDelay(tt.rawURL, tt.delay)
+			u, err := url.Parse(result)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantCD, u.Query().Get("cd"))
+			// Original path preserved
+			orig, _ := url.Parse(tt.rawURL)
+			assert.Equal(t, orig.Path, u.Path)
+			assert.Equal(t, orig.Host, u.Host)
+		})
+	}
+}
+
+func TestAppendClientDelay_InvalidURL(t *testing.T) {
+	// Invalid URLs are returned unchanged
+	bad := "://not-a-url"
+	assert.Equal(t, bad, appendClientDelay(bad, 100*time.Millisecond))
 }


### PR DESCRIPTION
## Summary
- Lower URL test concurrency from 10 to 6 workers (bounds memory)
- Report client-side queue delay via \`&cd=<ms>\` on callback URLs
- Server subtracts this to get true proxy roundtrip time

## Dependencies
- Server: lantern-cloud PR #2550 (parses \`&cd=\` param)

🤖 Generated with [Claude Code](https://claude.com/claude-code)