### PR TITLE
fix: enforce TLS 1.3 minimum in Reflex

### DIFF
--- a/protocol/reflex/inbound.go
+++ b/protocol/reflex/inbound.go
@@ -84,6 +84,7 @@ func (i *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata a
 	tlsConn := tls.Client(conn, &tls.Config{
 		ServerName:         i.serverName,
 		InsecureSkipVerify: true, //nolint:gosec // auth via cert fingerprint, not CA chain
+		MinVersion:         tls.VersionTLS13,
 	})
 	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		N.CloseOnHandshakeFailure(conn, onClose, fmt.Errorf("reflex: TLS handshake: %w", err))

--- a/protocol/reflex/outbound.go
+++ b/protocol/reflex/outbound.go
@@ -121,6 +121,7 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 	// No pre-handshake bytes. Auth is the certificate fingerprint.
 	tlsConn := tls.Server(tcpConn, &tls.Config{
 		Certificates: []tls.Certificate{o.tlsCert},
+		MinVersion:   tls.VersionTLS13,
 	})
 	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		tcpConn.Close()


### PR DESCRIPTION
Adds `MinVersion: tls.VersionTLS13` to both inbound and outbound TLS configs. Eliminates TLS 1.2 downgrade attack surface entirely. Identified in the [Reflex security analysis](https://github.com/getlantern/engineering/blob/main/docs/reflex-whitepaper.md#45-downgrade-attacks).