### PR TITLE
unbounded: bind pion ICE sockets to physical interface + lifecycle logs

### DIFF
--- a/protocol/unbounded/net.go
+++ b/protocol/unbounded/net.go
@@ -6,9 +6,12 @@ import (
 
 	"github.com/pion/transport/v4"
 	"github.com/pion/transport/v4/stdnet"
+	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing/common/control"
 	"github.com/sagernet/sing/common/metadata"
 	N "github.com/sagernet/sing/common/network"
+	"github.com/sagernet/sing/service"
 )
 
 // rtcNet is a pion transport.Net backed by a sing-box N.Dialer. Every pion
@@ -45,6 +48,72 @@ func (n *rtcNet) Dial(network, address string) (net.Conn, error) {
 
 func (n *rtcNet) ListenPacket(network, address string) (net.PacketConn, error) {
 	return n.dialer.ListenPacket(n.ctx, metadata.ParseSocksaddr(address))
+}
+
+// ListenUDP is the path pion's ICE agent takes for every host candidate
+// (see pion/ice/v4 gather.go → listenUDPInPortRange → a.net.ListenUDP).
+// Without this override, the call would fall through to the embedded
+// *stdnet.Net, which is a thin wrapper around net.ListenUDP — that
+// creates sockets with no platform socket-protection, so on a VPN
+// client where the host process also serves the default TUN, the
+// sockets' egress packets follow the routing table straight back
+// through the TUN. ICE connectivity checks never reach the peer and
+// every session dies with "NAT failure, aborting!" after 5s.
+//
+// We can't funnel this through n.dialer.ListenPacket because that API
+// doesn't take a local bind address (its signature is destination-only),
+// and pion needs one socket per interface IP to gather per-interface
+// host candidates. So we construct a net.ListenConfig directly and
+// attach the NetworkManager's bind-to-physical-interface Control
+// function (the same one sing-box's DefaultDialer appends when
+// auto_detect_interface is set at the route level — via ProtectFunc
+// on platforms with a platformInterface, or AutoDetectInterfaceFunc
+// otherwise). Sockets still bind to the per-interface local address
+// pion requested, but their egress interface is force-bound via
+// IP_BOUND_IF (macOS/iOS) / SO_BINDTODEVICE (Linux/Android).
+func (n *rtcNet) ListenUDP(network string, laddr *net.UDPAddr) (transport.UDPConn, error) {
+	lc := net.ListenConfig{
+		Control: bindEgressToPhysicalInterface(n.ctx),
+	}
+	addr := ""
+	if laddr != nil {
+		addr = laddr.String()
+	}
+	pc, err := lc.ListenPacket(n.ctx, network, addr)
+	if err != nil {
+		return nil, err
+	}
+	udpConn, ok := pc.(*net.UDPConn)
+	if !ok {
+		pc.Close()
+		return nil, &net.OpError{
+			Op:  "listen",
+			Net: network,
+			Err: net.InvalidAddrError("ListenConfig did not return *net.UDPConn"),
+		}
+	}
+	return udpConn, nil
+}
+
+// bindEgressToPhysicalInterface returns a net.ListenConfig.Control
+// function that force-binds newly-created sockets to the platform's
+// default physical interface. When no NetworkManager is registered on
+// ctx (tests, standalone sing-box without the tunnel wrapper), it's a
+// no-op — the socket follows the routing table like a plain
+// net.ListenUDP. In a VPN host process this keeps UDP sockets off the
+// TUN the host itself is serving. Source: the same plumbing
+// sing-box/common/dialer/default.go:NewDefault appends when
+// networkManager.AutoDetectInterface() is true (see the
+// ProtectFunc/AutoDetectInterfaceFunc branches).
+func bindEgressToPhysicalInterface(ctx context.Context) control.Func {
+	nm := service.FromContext[adapter.NetworkManager](ctx)
+	if nm == nil {
+		return nil
+	}
+	if pf := nm.ProtectFunc(); pf != nil {
+		return pf
+	}
+	return nm.AutoDetectInterfaceFunc()
 }
 
 func (n *rtcNet) DialTCP(network string, laddr, raddr *net.TCPAddr) (transport.TCPConn, error) {

--- a/protocol/unbounded/net.go
+++ b/protocol/unbounded/net.go
@@ -100,11 +100,18 @@ func (n *rtcNet) ListenUDP(network string, laddr *net.UDPAddr) (transport.UDPCon
 // default physical interface. When no NetworkManager is registered on
 // ctx (tests, standalone sing-box without the tunnel wrapper), it's a
 // no-op — the socket follows the routing table like a plain
-// net.ListenUDP. In a VPN host process this keeps UDP sockets off the
-// TUN the host itself is serving. Source: the same plumbing
-// sing-box/common/dialer/default.go:NewDefault appends when
-// networkManager.AutoDetectInterface() is true (see the
-// ProtectFunc/AutoDetectInterfaceFunc branches).
+// net.ListenUDP.
+//
+// Implementation-wise we borrow the same ProtectFunc /
+// AutoDetectInterfaceFunc hooks sing-box's default dialer uses, but we
+// apply them UNCONDITIONALLY whenever a NetworkManager is present —
+// not gated on networkManager.AutoDetectInterface() the way
+// sing-box/common/dialer/default.go:NewDefault is. This is
+// intentional: pion's ICE host-candidate gathering fails if sockets
+// aren't kept off the TUN we're serving, even when the user hasn't
+// explicitly set auto_detect_interface on the outbound. Gating on
+// AutoDetectInterface() would reintroduce the "NAT failure, aborting!"
+// regression this override exists to fix.
 func bindEgressToPhysicalInterface(ctx context.Context) control.Func {
 	nm := service.FromContext[adapter.NetworkManager](ctx)
 	if nm == nil {

--- a/protocol/unbounded/outbound.go
+++ b/protocol/unbounded/outbound.go
@@ -237,33 +237,34 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 		return nil, fmt.Errorf("unbounded: not started (DialContext called before Start)")
 	}
 	started := time.Now()
+	dest := destination.String()
 	switch N.NetworkName(network) {
 	case N.NetworkTCP:
-		o.logger.DebugContext(ctx, "unbounded TCP dial start", "dest", destination.String())
-		conn, err := o.dial(ctx, network, destination.String())
+		o.logger.DebugContext(ctx, "unbounded TCP dial start", "dest", dest)
+		conn, err := o.dial(ctx, network, dest)
 		if err != nil {
 			o.logger.ErrorContext(ctx, "unbounded TCP dial failed",
-				"dest", destination.String(),
+				"dest", dest,
 				"elapsed", time.Since(started),
 				"err", err)
 			return nil, err
 		}
 		o.logger.DebugContext(ctx, "unbounded TCP dial ok",
-			"dest", destination.String(),
+			"dest", dest,
 			"elapsed", time.Since(started))
 		return conn, nil
 	case N.NetworkUDP:
-		o.logger.DebugContext(ctx, "unbounded UoT dial start", "dest", destination.String())
+		o.logger.DebugContext(ctx, "unbounded UoT dial start", "dest", dest)
 		conn, err := o.uot.DialContext(ctx, network, destination)
 		if err != nil {
 			o.logger.ErrorContext(ctx, "unbounded UoT dial failed",
-				"dest", destination.String(),
+				"dest", dest,
 				"elapsed", time.Since(started),
 				"err", err)
 			return nil, err
 		}
 		o.logger.DebugContext(ctx, "unbounded UoT dial ok",
-			"dest", destination.String(),
+			"dest", dest,
 			"elapsed", time.Since(started))
 		return conn, nil
 	}
@@ -279,17 +280,18 @@ func (o *Outbound) ListenPacket(ctx context.Context, destination M.Socksaddr) (n
 		return nil, fmt.Errorf("unbounded: not started (ListenPacket called before Start)")
 	}
 	started := time.Now()
-	o.logger.InfoContext(ctx, "unbounded UoT ListenPacket start", "dest", destination.String())
+	dest := destination.String()
+	o.logger.DebugContext(ctx, "unbounded UoT ListenPacket start", "dest", dest)
 	pc, err := o.uot.ListenPacket(ctx, destination)
 	if err != nil {
 		o.logger.ErrorContext(ctx, "unbounded UoT ListenPacket failed",
-			"dest", destination.String(),
+			"dest", dest,
 			"elapsed", time.Since(started),
 			"err", err)
 		return nil, err
 	}
-	o.logger.InfoContext(ctx, "unbounded UoT ListenPacket ok",
-		"dest", destination.String(),
+	o.logger.DebugContext(ctx, "unbounded UoT ListenPacket ok",
+		"dest", dest,
 		"elapsed", time.Since(started))
 	return pc, nil
 }

--- a/protocol/unbounded/outbound.go
+++ b/protocol/unbounded/outbound.go
@@ -175,6 +175,18 @@ func (o *Outbound) Start(stage adapter.StartStage) error {
 		return nil
 	}
 
+	startCtx := context.Background()
+	o.logger.InfoContext(startCtx, "unbounded Start begin",
+		"tag", o.Tag(),
+		"discovery_srv", o.rtcOpt.DiscoverySrv,
+		"egress_addr", o.egOpt.Addr,
+		"ctable_size", o.bfOpt.CTableSize,
+		"ptable_size", o.bfOpt.PTableSize,
+		"client_type", o.bfOpt.ClientType,
+		"insecure_tls", o.tlsCfg.insecure,
+	)
+	startedAt := time.Now()
+
 	tlsConf, err := selfSignedTLSConfig(o.tlsCfg.insecure, o.tlsCfg.ca, o.tlsCfg.serverName)
 	if err != nil {
 		return fmt.Errorf("unbounded: build TLS config: %w", err)
@@ -184,6 +196,7 @@ func (o *Outbound) Start(stage adapter.StartStage) error {
 	if err != nil {
 		return fmt.Errorf("unbounded: start broflake: %w", err)
 	}
+	o.logger.InfoContext(startCtx, "unbounded broflake built", "elapsed", time.Since(startedAt))
 	ql, err := UBClientcore.NewQUICLayer(bfConn, tlsConf)
 	if err != nil {
 		ui.Stop()
@@ -196,6 +209,8 @@ func (o *Outbound) Start(stage adapter.StartStage) error {
 	o.dial = UBClientcore.CreateSOCKS5Dialer(ql)
 
 	go o.ql.ListenAndMaintainQUICConnection()
+	o.logger.InfoContext(startCtx, "unbounded Start complete, SOCKS5Dialer ready",
+		"elapsed", time.Since(startedAt))
 	return nil
 }
 
@@ -221,13 +236,36 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 	if o.dial == nil {
 		return nil, fmt.Errorf("unbounded: not started (DialContext called before Start)")
 	}
+	started := time.Now()
 	switch N.NetworkName(network) {
 	case N.NetworkTCP:
-		o.logger.DebugContext(ctx, "unbounded TCP dial to ", destination)
-		return o.dial(ctx, network, destination.String())
+		o.logger.DebugContext(ctx, "unbounded TCP dial start", "dest", destination.String())
+		conn, err := o.dial(ctx, network, destination.String())
+		if err != nil {
+			o.logger.ErrorContext(ctx, "unbounded TCP dial failed",
+				"dest", destination.String(),
+				"elapsed", time.Since(started),
+				"err", err)
+			return nil, err
+		}
+		o.logger.DebugContext(ctx, "unbounded TCP dial ok",
+			"dest", destination.String(),
+			"elapsed", time.Since(started))
+		return conn, nil
 	case N.NetworkUDP:
-		o.logger.DebugContext(ctx, "unbounded UoT dial to ", destination)
-		return o.uot.DialContext(ctx, network, destination)
+		o.logger.DebugContext(ctx, "unbounded UoT dial start", "dest", destination.String())
+		conn, err := o.uot.DialContext(ctx, network, destination)
+		if err != nil {
+			o.logger.ErrorContext(ctx, "unbounded UoT dial failed",
+				"dest", destination.String(),
+				"elapsed", time.Since(started),
+				"err", err)
+			return nil, err
+		}
+		o.logger.DebugContext(ctx, "unbounded UoT dial ok",
+			"dest", destination.String(),
+			"elapsed", time.Since(started))
+		return conn, nil
 	}
 	return nil, fmt.Errorf("unbounded: unsupported network %q", network)
 }
@@ -240,8 +278,20 @@ func (o *Outbound) ListenPacket(ctx context.Context, destination M.Socksaddr) (n
 	if o.dial == nil {
 		return nil, fmt.Errorf("unbounded: not started (ListenPacket called before Start)")
 	}
-	o.logger.DebugContext(ctx, "unbounded UoT packet dial to ", destination)
-	return o.uot.ListenPacket(ctx, destination)
+	started := time.Now()
+	o.logger.InfoContext(ctx, "unbounded UoT ListenPacket start", "dest", destination.String())
+	pc, err := o.uot.ListenPacket(ctx, destination)
+	if err != nil {
+		o.logger.ErrorContext(ctx, "unbounded UoT ListenPacket failed",
+			"dest", destination.String(),
+			"elapsed", time.Since(started),
+			"err", err)
+		return nil, err
+	}
+	o.logger.InfoContext(ctx, "unbounded UoT ListenPacket ok",
+		"dest", destination.String(),
+		"elapsed", time.Since(started))
+	return pc, nil
 }
 
 // signalingClient returns the HTTP client broflake uses to reach freddie.


### PR DESCRIPTION
## Summary

Two fixes surfaced during end-to-end Unbounded debugging on 2026-04-20:

1. **Override \`rtcNet.ListenUDP\`** so pion's ICE agent doesn't fall through to \`*stdnet.Net\`. Without the override, ICE host-candidate sockets get plain \`net.ListenUDP()\` with no platform socket-protection — in a VPN host process the egress packets route back through the TUN we're serving, ICE checks never reach the peer, every session dies with \"NAT failure, aborting!\" after 5 s.
2. **Lifecycle logs** in \`Outbound.Start\` + start/fail/ok markers in \`DialContext\` (Debug success path, Error fail path, elapsed time on all). Silent in normal operation but gives us the \"when did Start complete\" / \"which dial failed how quickly\" data that was missing while debugging.

## The rtcNet.ListenUDP story

The existing \`rtcNet\` type overrides \`ListenPacket\`, \`DialTCP\`, \`DialUDP\` — but pion's ICE agent specifically calls \`a.net.ListenUDP\` (\`pion/ice/v4\` → \`gather.go\` → \`listenUDPInPortRange\`). That falls through to the embedded \`*stdnet.Net\`, which just delegates to \`net.ListenUDP\`. The resulting sockets have no interface binding, so on macOS/iOS their egress packets follow the routing table straight back through the TUN the host is serving.

We can't funnel this through \`n.dialer.ListenPacket\` because that API is destination-only (no local bind address), and pion needs one socket per interface IP for per-interface host-candidate gathering. The override builds a \`net.ListenConfig\` directly and attaches a \`Control\` func that force-binds via \`IP_BOUND_IF\` (macOS) / \`SO_BINDTODEVICE\` (Linux/Android) — same plumbing sing-box's \`DefaultDialer\` appends when \`auto_detect_interface\` is set at the route level (\`ProtectFunc\` on platforms with a \`platformInterface\`, \`AutoDetectInterfaceFunc\` otherwise).

Falls through to stock behaviour when no \`NetworkManager\` is registered on ctx (tests, standalone sing-box without the tunnel wrapper).

## Base

Targeting \`fisk/unbounded-outbound-v2\` (PR #241). Will retarget to \`main\` after that lands.

## Test plan

- [x] \`go build ./protocol/unbounded/...\` clean
- [x] Manually verified on test droplet + desktop Lantern: consumer pairs with widget, WebRTC datachannel opens, ICE candidates bind to physical interface (\`en0\`-equivalent) rather than \`utun\*\`
- [ ] iOS / Android smoke once there's a build that includes this

🤖 Generated with [Claude Code](https://claude.com/claude-code)