### PR TITLE
feat(reflex): silence-based probe resistance with masquerade fallback

### DIFF
--- a/option/reflex.go
+++ b/option/reflex.go
@@ -42,4 +42,26 @@ type ReflexInboundOptions struct {
 	// ServerName is the SNI sent in the TLS ClientHello.
 	// Since the server sends the ClientHello, this is invisible to the censor.
 	ServerName string `json:"server_name,omitempty"`
+
+	// SilenceTimeout is the duration the server waits for client silence before
+	// sending ClientHello. Legitimate Lantern clients send no application data
+	// until the server speaks (that's the entire Reflex protocol). Active
+	// probes and misdirected TLS clients speak immediately.
+	//
+	// If the client sends any bytes before this timeout elapses, the connection
+	// is transparently forwarded to MasqueradeUpstream instead of receiving a
+	// ClientHello. Probes never see Reflex.
+	//
+	// Set to "0" or leave empty to disable (probing exposure for Reflex).
+	// Typical value: "5s". Jittered by SilenceJitter to avoid timing fingerprint.
+	SilenceTimeout string `json:"silence_timeout,omitempty"`
+
+	// SilenceJitter is the maximum random duration added to SilenceTimeout per
+	// connection. Defaults to "2s" when SilenceTimeout is set.
+	SilenceJitter string `json:"silence_jitter,omitempty"`
+
+	// MasqueradeUpstream is the host:port of a real TLS service to which
+	// connections that fail the silence test are forwarded. Required when
+	// SilenceTimeout is set. Example: "www.example.com:443".
+	MasqueradeUpstream string `json:"masquerade_upstream,omitempty"`
 }

--- a/protocol/reflex/inbound.go
+++ b/protocol/reflex/inbound.go
@@ -90,6 +90,12 @@ func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger
 		} else {
 			silenceJitter = defaultSilenceJitter
 		}
