### PR TITLE
feat: Reflex protocol — server-initiated TLS to defeat censorship

### DIFF
--- a/constant/proxy.go
+++ b/constant/proxy.go
@@ -4,6 +4,7 @@ const (
 	TypeAmnezia  = "amnezia"
 	TypeALGeneva = "algeneva"
 	TypeOutline  = "outline"
+	TypeReflex   = "reflex"
 	TypeSamizdat = "samizdat"
 	TypeWATER    = "water"
 )

--- a/option/reflex.go
+++ b/option/reflex.go
@@ -33,9 +33,10 @@ type ReflexOutboundOptions struct {
 type ReflexInboundOptions struct {
 	option.ListenOptions
 
-	// AuthTokens contains the SHA-256 fingerprints (hex-encoded) of allowed
-	// client certificates. Only connections presenting a certificate with a
-	// matching fingerprint are accepted.
+	// AuthTokens contains the SHA-256 fingerprints (lowercase hex-encoded) of
+	// allowed peer certificates. In Reflex, the TCP client acts as TLS server
+	// and presents a certificate; the TCP server validates its fingerprint.
+	// Only connections with a matching fingerprint are accepted.
 	AuthTokens []string `json:"auth_tokens"`
 
 	// ServerName is the SNI sent in the TLS ClientHello.

--- a/option/reflex.go
+++ b/option/reflex.go
@@ -7,18 +7,19 @@ import "github.com/sagernet/sing-box/option"
 // initiates the TLS handshake (sends ClientHello). This defeats SNI
 // extraction and JA3/JA4 fingerprinting by the censor, since no
 // ClientHello ever appears in the client→server direction.
+//
+// Authentication: the server validates the client's TLS certificate
+// fingerprint (SHA-256 of the DER-encoded certificate). No pre-handshake
+// bytes are exchanged — the entire auth is within standard TLS.
 type ReflexOutboundOptions struct {
 	option.DialerOptions
 	option.ServerOptions
 
-	// AuthToken is a pre-shared 8-byte token (hex-encoded, 16 chars) sent
-	// before the TLS handshake to identify this as a Reflex client.
-	AuthToken string `json:"auth_token"`
-
 	// TLS certificate for the client's TLS server role.
-	// Can be provided inline or as file paths.
-	CertPEM string `json:"cert_pem,omitempty"`
-	KeyPEM  string `json:"key_pem,omitempty"`
+	// The SHA-256 fingerprint of this cert serves as authentication —
+	// the server validates it during the TLS handshake.
+	CertPEM  string `json:"cert_pem,omitempty"`
+	KeyPEM   string `json:"key_pem,omitempty"`
 	CertPath string `json:"cert_path,omitempty"`
 	KeyPath  string `json:"key_path,omitempty"`
 
@@ -27,13 +28,14 @@ type ReflexOutboundOptions struct {
 }
 
 // ReflexInboundOptions configures a Reflex inbound proxy.
-// The TCP server acts as the TLS client — it sends ClientHello after
-// receiving the auth token from the TCP client.
+// The TCP server acts as the TLS client — it sends ClientHello immediately
+// upon accepting a connection, then validates the peer's certificate.
 type ReflexInboundOptions struct {
 	option.ListenOptions
 
-	// AuthTokens is the set of valid pre-shared tokens (hex-encoded).
-	// Connections with invalid tokens are closed.
+	// AuthTokens contains the SHA-256 fingerprints (hex-encoded) of allowed
+	// client certificates. Only connections presenting a certificate with a
+	// matching fingerprint are accepted.
 	AuthTokens []string `json:"auth_tokens"`
 
 	// ServerName is the SNI sent in the TLS ClientHello.

--- a/option/reflex.go
+++ b/option/reflex.go
@@ -1,0 +1,42 @@
+package option
+
+import "github.com/sagernet/sing-box/option"
+
+// ReflexOutboundOptions configures a Reflex outbound proxy.
+// In Reflex, the TCP client acts as the TLS server — the proxy server
+// initiates the TLS handshake (sends ClientHello). This defeats SNI
+// extraction and JA3/JA4 fingerprinting by the censor, since no
+// ClientHello ever appears in the client→server direction.
+type ReflexOutboundOptions struct {
+	option.DialerOptions
+	option.ServerOptions
+
+	// AuthToken is a pre-shared 8-byte token (hex-encoded, 16 chars) sent
+	// before the TLS handshake to identify this as a Reflex client.
+	AuthToken string `json:"auth_token"`
+
+	// TLS certificate for the client's TLS server role.
+	// Can be provided inline or as file paths.
+	CertPEM string `json:"cert_pem,omitempty"`
+	KeyPEM  string `json:"key_pem,omitempty"`
+	CertPath string `json:"cert_path,omitempty"`
+	KeyPath  string `json:"key_path,omitempty"`
+
+	// ConnectTimeout for the TCP + reversed TLS handshake (default: "15s").
+	ConnectTimeout string `json:"connect_timeout,omitempty"`
+}
+
+// ReflexInboundOptions configures a Reflex inbound proxy.
+// The TCP server acts as the TLS client — it sends ClientHello after
+// receiving the auth token from the TCP client.
+type ReflexInboundOptions struct {
+	option.ListenOptions
+
+	// AuthTokens is the set of valid pre-shared tokens (hex-encoded).
+	// Connections with invalid tokens are closed.
+	AuthTokens []string `json:"auth_tokens"`
+
+	// ServerName is the SNI sent in the TLS ClientHello.
+	// Since the server sends the ClientHello, this is invisible to the censor.
+	ServerName string `json:"server_name,omitempty"`
+}

--- a/protocol/reflex/inbound.go
+++ b/protocol/reflex/inbound.go
@@ -2,11 +2,12 @@ package reflex
 
 import (
 	"context"
-	"crypto/sha256"
 	"crypto/tls"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"net"
+	"strings"
 
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/adapter/inbound"
@@ -25,27 +26,28 @@ func RegisterInbound(registry *inbound.Registry) {
 
 // Inbound implements the server side of Reflex. It accepts TCP connections,
 // immediately sends a TLS ClientHello (reversed role), then validates the
-// client's TLS certificate fingerprint as authentication. No pre-handshake
-// bytes are exchanged — the entire flow looks like a TLS connection where
-// the server speaks first.
+// peer's certificate fingerprint as authentication.
 type Inbound struct {
 	inbound.Adapter
-	ctx            context.Context
-	logger         log.ContextLogger
-	router         adapter.Router
-	listener       *listener.Listener
-	certFPs        map[string]bool // allowed SHA-256 cert fingerprints (hex)
-	serverName     string
+	ctx        context.Context
+	logger     log.ContextLogger
+	router     adapter.Router
+	listener   *listener.Listener
+	certFPs    map[string]bool // allowed SHA-256 cert fingerprints (lowercase hex)
+	serverName string
 }
 
 func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger, tag string, options option.ReflexInboundOptions) (adapter.Inbound, error) {
-	// Parse allowed certificate fingerprints
 	fps := make(map[string]bool, len(options.AuthTokens))
 	for _, fp := range options.AuthTokens {
-		fps[fp] = true
+		normalized := strings.ToLower(strings.TrimSpace(fp))
+		if len(normalized) != 64 {
+			return nil, fmt.Errorf("reflex: invalid auth_tokens entry %q (expected 64 hex chars / SHA-256)", fp)
+		}
+		fps[normalized] = true
 	}
 	if len(fps) == 0 {
-		return nil, fmt.Errorf("reflex: at least one auth_token (cert fingerprint) is required")
+		return nil, fmt.Errorf("reflex: at least one auth_tokens entry (cert fingerprint) is required")
 	}
 
 	serverName := options.ServerName
@@ -74,40 +76,45 @@ func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger
 }
 
 // NewConnectionEx handles a new TCP connection with the reversed TLS handshake.
-// The server immediately acts as TLS client — no pre-handshake bytes needed.
 func (i *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
-	// 1. Act as TLS client — send ClientHello immediately.
-	// Request the peer's certificate for authentication.
+	// Act as TLS client — send ClientHello immediately.
+	// InsecureSkipVerify is intentional: the peer presents a self-signed cert
+	// and we authenticate by validating its SHA-256 fingerprint against the
+	// pre-shared list. Standard CA validation is not applicable here.
 	tlsConn := tls.Client(conn, &tls.Config{
 		ServerName:         i.serverName,
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: true, //nolint:gosec // auth via cert fingerprint, not CA chain
 	})
 	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		N.CloseOnHandshakeFailure(conn, onClose, fmt.Errorf("reflex: TLS handshake: %w", err))
 		return
 	}
 
-	// 2. Validate the peer's certificate fingerprint
+	// Validate peer certificate fingerprint
 	state := tlsConn.ConnectionState()
 	if len(state.PeerCertificates) == 0 {
 		N.CloseOnHandshakeFailure(tlsConn, onClose, fmt.Errorf("reflex: no peer certificate"))
 		return
 	}
-	hash := sha256.Sum256(state.PeerCertificates[0].Raw)
-	fp := fmt.Sprintf("%x", hash)
+	fp := DERFingerprint(state.PeerCertificates[0].Raw)
 	if !i.certFPs[fp] {
 		i.logger.DebugContext(ctx, "reflex: unknown cert fingerprint: ", fp)
 		N.CloseOnHandshakeFailure(tlsConn, onClose, fmt.Errorf("reflex: unauthorized"))
 		return
 	}
 
-	// 3. Read destination: 1 byte length + host:port string
-	lenBuf := make([]byte, 1)
-	if _, err := io.ReadFull(tlsConn, lenBuf); err != nil {
+	// Read destination: 2-byte big-endian length + host:port string
+	var lenBuf [2]byte
+	if _, err := io.ReadFull(tlsConn, lenBuf[:]); err != nil {
 		N.CloseOnHandshakeFailure(tlsConn, onClose, fmt.Errorf("reflex: read destination length: %w", err))
 		return
 	}
-	destBuf := make([]byte, lenBuf[0])
+	destLen := binary.BigEndian.Uint16(lenBuf[:])
+	if destLen == 0 || destLen > 4096 {
+		N.CloseOnHandshakeFailure(tlsConn, onClose, fmt.Errorf("reflex: invalid destination length %d", destLen))
+		return
+	}
+	destBuf := make([]byte, destLen)
 	if _, err := io.ReadFull(tlsConn, destBuf); err != nil {
 		N.CloseOnHandshakeFailure(tlsConn, onClose, fmt.Errorf("reflex: read destination: %w", err))
 		return
@@ -116,7 +123,6 @@ func (i *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata a
 
 	i.logger.TraceContext(ctx, "reflex connection from ", metadata.Source, " to ", destination)
 
-	// 4. Route through sing-box
 	metadata.Inbound = i.Tag()
 	metadata.InboundType = constant.TypeReflex
 	metadata.Destination = destination

--- a/protocol/reflex/inbound.go
+++ b/protocol/reflex/inbound.go
@@ -1,0 +1,140 @@
+package reflex
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/inbound"
+	"github.com/sagernet/sing-box/common/listener"
+	"github.com/sagernet/sing-box/log"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+
+	"github.com/getlantern/lantern-box/constant"
+	"github.com/getlantern/lantern-box/option"
+)
+
+func RegisterInbound(registry *inbound.Registry) {
+	inbound.Register[option.ReflexInboundOptions](registry, constant.TypeReflex, NewInbound)
+}
+
+// Inbound implements the server side of Reflex. It accepts TCP connections,
+// reads an auth token, then acts as a TLS client (sends ClientHello to the
+// TCP client). After the reversed TLS handshake, it reads the destination
+// and routes traffic through the sing-box router.
+type Inbound struct {
+	inbound.Adapter
+	ctx        context.Context
+	logger     log.ContextLogger
+	router     adapter.Router
+	listener   *listener.Listener
+	authTokens map[string]bool
+	serverName string
+}
+
+func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger, tag string, options option.ReflexInboundOptions) (adapter.Inbound, error) {
+	tokens := make(map[string]bool, len(options.AuthTokens))
+	for _, t := range options.AuthTokens {
+		b, err := hex.DecodeString(t)
+		if err != nil || len(b) != 8 {
+			return nil, fmt.Errorf("reflex: invalid auth_token %q (must be 16 hex chars)", t)
+		}
+		tokens[string(b)] = true
+	}
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("reflex: at least one auth_token is required")
+	}
+
+	serverName := options.ServerName
+	if serverName == "" {
+		serverName = "www.example.com"
+	}
+
+	ib := &Inbound{
+		Adapter:    inbound.NewAdapter(constant.TypeReflex, tag),
+		ctx:        ctx,
+		logger:     lg,
+		router:     router,
+		authTokens: tokens,
+		serverName: serverName,
+	}
+
+	ib.listener = listener.New(listener.Options{
+		Context:           ctx,
+		Logger:            lg,
+		Network:           []string{N.NetworkTCP},
+		Listen:            options.ListenOptions,
+		ConnectionHandler: ib,
+	})
+
+	return ib, nil
+}
+
+// NewConnectionEx handles a new TCP connection with the reversed TLS handshake.
+func (i *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	// 1. Read 8-byte auth token
+	token := make([]byte, 8)
+	if _, err := io.ReadFull(conn, token); err != nil {
+		N.CloseOnHandshakeFailure(conn, onClose, fmt.Errorf("reflex: read auth token: %w", err))
+		return
+	}
+
+	// 2. Validate token
+	if !i.authTokens[string(token)] {
+		slog.Debug("reflex: invalid auth token, closing connection")
+		N.CloseOnHandshakeFailure(conn, onClose, fmt.Errorf("reflex: invalid auth token"))
+		return
+	}
+
+	// 3. Act as TLS client — send ClientHello to the TCP client
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName:         i.serverName,
+		InsecureSkipVerify: true,
+	})
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		N.CloseOnHandshakeFailure(conn, onClose, fmt.Errorf("reflex: TLS handshake: %w", err))
+		return
+	}
+
+	// 4. Read destination: 1 byte length + host:port string
+	lenBuf := make([]byte, 1)
+	if _, err := io.ReadFull(tlsConn, lenBuf); err != nil {
+		N.CloseOnHandshakeFailure(tlsConn, onClose, fmt.Errorf("reflex: read destination length: %w", err))
+		return
+	}
+	destBuf := make([]byte, lenBuf[0])
+	if _, err := io.ReadFull(tlsConn, destBuf); err != nil {
+		N.CloseOnHandshakeFailure(tlsConn, onClose, fmt.Errorf("reflex: read destination: %w", err))
+		return
+	}
+	destination := M.ParseSocksaddr(string(destBuf))
+
+	i.logger.TraceContext(ctx, "reflex connection from ", metadata.Source, " to ", destination)
+
+	// 5. Route through sing-box
+	metadata.Inbound = i.Tag()
+	metadata.InboundType = constant.TypeReflex
+	metadata.Destination = destination
+
+	i.router.RouteConnectionEx(ctx, tlsConn, metadata, onClose)
+}
+
+func (i *Inbound) Start(stage adapter.StartStage) error {
+	if stage != adapter.StartStateStart {
+		return nil
+	}
+	return i.listener.Start()
+}
+
+func (i *Inbound) Close() error {
+	if i.listener != nil {
+		return i.listener.Close()
+	}
+	return nil
+}

--- a/protocol/reflex/inbound.go
+++ b/protocol/reflex/inbound.go
@@ -2,11 +2,10 @@ package reflex
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
-	"encoding/hex"
 	"fmt"
 	"io"
-	"log/slog"
 	"net"
 
 	"github.com/sagernet/sing-box/adapter"
@@ -25,30 +24,28 @@ func RegisterInbound(registry *inbound.Registry) {
 }
 
 // Inbound implements the server side of Reflex. It accepts TCP connections,
-// reads an auth token, then acts as a TLS client (sends ClientHello to the
-// TCP client). After the reversed TLS handshake, it reads the destination
-// and routes traffic through the sing-box router.
+// immediately sends a TLS ClientHello (reversed role), then validates the
+// client's TLS certificate fingerprint as authentication. No pre-handshake
+// bytes are exchanged — the entire flow looks like a TLS connection where
+// the server speaks first.
 type Inbound struct {
 	inbound.Adapter
-	ctx        context.Context
-	logger     log.ContextLogger
-	router     adapter.Router
-	listener   *listener.Listener
-	authTokens map[string]bool
-	serverName string
+	ctx            context.Context
+	logger         log.ContextLogger
+	router         adapter.Router
+	listener       *listener.Listener
+	certFPs        map[string]bool // allowed SHA-256 cert fingerprints (hex)
+	serverName     string
 }
 
 func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger, tag string, options option.ReflexInboundOptions) (adapter.Inbound, error) {
-	tokens := make(map[string]bool, len(options.AuthTokens))
-	for _, t := range options.AuthTokens {
-		b, err := hex.DecodeString(t)
-		if err != nil || len(b) != 8 {
-			return nil, fmt.Errorf("reflex: invalid auth_token %q (must be 16 hex chars)", t)
-		}
-		tokens[string(b)] = true
+	// Parse allowed certificate fingerprints
+	fps := make(map[string]bool, len(options.AuthTokens))
+	for _, fp := range options.AuthTokens {
+		fps[fp] = true
 	}
-	if len(tokens) == 0 {
-		return nil, fmt.Errorf("reflex: at least one auth_token is required")
+	if len(fps) == 0 {
+		return nil, fmt.Errorf("reflex: at least one auth_token (cert fingerprint) is required")
 	}
 
 	serverName := options.ServerName
@@ -61,7 +58,7 @@ func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger
 		ctx:        ctx,
 		logger:     lg,
 		router:     router,
-		authTokens: tokens,
+		certFPs:    fps,
 		serverName: serverName,
 	}
 
@@ -77,22 +74,10 @@ func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger
 }
 
 // NewConnectionEx handles a new TCP connection with the reversed TLS handshake.
+// The server immediately acts as TLS client — no pre-handshake bytes needed.
 func (i *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
-	// 1. Read 8-byte auth token
-	token := make([]byte, 8)
-	if _, err := io.ReadFull(conn, token); err != nil {
-		N.CloseOnHandshakeFailure(conn, onClose, fmt.Errorf("reflex: read auth token: %w", err))
-		return
-	}
-
-	// 2. Validate token
-	if !i.authTokens[string(token)] {
-		slog.Debug("reflex: invalid auth token, closing connection")
-		N.CloseOnHandshakeFailure(conn, onClose, fmt.Errorf("reflex: invalid auth token"))
-		return
-	}
-
-	// 3. Act as TLS client — send ClientHello to the TCP client
+	// 1. Act as TLS client — send ClientHello immediately.
+	// Request the peer's certificate for authentication.
 	tlsConn := tls.Client(conn, &tls.Config{
 		ServerName:         i.serverName,
 		InsecureSkipVerify: true,
@@ -102,7 +87,21 @@ func (i *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata a
 		return
 	}
 
-	// 4. Read destination: 1 byte length + host:port string
+	// 2. Validate the peer's certificate fingerprint
+	state := tlsConn.ConnectionState()
+	if len(state.PeerCertificates) == 0 {
+		N.CloseOnHandshakeFailure(tlsConn, onClose, fmt.Errorf("reflex: no peer certificate"))
+		return
+	}
+	hash := sha256.Sum256(state.PeerCertificates[0].Raw)
+	fp := fmt.Sprintf("%x", hash)
+	if !i.certFPs[fp] {
+		i.logger.DebugContext(ctx, "reflex: unknown cert fingerprint: ", fp)
+		N.CloseOnHandshakeFailure(tlsConn, onClose, fmt.Errorf("reflex: unauthorized"))
+		return
+	}
+
+	// 3. Read destination: 1 byte length + host:port string
 	lenBuf := make([]byte, 1)
 	if _, err := io.ReadFull(tlsConn, lenBuf); err != nil {
 		N.CloseOnHandshakeFailure(tlsConn, onClose, fmt.Errorf("reflex: read destination length: %w", err))
@@ -117,7 +116,7 @@ func (i *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata a
 
 	i.logger.TraceContext(ctx, "reflex connection from ", metadata.Source, " to ", destination)
 
-	// 5. Route through sing-box
+	// 4. Route through sing-box
 	metadata.Inbound = i.Tag()
 	metadata.InboundType = constant.TypeReflex
 	metadata.Destination = destination

--- a/protocol/reflex/outbound.go
+++ b/protocol/reflex/outbound.go
@@ -1,0 +1,151 @@
+// Package reflex implements the Reflex protocol, where TLS roles are reversed
+// relative to TCP roles. The TCP client acts as the TLS server, and the TCP
+// server (proxy) acts as the TLS client. This defeats SNI-based censorship and
+// JA3/JA4 fingerprinting because no ClientHello appears in the client→server
+// direction.
+package reflex
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/outbound"
+	"github.com/sagernet/sing-box/common/dialer"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing/common/logger"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+
+	"github.com/getlantern/lantern-box/constant"
+	"github.com/getlantern/lantern-box/option"
+)
+
+func RegisterOutbound(registry *outbound.Registry) {
+	outbound.Register[option.ReflexOutboundOptions](registry, constant.TypeReflex, NewOutbound)
+}
+
+// Outbound implements the client side of Reflex. It dials a TCP connection,
+// sends an auth token, then acts as a TLS server (waits for ClientHello from
+// the proxy). After the reversed TLS handshake, it proxies traffic through
+// the encrypted channel.
+type Outbound struct {
+	outbound.Adapter
+	logger  logger.ContextLogger
+	dialer  N.Dialer
+	server  string
+	port    uint16
+	token   []byte
+	tlsCert tls.Certificate
+	timeout time.Duration
+}
+
+func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogger, tag string, options option.ReflexOutboundOptions) (adapter.Outbound, error) {
+	// Parse auth token
+	token, err := hex.DecodeString(options.AuthToken)
+	if err != nil || len(token) != 8 {
+		return nil, fmt.Errorf("reflex: auth_token must be 16 hex chars (8 bytes): %w", err)
+	}
+
+	// Load TLS certificate (client acts as TLS server, so needs a cert)
+	var tlsCert tls.Certificate
+	if options.CertPEM != "" && options.KeyPEM != "" {
+		tlsCert, err = tls.X509KeyPair([]byte(options.CertPEM), []byte(options.KeyPEM))
+		if err != nil {
+			return nil, fmt.Errorf("reflex: invalid inline cert/key: %w", err)
+		}
+	} else if options.CertPath != "" && options.KeyPath != "" {
+		tlsCert, err = tls.LoadX509KeyPair(options.CertPath, options.KeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("reflex: failed to load cert/key files: %w", err)
+		}
+	} else {
+		return nil, fmt.Errorf("reflex: outbound requires TLS certificate (cert_pem+key_pem or cert_path+key_path)")
+	}
+
+	timeout := 15 * time.Second
+	if options.ConnectTimeout != "" {
+		timeout, err = time.ParseDuration(options.ConnectTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("reflex: invalid connect_timeout: %w", err)
+		}
+	}
+
+	outboundDialer, err := dialer.New(ctx, options.DialerOptions, options.ServerIsDomain())
+	if err != nil {
+		return nil, err
+	}
+
+	return &Outbound{
+		Adapter: outbound.NewAdapterWithDialerOptions(constant.TypeReflex, tag, []string{N.NetworkTCP}, options.DialerOptions),
+		logger:  lg,
+		dialer:  outboundDialer,
+		server:  options.Server,
+		port:    options.ServerPort,
+		token:   token,
+		tlsCert: tlsCert,
+		timeout: timeout,
+	}, nil
+}
+
+func (o *Outbound) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
+	if network != N.NetworkTCP {
+		return nil, fmt.Errorf("reflex: only TCP is supported")
+	}
+
+	o.logger.TraceContext(ctx, "dialing reflex connection to ", o.server, ":", o.port)
+
+	// 1. Establish TCP connection to proxy server
+	serverAddr := M.ParseSocksaddrHostPort(o.server, o.port)
+	tcpConn, err := o.dialer.DialContext(ctx, N.NetworkTCP, serverAddr)
+	if err != nil {
+		return nil, fmt.Errorf("reflex: TCP dial failed: %w", err)
+	}
+
+	// Set deadline for the auth + handshake phase
+	tcpConn.SetDeadline(time.Now().Add(o.timeout))
+	defer tcpConn.SetDeadline(time.Time{}) // clear after handshake
+
+	// 2. Send auth token (client speaks first with short ID)
+	if _, err := tcpConn.Write(o.token); err != nil {
+		tcpConn.Close()
+		return nil, fmt.Errorf("reflex: failed to send auth token: %w", err)
+	}
+
+	// 3. Act as TLS server — wait for ClientHello from the proxy
+	tlsConn := tls.Server(tcpConn, &tls.Config{
+		Certificates: []tls.Certificate{o.tlsCert},
+	})
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		tcpConn.Close()
+		return nil, fmt.Errorf("reflex: reversed TLS handshake failed: %w", err)
+	}
+
+	o.logger.TraceContext(ctx, "reflex connection established")
+
+	// 4. Send the actual destination as the first message over the encrypted channel
+	destStr := destination.String() // host:port format
+	destLen := byte(len(destStr))
+	if _, err := tlsConn.Write(append([]byte{destLen}, []byte(destStr)...)); err != nil {
+		tlsConn.Close()
+		return nil, fmt.Errorf("reflex: failed to send destination: %w", err)
+	}
+
+	return tlsConn, nil
+}
+
+func (o *Outbound) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
+	return nil, fmt.Errorf("reflex: UDP not supported")
+}
+
+func (o *Outbound) Network() []string {
+	return []string{N.NetworkTCP}
+}
+
+func (o *Outbound) Close() error {
+	return nil
+}

--- a/protocol/reflex/outbound.go
+++ b/protocol/reflex/outbound.go
@@ -5,14 +5,16 @@
 // direction.
 //
 // Authentication is embedded in the TLS handshake itself: the client presents
-// a certificate whose SHA-256 fingerprint the server validates against a
-// pre-shared expected value. No pre-handshake auth bytes are sent.
+// a TLS certificate whose SHA-256 fingerprint the server validates against a
+// pre-shared expected value. No pre-handshake bytes are exchanged.
 package reflex
 
 import (
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"time"
@@ -36,7 +38,6 @@ func RegisterOutbound(registry *outbound.Registry) {
 // Outbound implements the client side of Reflex. It dials a TCP connection,
 // then acts as a TLS server (waits for ClientHello from the proxy). The server
 // validates the client's TLS certificate fingerprint as authentication.
-// No pre-handshake bytes are sent — the entire auth is within the TLS handshake.
 type Outbound struct {
 	outbound.Adapter
 	logger  logger.ContextLogger
@@ -48,25 +49,32 @@ type Outbound struct {
 }
 
 func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogger, tag string, options option.ReflexOutboundOptions) (adapter.Outbound, error) {
-	// Load TLS certificate (client acts as TLS server, so needs a cert).
-	// The SHA-256 fingerprint of this cert is the auth token — the server
-	// validates it during the handshake.
 	var (
 		tlsCert tls.Certificate
 		err     error
 	)
-	if options.CertPEM != "" && options.KeyPEM != "" {
+
+	hasPEM := options.CertPEM != "" || options.KeyPEM != ""
+	hasFile := options.CertPath != "" || options.KeyPath != ""
+
+	if hasPEM && hasFile {
+		return nil, fmt.Errorf("reflex: specify either inline PEM (cert_pem+key_pem) or file paths (cert_path+key_path), not both")
+	}
+	if hasPEM {
+		if options.CertPEM == "" || options.KeyPEM == "" {
+			return nil, fmt.Errorf("reflex: both cert_pem and key_pem must be provided together")
+		}
 		tlsCert, err = tls.X509KeyPair([]byte(options.CertPEM), []byte(options.KeyPEM))
-		if err != nil {
-			return nil, fmt.Errorf("reflex: invalid inline cert/key: %w", err)
+	} else if hasFile {
+		if options.CertPath == "" || options.KeyPath == "" {
+			return nil, fmt.Errorf("reflex: both cert_path and key_path must be provided together")
 		}
-	} else if options.CertPath != "" && options.KeyPath != "" {
 		tlsCert, err = tls.LoadX509KeyPair(options.CertPath, options.KeyPath)
-		if err != nil {
-			return nil, fmt.Errorf("reflex: failed to load cert/key files: %w", err)
-		}
 	} else {
 		return nil, fmt.Errorf("reflex: outbound requires TLS certificate (cert_pem+key_pem or cert_path+key_path)")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reflex: loading TLS certificate: %w", err)
 	}
 
 	timeout := 15 * time.Second
@@ -100,7 +108,6 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 
 	o.logger.TraceContext(ctx, "dialing reflex connection to ", o.server, ":", o.port)
 
-	// 1. Establish TCP connection to proxy server
 	serverAddr := M.ParseSocksaddrHostPort(o.server, o.port)
 	tcpConn, err := o.dialer.DialContext(ctx, N.NetworkTCP, serverAddr)
 	if err != nil {
@@ -110,8 +117,8 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 	tcpConn.SetDeadline(time.Now().Add(o.timeout))
 	defer tcpConn.SetDeadline(time.Time{})
 
-	// 2. Act as TLS server — wait for ClientHello from the proxy.
-	// No pre-handshake bytes sent. Auth is the certificate fingerprint.
+	// Act as TLS server — wait for ClientHello from the proxy.
+	// No pre-handshake bytes. Auth is the certificate fingerprint.
 	tlsConn := tls.Server(tcpConn, &tls.Config{
 		Certificates: []tls.Certificate{o.tlsCert},
 	})
@@ -122,10 +129,15 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 
 	o.logger.TraceContext(ctx, "reflex connection established")
 
-	// 3. Send destination over the encrypted channel
+	// Send destination over encrypted channel: 2-byte big-endian length + host:port
 	destStr := destination.String()
-	destLen := byte(len(destStr))
-	if _, err := tlsConn.Write(append([]byte{destLen}, []byte(destStr)...)); err != nil {
+	if len(destStr) == 0 || len(destStr) > 65535 {
+		tlsConn.Close()
+		return nil, fmt.Errorf("reflex: destination too long (%d bytes)", len(destStr))
+	}
+	var lenBuf [2]byte
+	binary.BigEndian.PutUint16(lenBuf[:], uint16(len(destStr)))
+	if _, err := tlsConn.Write(append(lenBuf[:], []byte(destStr)...)); err != nil {
 		tlsConn.Close()
 		return nil, fmt.Errorf("reflex: failed to send destination: %w", err)
 	}
@@ -145,12 +157,8 @@ func (o *Outbound) Close() error {
 	return nil
 }
 
-// CertFingerprint returns the SHA-256 fingerprint of the outbound's TLS
-// certificate. This is what the server uses to authenticate the client.
-func CertFingerprint(cert tls.Certificate) string {
-	if len(cert.Certificate) == 0 {
-		return ""
-	}
-	hash := sha256.Sum256(cert.Certificate[0])
-	return fmt.Sprintf("%x", hash)
+// DERFingerprint returns the hex-encoded SHA-256 of DER-encoded certificate bytes.
+func DERFingerprint(der []byte) string {
+	hash := sha256.Sum256(der)
+	return hex.EncodeToString(hash[:])
 }

--- a/protocol/reflex/outbound.go
+++ b/protocol/reflex/outbound.go
@@ -3,12 +3,16 @@
 // server (proxy) acts as the TLS client. This defeats SNI-based censorship and
 // JA3/JA4 fingerprinting because no ClientHello appears in the client→server
 // direction.
+//
+// Authentication is embedded in the TLS handshake itself: the client presents
+// a certificate whose SHA-256 fingerprint the server validates against a
+// pre-shared expected value. No pre-handshake auth bytes are sent.
 package reflex
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
-	"encoding/hex"
 	"fmt"
 	"net"
 	"time"
@@ -30,29 +34,27 @@ func RegisterOutbound(registry *outbound.Registry) {
 }
 
 // Outbound implements the client side of Reflex. It dials a TCP connection,
-// sends an auth token, then acts as a TLS server (waits for ClientHello from
-// the proxy). After the reversed TLS handshake, it proxies traffic through
-// the encrypted channel.
+// then acts as a TLS server (waits for ClientHello from the proxy). The server
+// validates the client's TLS certificate fingerprint as authentication.
+// No pre-handshake bytes are sent — the entire auth is within the TLS handshake.
 type Outbound struct {
 	outbound.Adapter
 	logger  logger.ContextLogger
 	dialer  N.Dialer
 	server  string
 	port    uint16
-	token   []byte
 	tlsCert tls.Certificate
 	timeout time.Duration
 }
 
 func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogger, tag string, options option.ReflexOutboundOptions) (adapter.Outbound, error) {
-	// Parse auth token
-	token, err := hex.DecodeString(options.AuthToken)
-	if err != nil || len(token) != 8 {
-		return nil, fmt.Errorf("reflex: auth_token must be 16 hex chars (8 bytes): %w", err)
-	}
-
-	// Load TLS certificate (client acts as TLS server, so needs a cert)
-	var tlsCert tls.Certificate
+	// Load TLS certificate (client acts as TLS server, so needs a cert).
+	// The SHA-256 fingerprint of this cert is the auth token — the server
+	// validates it during the handshake.
+	var (
+		tlsCert tls.Certificate
+		err     error
+	)
 	if options.CertPEM != "" && options.KeyPEM != "" {
 		tlsCert, err = tls.X509KeyPair([]byte(options.CertPEM), []byte(options.KeyPEM))
 		if err != nil {
@@ -86,7 +88,6 @@ func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogge
 		dialer:  outboundDialer,
 		server:  options.Server,
 		port:    options.ServerPort,
-		token:   token,
 		tlsCert: tlsCert,
 		timeout: timeout,
 	}, nil
@@ -106,29 +107,23 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 		return nil, fmt.Errorf("reflex: TCP dial failed: %w", err)
 	}
 
-	// Set deadline for the auth + handshake phase
 	tcpConn.SetDeadline(time.Now().Add(o.timeout))
-	defer tcpConn.SetDeadline(time.Time{}) // clear after handshake
+	defer tcpConn.SetDeadline(time.Time{})
 
-	// 2. Send auth token (client speaks first with short ID)
-	if _, err := tcpConn.Write(o.token); err != nil {
-		tcpConn.Close()
-		return nil, fmt.Errorf("reflex: failed to send auth token: %w", err)
-	}
-
-	// 3. Act as TLS server — wait for ClientHello from the proxy
+	// 2. Act as TLS server — wait for ClientHello from the proxy.
+	// No pre-handshake bytes sent. Auth is the certificate fingerprint.
 	tlsConn := tls.Server(tcpConn, &tls.Config{
 		Certificates: []tls.Certificate{o.tlsCert},
 	})
 	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		tcpConn.Close()
-		return nil, fmt.Errorf("reflex: reversed TLS handshake failed: %w", err)
+		return nil, fmt.Errorf("reflex: TLS handshake failed: %w", err)
 	}
 
 	o.logger.TraceContext(ctx, "reflex connection established")
 
-	// 4. Send the actual destination as the first message over the encrypted channel
-	destStr := destination.String() // host:port format
+	// 3. Send destination over the encrypted channel
+	destStr := destination.String()
 	destLen := byte(len(destStr))
 	if _, err := tlsConn.Write(append([]byte{destLen}, []byte(destStr)...)); err != nil {
 		tlsConn.Close()
@@ -148,4 +143,14 @@ func (o *Outbound) Network() []string {
 
 func (o *Outbound) Close() error {
 	return nil
+}
+
+// CertFingerprint returns the SHA-256 fingerprint of the outbound's TLS
+// certificate. This is what the server uses to authenticate the client.
+func CertFingerprint(cert tls.Certificate) string {
+	if len(cert.Certificate) == 0 {
+		return ""
+	}
+	hash := sha256.Sum256(cert.Certificate[0])
+	return fmt.Sprintf("%x", hash)
 }

--- a/protocol/register.go
+++ b/protocol/register.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getlantern/lantern-box/protocol/amnezia"
 	"github.com/getlantern/lantern-box/protocol/group"
 	"github.com/getlantern/lantern-box/protocol/outline"
+	"github.com/getlantern/lantern-box/protocol/reflex"
 	"github.com/getlantern/lantern-box/protocol/samizdat"
 	"github.com/getlantern/lantern-box/protocol/water"
 )
@@ -22,6 +23,7 @@ var supportedProtocols = []string{
 	"algeneva",
 	"amnezia",
 	"outline",
+	"reflex",
 	"samizdat",
 	"water",
 
@@ -66,6 +68,7 @@ func RegisterProtocols(ctx context.Context) context.Context {
 
 func registerInbounds(registry *inbound.Registry) {
 	algeneva.RegisterInbound(registry)
+	reflex.RegisterInbound(registry)
 	samizdat.RegisterInbound(registry)
 	water.RegisterInbound(registry)
 }
@@ -74,6 +77,7 @@ func registerOutbounds(registry *outbound.Registry) {
 	// custom protocol outbounds
 	algeneva.RegisterOutbound(registry)
 	outline.RegisterOutbound(registry)
+	reflex.RegisterOutbound(registry)
 	samizdat.RegisterOutbound(registry)
 	water.RegisterOutbound(registry)
 


### PR DESCRIPTION
## Summary

Adds the **Reflex** protocol to lantern-box — a novel censorship circumvention technique where TLS roles are reversed relative to TCP roles. The proxy server sends the TLS ClientHello, while the censored client acts as the TLS server.

### Why this defeats censorship

| Detection Method | How Reflex Defeats It |
|-----------------|----------------------|
| **SNI extraction** | ClientHello is in server→client direction; DPI inspects client→server |
| **JA3/JA4 fingerprinting** | Client never sends ClientHello; nothing to fingerprint |
| **[Fully encrypted traffic detection](https://gfw.report/publications/usenixsecurity23/en/)** | Client's first data is TLS ServerHello (`\x16\x03`), satisfying GFW's Ex5 exemption |
| **[QUIC SNI extraction](https://gfw.report/publications/usenixsecurity25/en/)** | N/A (TCP-based) |

### Protocol flow

```
Client (censored)              Server (proxy)
  |--- TCP SYN ----------------->|
  |<-- TCP SYN-ACK --------------|
  |--- 8-byte auth token ------->|
  |<-- TLS ClientHello ----------|  ← Server sends ClientHello!
  |--- TLS ServerHello + Cert -->|  ← Client acts as TLS server
  |<-- TLS Finished -------------|
  |--- TLS Finished ------------>|
  |--- destination (encrypted) ->|
  |   Proxy tunnel active        |
```

### Files

| File | Purpose |
|------|---------|
| `option/reflex.go` | Options structs for outbound + inbound |
| `constant/proxy.go` | `TypeReflex = "reflex"` |
| `protocol/reflex/outbound.go` | Client side: TCP client, TLS server |
| `protocol/reflex/inbound.go` | Server side: TCP server, TLS client |
| `protocol/register.go` | Register both adapters |

### Ticket

https://github.com/getlantern/engineering/issues/3166

## Test plan
- [ ] Unit test: outbound + inbound connect through reversed TLS
- [ ] Integration test: proxy traffic flows through Reflex tunnel
- [ ] Verify no ClientHello in client→server direction (tcpdump/Wireshark)
- [ ] Test with invalid auth token → connection rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)