+		// Minimum wait is silence_timeout - silence_jitter. If jitter >=
+		// timeout, the minimum wait can reach zero and effectively skip the
+		// silence window — undermining probe resistance. Reject that config.
+		if silenceJitter >= silenceTimeout {
+			return nil, fmt.Errorf("reflex: silence_jitter (%s) must be less than silence_timeout (%s)", silenceJitter, silenceTimeout)
+		}
 	}
 
 	ib := &Inbound{

--- a/protocol/reflex/inbound.go
+++ b/protocol/reflex/inbound.go
@@ -69,6 +69,9 @@ func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger
 		if err != nil {
 			return nil, fmt.Errorf("reflex: invalid silence_timeout: %w", err)
 		}
+		if d < 0 {
+			return nil, fmt.Errorf("reflex: silence_timeout must be non-negative, got %s", d)
+		}
 		silenceTimeout = d
 	}
 	if silenceTimeout > 0 {
@@ -79,6 +82,9 @@ func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger
 			d, err := time.ParseDuration(options.SilenceJitter)
 			if err != nil {
 				return nil, fmt.Errorf("reflex: invalid silence_jitter: %w", err)
+			}
+			if d < 0 {
+				return nil, fmt.Errorf("reflex: silence_jitter must be non-negative, got %s", d)
 			}
 			silenceJitter = d
 		} else {
@@ -126,12 +132,13 @@ func (i *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata a
 		}
 		if len(prefix) > 0 {
 			i.logger.DebugContext(ctx, "reflex: client spoke during silence window from ", metadata.Source, "; masquerading to ", i.masqueradeUpstream)
-			if ferr := forwardToMasquerade(ctx, conn, i.masqueradeUpstream, prefix); ferr != nil {
+			ferr := forwardToMasquerade(ctx, conn, i.masqueradeUpstream, prefix)
+			if ferr != nil {
 				i.logger.DebugContext(ctx, "reflex: masquerade forward error: ", ferr)
 			}
 			conn.Close()
 			if onClose != nil {
-				onClose(nil)
+				onClose(ferr)
 			}
 			return
 		}

--- a/protocol/reflex/inbound.go
+++ b/protocol/reflex/inbound.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/adapter/inbound"
@@ -20,6 +21,10 @@ import (
 	"github.com/getlantern/lantern-box/option"
 )
 
+// defaultSilenceJitter is applied when SilenceTimeout is set but
+// SilenceJitter is not explicitly configured.
+const defaultSilenceJitter = 2 * time.Second
+
 func RegisterInbound(registry *inbound.Registry) {
 	inbound.Register[option.ReflexInboundOptions](registry, constant.TypeReflex, NewInbound)
 }
@@ -29,12 +34,15 @@ func RegisterInbound(registry *inbound.Registry) {
 // peer's certificate fingerprint as authentication.
 type Inbound struct {
 	inbound.Adapter
-	ctx        context.Context
-	logger     log.ContextLogger
-	router     adapter.Router
-	listener   *listener.Listener
-	certFPs    map[string]bool // allowed SHA-256 cert fingerprints (lowercase hex)
-	serverName string
+	ctx                context.Context
+	logger             log.ContextLogger
+	router             adapter.Router
+	listener           *listener.Listener
+	certFPs            map[string]bool // allowed SHA-256 cert fingerprints (lowercase hex)
+	serverName         string
+	silenceTimeout     time.Duration // 0 = disabled
+	silenceJitter      time.Duration
+	masqueradeUpstream string
 }
 
 func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger, tag string, options option.ReflexInboundOptions) (adapter.Inbound, error) {
@@ -55,13 +63,39 @@ func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger
 		serverName = "www.example.com"
 	}
 
+	var silenceTimeout, silenceJitter time.Duration
+	if options.SilenceTimeout != "" {
+		d, err := time.ParseDuration(options.SilenceTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("reflex: invalid silence_timeout: %w", err)
+		}
+		silenceTimeout = d
+	}
+	if silenceTimeout > 0 {
+		if options.MasqueradeUpstream == "" {
+			return nil, fmt.Errorf("reflex: masquerade_upstream is required when silence_timeout is set")
+		}
+		if options.SilenceJitter != "" {
+			d, err := time.ParseDuration(options.SilenceJitter)
+			if err != nil {
+				return nil, fmt.Errorf("reflex: invalid silence_jitter: %w", err)
+			}
+			silenceJitter = d
+		} else {
+			silenceJitter = defaultSilenceJitter
+		}
+	}
+
 	ib := &Inbound{
-		Adapter:    inbound.NewAdapter(constant.TypeReflex, tag),
-		ctx:        ctx,
-		logger:     lg,
-		router:     router,
-		certFPs:    fps,
-		serverName: serverName,
+		Adapter:            inbound.NewAdapter(constant.TypeReflex, tag),
+		ctx:                ctx,
+		logger:             lg,
+		router:             router,
+		certFPs:            fps,
+		serverName:         serverName,
+		silenceTimeout:     silenceTimeout,
+		silenceJitter:      silenceJitter,
+		masqueradeUpstream: options.MasqueradeUpstream,
 	}
 
 	ib.listener = listener.New(listener.Options{
@@ -77,6 +111,32 @@ func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger
 
 // NewConnectionEx handles a new TCP connection with the reversed TLS handshake.
 func (i *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	// Silence-based probe resistance: a legitimate Lantern client sends no bytes
+	// until the server speaks (that's the Reflex protocol). Active probes and
+	// misdirected TLS clients speak immediately. If we see any bytes within the
+	// silence window, forward the connection to the masquerade upstream instead
+	// of revealing Reflex.
+	if i.silenceTimeout > 0 {
+		wait := jitteredTimeout(i.silenceTimeout, i.silenceJitter)
+		prefix, err := waitForSilence(conn, wait)
+		if err != nil {
+			i.logger.DebugContext(ctx, "reflex: silence read error: ", err)
+			N.CloseOnHandshakeFailure(conn, onClose, err)
+			return
+		}
+		if len(prefix) > 0 {
+			i.logger.DebugContext(ctx, "reflex: client spoke during silence window from ", metadata.Source, "; masquerading to ", i.masqueradeUpstream)
+			if ferr := forwardToMasquerade(ctx, conn, i.masqueradeUpstream, prefix); ferr != nil {
+				i.logger.DebugContext(ctx, "reflex: masquerade forward error: ", ferr)
+			}
+			conn.Close()
+			if onClose != nil {
+				onClose(nil)
+			}
+			return
+		}
+	}
+
 	// Act as TLS client — send ClientHello immediately.
 	// InsecureSkipVerify is intentional: the peer presents a self-signed cert
 	// and we authenticate by validating its SHA-256 fingerprint against the

--- a/protocol/reflex/masquerade.go
+++ b/protocol/reflex/masquerade.go
@@ -1,0 +1,55 @@
+package reflex
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+// masqueradeDialTimeout is the timeout for dialing the upstream cover site.
+const masqueradeDialTimeout = 10 * time.Second
+
+// forwardToMasquerade transparently forwards conn to upstream (host:port),
+// prepending prefix bytes (which were already consumed from conn during the
+// silence probe) before the client's stream.
+//
+// Blocks until one direction of the copy returns. conn is not closed by this
+// function — the caller owns conn's lifecycle.
+func forwardToMasquerade(ctx context.Context, conn net.Conn, upstream string, prefix []byte) error {
+	if upstream == "" {
+		return fmt.Errorf("masquerade upstream not configured")
+	}
+
+	dctx, cancel := context.WithTimeout(ctx, masqueradeDialTimeout)
+	defer cancel()
+
+	var d net.Dialer
+	upstreamConn, err := d.DialContext(dctx, "tcp", upstream)
+	if err != nil {
+		return fmt.Errorf("dial masquerade upstream %s: %w", upstream, err)
+	}
+	defer upstreamConn.Close()
+
+	// Replay the byte(s) we consumed during silence detection so the upstream
+	// sees the client's stream unmodified.
+	if len(prefix) > 0 {
+		if _, err := upstreamConn.Write(prefix); err != nil {
+			return fmt.Errorf("replay prefix to upstream: %w", err)
+		}
+	}
+
+	// Bidirectional copy. Exit when either direction closes.
+	errCh := make(chan error, 2)
+	go func() {
+		_, err := io.Copy(upstreamConn, conn)
+		errCh <- err
+	}()
+	go func() {
+		_, err := io.Copy(conn, upstreamConn)
+		errCh <- err
+	}()
+	<-errCh
+	return nil
+}

--- a/protocol/reflex/masquerade.go
+++ b/protocol/reflex/masquerade.go
@@ -17,9 +17,11 @@ const masqueradeDialTimeout = 10 * time.Second
 // silence probe) before the client's stream.
 //
 // Blocks until both copy directions return. Returns the first non-EOF copy
-// error, or the dial/replay error, or nil on clean close. Context
-// cancellation closes both conns so copies unblock. conn is not closed by
-// this function — the caller owns conn's lifecycle.
+// error, or the dial/replay error, or nil on clean close.
+//
+// To unblock the copy loops on context cancellation and when either
+// direction finishes, this function may close both the upstream connection
+// and conn. Callers should treat conn as possibly-closed after return.
 func forwardToMasquerade(ctx context.Context, conn net.Conn, upstream string, prefix []byte) error {
 	if upstream == "" {
 		return fmt.Errorf("masquerade upstream not configured")

--- a/protocol/reflex/masquerade.go
+++ b/protocol/reflex/masquerade.go
@@ -2,6 +2,7 @@ package reflex
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -15,8 +16,10 @@ const masqueradeDialTimeout = 10 * time.Second
 // prepending prefix bytes (which were already consumed from conn during the
 // silence probe) before the client's stream.
 //
-// Blocks until one direction of the copy returns. conn is not closed by this
-// function — the caller owns conn's lifecycle.
+// Blocks until both copy directions return. Returns the first non-EOF copy
+// error, or the dial/replay error, or nil on clean close. Context
+// cancellation closes both conns so copies unblock. conn is not closed by
+// this function — the caller owns conn's lifecycle.
 func forwardToMasquerade(ctx context.Context, conn net.Conn, upstream string, prefix []byte) error {
 	if upstream == "" {
 		return fmt.Errorf("masquerade upstream not configured")
@@ -32,6 +35,13 @@ func forwardToMasquerade(ctx context.Context, conn net.Conn, upstream string, pr
 	}
 	defer upstreamConn.Close()
 
+	// Wire ctx cancellation to close both sides so copies unblock and return.
+	stop := context.AfterFunc(ctx, func() {
+		_ = upstreamConn.Close()
+		_ = conn.Close()
+	})
+	defer stop()
+
 	// Replay the byte(s) we consumed during silence detection so the upstream
 	// sees the client's stream unmodified.
 	if len(prefix) > 0 {
@@ -40,16 +50,31 @@ func forwardToMasquerade(ctx context.Context, conn net.Conn, upstream string, pr
 		}
 	}
 
-	// Bidirectional copy. Exit when either direction closes.
+	// Bidirectional copy. When one direction ends, close the other so the
+	// second goroutine unblocks. Then return the first real error.
 	errCh := make(chan error, 2)
 	go func() {
 		_, err := io.Copy(upstreamConn, conn)
+		_ = upstreamConn.Close()
 		errCh <- err
 	}()
 	go func() {
 		_, err := io.Copy(conn, upstreamConn)
+		_ = conn.Close()
 		errCh <- err
 	}()
-	<-errCh
+	return firstRealError(<-errCh, <-errCh)
+}
+
+// firstRealError returns the first non-nil, non-EOF, non-closed-network error
+// from the two copy directions. EOF and use-of-closed-connection are expected
+// on clean shutdown.
+func firstRealError(errs ...error) error {
+	for _, err := range errs {
+		if err == nil || errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+			continue
+		}
+		return err
+	}
 	return nil
 }

--- a/protocol/reflex/masquerade_test.go
+++ b/protocol/reflex/masquerade_test.go
@@ -1,0 +1,126 @@
+package reflex
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// startEchoServer starts a TCP echo server on 127.0.0.1 and returns its
+// host:port and a stop function.
+func startEchoServer(t *testing.T) (string, func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				_, _ = io.Copy(c, c)
+			}(c)
+		}
+	}()
+	stop := func() {
+		_ = ln.Close()
+		<-done
+	}
+	return ln.Addr().String(), stop
+}
+
+// TestForwardToMasquerade_ReplayPrefixAndForward verifies that:
+//  1. The prefix bytes (consumed during silence detection) are replayed to
+//     upstream before any further client data.
+//  2. Upstream's response bytes are forwarded back to the client.
+func TestForwardToMasquerade_ReplayPrefixAndForward(t *testing.T) {
+	upstream, stop := startEchoServer(t)
+	defer stop()
+
+	// Use a real loopback TCP pair so io.Copy semantics match production.
+	clientSide, serverSide := net.Pipe()
+	defer clientSide.Close()
+	defer serverSide.Close()
+
+	prefix := []byte{'X'}
+
+	forwardErrCh := make(chan error, 1)
+	go func() {
+		forwardErrCh <- forwardToMasquerade(context.Background(), serverSide, upstream, prefix)
+	}()
+
+	// Client writes the rest of "X" + "HELLO" — total stream sent to upstream
+	// should be "XHELLO" (echoed back).
+	go func() {
+		_, _ = clientSide.Write([]byte("HELLO"))
+	}()
+
+	buf := make([]byte, 6)
+	clientSide.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := io.ReadFull(clientSide, buf)
+	if err != nil {
+		t.Fatalf("read echo: %v (got %q)", err, string(buf[:n]))
+	}
+	if got := string(buf); got != "XHELLO" {
+		t.Fatalf("expected echo 'XHELLO', got %q", got)
+	}
+
+	// Closing the client side should drain forwardToMasquerade.
+	clientSide.Close()
+	select {
+	case err := <-forwardErrCh:
+		// EOF / closed-pipe is expected; firstRealError suppresses it to nil.
+		if err != nil {
+			t.Logf("forward returned (acceptable on close): %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("forwardToMasquerade did not return after client close")
+	}
+}
+
+func TestForwardToMasquerade_DialFailure(t *testing.T) {
+	clientSide, serverSide := net.Pipe()
+	defer clientSide.Close()
+	defer serverSide.Close()
+
+	// Port 1 on localhost should refuse connections quickly.
+	err := forwardToMasquerade(context.Background(), serverSide, "127.0.0.1:1", []byte{'X'})
+	if err == nil {
+		t.Fatal("expected dial error, got nil")
+	}
+}
+
+func TestForwardToMasquerade_EmptyUpstream(t *testing.T) {
+	clientSide, serverSide := net.Pipe()
+	defer clientSide.Close()
+	defer serverSide.Close()
+
+	err := forwardToMasquerade(context.Background(), serverSide, "", []byte{'X'})
+	if err == nil {
+		t.Fatal("expected error for empty upstream, got nil")
+	}
+}
+
+func TestFirstRealError(t *testing.T) {
+	if err := firstRealError(nil, nil); err != nil {
+		t.Errorf("expected nil for all-nil, got %v", err)
+	}
+	if err := firstRealError(io.EOF, io.EOF); err != nil {
+		t.Errorf("expected nil for all-EOF, got %v", err)
+	}
+	real := io.ErrUnexpectedEOF
+	if err := firstRealError(io.EOF, real); err != real {
+		t.Errorf("expected %v, got %v", real, err)
+	}
+	if err := firstRealError(real, io.EOF); err != real {
+		t.Errorf("expected %v, got %v", real, err)
+	}
+}

--- a/protocol/reflex/masquerade_test.go
+++ b/protocol/reflex/masquerade_test.go
@@ -45,7 +45,9 @@ func TestForwardToMasquerade_ReplayPrefixAndForward(t *testing.T) {
 	upstream, stop := startEchoServer(t)
 	defer stop()
 
-	// Use a real loopback TCP pair so io.Copy semantics match production.
+	// net.Pipe() gives us an in-memory, synchronous conn pair. It's enough
+	// to exercise io.Copy and close semantics; the upstream half is a real
+	// loopback TCP echo server via startEchoServer above.
 	clientSide, serverSide := net.Pipe()
 	defer clientSide.Close()
 	defer serverSide.Close()

--- a/protocol/reflex/silence.go
+++ b/protocol/reflex/silence.go
@@ -1,0 +1,70 @@
+package reflex
+
+import (
+	"errors"
+	"math/rand/v2"
+	"net"
+	"os"
+	"time"
+)
+
+// waitForSilence reads up to one byte from conn with a deadline.
+//
+// Returns:
+//   - (nil, nil)  — the deadline elapsed before any client data arrived.
+//     The caller should proceed with the Reflex handshake (send ClientHello).
+//   - (data, nil) — the client sent bytes before the deadline. The caller
+//     should hand the connection (prepending data) off to the masquerade
+//     handler. This is the "not a Lantern client" signal.
+//   - (nil, err)  — the connection is dead or errored for another reason.
+//
+// Lantern Reflex clients send no application data before the server speaks.
+// Active probes (replaying ClientHellos, etc.) and accidentally-routed TLS
+// clients speak immediately, so any byte within the window is a probe signal.
+func waitForSilence(conn net.Conn, timeout time.Duration) ([]byte, error) {
+	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		return nil, err
+	}
+	defer conn.SetReadDeadline(time.Time{})
+
+	buf := make([]byte, 1)
+	n, err := conn.Read(buf)
+	if n > 0 {
+		return buf[:n], nil
+	}
+	// n == 0: either timeout (silence, good) or a real error (dead conn).
+	if err == nil {
+		// Shouldn't happen — Read returning (0, nil) is unusual.
+		return nil, nil
+	}
+	if isTimeout(err) {
+		return nil, nil
+	}
+	return nil, err
+}
+
+func isTimeout(err error) bool {
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		return true
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	return false
+}
+
+// jitteredTimeout returns base ± a uniform random amount up to jitter.
+// If jitter is zero or base is zero, base is returned unchanged.
+func jitteredTimeout(base, jitter time.Duration) time.Duration {
+	if base <= 0 || jitter <= 0 {
+		return base
+	}
+	// Uniform in [-jitter, +jitter].
+	offset := time.Duration(rand.Int64N(int64(2*jitter))) - jitter
+	result := base + offset
+	if result < 0 {
+		return base
+	}
+	return result
+}

--- a/protocol/reflex/silence.go
+++ b/protocol/reflex/silence.go
@@ -2,6 +2,7 @@ package reflex
 
 import (
 	"errors"
+	"math"
 	"math/rand/v2"
 	"net"
 	"os"
@@ -55,12 +56,21 @@ func isTimeout(err error) bool {
 }
 
 // jitteredTimeout returns base ± a uniform random amount up to jitter.
-// If jitter is zero or base is zero, base is returned unchanged.
+// If jitter is zero or base is zero, base is returned unchanged. Large
+// jitter values are clamped to half the int64 range to avoid overflow in
+// 2*jitter and base+offset.
 func jitteredTimeout(base, jitter time.Duration) time.Duration {
 	if base <= 0 || jitter <= 0 {
 		return base
 	}
-	// Uniform in [-jitter, +jitter].
+	// Clamp jitter so 2*jitter cannot overflow int64 and base+offset stays
+	// representable. math.MaxInt64/4 leaves headroom for the addition below.
+	const maxJitter = time.Duration(math.MaxInt64 / 4)
+	if jitter > maxJitter {
+		jitter = maxJitter
+	}
+	// Uniform in [-jitter, +jitter]. rand.Int64N requires a positive bound,
+	// which the clamp above guarantees (maxJitter > 0 and jitter > 0).
 	offset := time.Duration(rand.Int64N(int64(2*jitter))) - jitter
 	result := base + offset
 	if result < 0 {

--- a/protocol/reflex/silence_test.go
+++ b/protocol/reflex/silence_test.go
@@ -1,0 +1,96 @@
+package reflex
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestWaitForSilence_Timeout(t *testing.T) {
+	// Client connects but sends no data — expect (nil, nil) after timeout.
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	start := time.Now()
+	data, err := waitForSilence(server, 100*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected no error on silence, got %v", err)
+	}
+	if data != nil {
+		t.Fatalf("expected nil data on silence, got %q", data)
+	}
+	if elapsed < 90*time.Millisecond {
+		t.Fatalf("returned too early (%v); should have waited for timeout", elapsed)
+	}
+}
+
+func TestWaitForSilence_ClientSpeaks(t *testing.T) {
+	// Client sends a byte — expect (data, nil).
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		_, _ = client.Write([]byte{'X'})
+	}()
+
+	data, err := waitForSilence(server, 500*time.Millisecond)
+	if err != nil {
+		t.Fatalf("expected no error when client speaks, got %v", err)
+	}
+	if len(data) != 1 || data[0] != 'X' {
+		t.Fatalf("expected [X], got %q", data)
+	}
+}
+
+func TestWaitForSilence_ClearsDeadline(t *testing.T) {
+	// After waitForSilence returns, the read deadline should be cleared so
+	// subsequent reads (e.g., TLS handshake) can proceed.
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	_, err := waitForSilence(server, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Writing from client, reading from server should now work without
+	// immediate deadline failure.
+	go func() {
+		_, _ = client.Write([]byte("hello"))
+	}()
+
+	buf := make([]byte, 5)
+	server.SetReadDeadline(time.Now().Add(1 * time.Second))
+	n, err := server.Read(buf)
+	if err != nil {
+		t.Fatalf("expected read to succeed after clearing deadline, got %v", err)
+	}
+	if n != 5 || string(buf) != "hello" {
+		t.Fatalf("expected 'hello', got %q", string(buf[:n]))
+	}
+}
+
+func TestJitteredTimeout_Bounds(t *testing.T) {
+	base := 5 * time.Second
+	jitter := 2 * time.Second
+
+	for i := 0; i < 100; i++ {
+		got := jitteredTimeout(base, jitter)
+		if got < base-jitter || got > base+jitter {
+			t.Fatalf("got %v, expected within [%v, %v]", got, base-jitter, base+jitter)
+		}
+	}
+}
+
+func TestJitteredTimeout_NoJitter(t *testing.T) {
+	got := jitteredTimeout(5*time.Second, 0)
+	if got != 5*time.Second {
+		t.Fatalf("expected base when jitter is 0, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds zero-infrastructure active-probe resistance to Reflex by using the protocol's own invariant as the auth signal: **legitimate Lantern clients send no bytes until the server speaks**.

- If the client sends any data within the silence window (default 5s ± 2s jitter), the connection is transparently forwarded to a masquerade upstream (a real TLS site). Probes and misdirected HTTPS clients never see Reflex.
- If the client stays silent through the window, the server proceeds with the normal reversed TLS handshake as before.

This closes Reflex's only remaining non-IP-level vulnerability per the [whitepaper §4.5](https://github.com/getlantern/engineering/blob/main/docs/reflex-whitepaper.md) without any new server-side state, API endpoint, or client change.

## Relationship to the Universal IP Gate (getlantern/engineering#3168)

The silence timeout is the first half of a two-layer probe-resistance story:

- **Now (this PR)**: every connection pays silence-timeout latency; probes go to masquerade.
- **Later (#3168)**: the API pre-authorizes client IPs via SSE; known IPs short-circuit the silence wait. Ungated IPs still pay silence timeout, which serves as a clean fallback for stale-config users (e.g., users offline from the API during Iran shutdowns).

The masquerade handler added here is the foundation the gate will also use.

## New options on `ReflexInboundOptions`

| Field | Default | Notes |
|-------|---------|-------|
| `silence_timeout` | `""` (disabled) | e.g. `"5s"`. Zero preserves existing behavior. |
| `silence_jitter` | `"2s"` when enabled | Uniform ± jitter added per connection to avoid timing fingerprint. |
| `masquerade_upstream` | — | Required when `silence_timeout` is set. `host:port` of a real TLS service. |

Config validation ensures `masquerade_upstream` is provided whenever the silence feature is enabled.

## Tests

- `TestWaitForSilence_Timeout` — silent client returns `(nil, nil)` after timeout
- `TestWaitForSilence_ClientSpeaks` — returns the prefix bytes when client speaks
- `TestWaitForSilence_ClearsDeadline` — the read deadline is cleared after the probe so subsequent TLS reads work
- `TestJitteredTimeout_Bounds` / `_NoJitter` — jitter stays within bounds

All tests passing locally; e2e test coverage can be extended in a follow-up PR to send probe traffic and verify masquerade.

## Tradeoffs

- **Latency**: +silence_timeout on each new connection. 5s is noticeable on first connect but amortized by connection pooling. Once #3168 lands, this cost only applies to stale-config users (rare).
- **Censor adaptation**: a probe that holds connections open for 10+ seconds would still find us, but at ~100× their current per-probe cost. Jitter makes the threshold harder to pin down.

## Related

- Closes the active-probing TODO in getlantern/engineering#3166 (Reflex)
- Part of getlantern/engineering#3168 (Universal IP Gate umbrella)