### PR TITLE
deps: bump broflake to main + quic-go fork to v0.59.0-unbounded

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -311,4 +311,11 @@ require (
 
 replace github.com/quic-go/quic-go => github.com/getlantern/quic-go-unbounded-fork v0.59.0-unbounded
 
+// Keep qpack on v0.5.1 for sing-box-minimal/sagernet quic-go HTTP/3 compatibility:
+// sing-box-minimal@v1.12.21-lantern pins sagernet/quic-go@v0.52.0-sing-box-mod.3,
+// whose http3 package (used by hysteria2, DoQ, v2rayquic) was compiled against
+// qpack's v0.5.1 API (NewDecoder(cb) + DecodeFull, both removed in v0.6.0).
+// Without this override, MVS picks v0.6.0 via quic-go/quic-go v0.59.0's require
+// and the build breaks. Remove once sing-box-minimal bumps to a sagernet/quic-go
+// release that uses the qpack v0.6.0 API (v0.59.0-sing-box-mod.4 or later).
 replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ replace github.com/refraction-networking/water => github.com/getlantern/water v0
 require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52
-	github.com/getlantern/broflake v0.0.0-20260417230047-38c1be9d5596
+	github.com/getlantern/broflake v0.0.0-20260421172440-caea0799b63a
 	github.com/getlantern/geo v0.0.0-20241129152027-2fc88c10f91e
 	github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90
 	github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974
@@ -221,7 +221,7 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus-community/pro-bing v0.4.0 // indirect
 	github.com/protolambda/ctxlock v0.1.0 // indirect
-	github.com/quic-go/qpack v0.5.1 // indirect
+	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/refraction-networking/utls v1.8.2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
@@ -262,6 +262,7 @@ require (
 	github.com/tailscale/peercred v0.0.0-20250107143737-35a0c7bd7edc // indirect
 	github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976 // indirect
 	github.com/tevino/abool/v2 v2.1.0 // indirect
+	github.com/theodorsm/covert-dtls v1.5.0 // indirect
 	github.com/tidwall/btree v1.8.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
@@ -308,4 +309,6 @@ require (
 	zombiezen.com/go/sqlite v0.13.1 // indirect
 )
 
-replace github.com/quic-go/quic-go => github.com/getlantern/quic-go-unbounded-fork v0.56.1-unbounded
+replace github.com/quic-go/quic-go => github.com/getlantern/quic-go-unbounded-fork v0.59.0-unbounded
+
+replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/gaukas/wazerofs v0.1.0 h1:wIkW1bAxSnpaaVkQ5LOb1tm1BXdVap3eKjJpVWIqt2E
 github.com/gaukas/wazerofs v0.1.0/go.mod h1:+JECB9Fwt0taPqSgHckG9lmT3tcoVK+9VJozTsq9UlI=
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 h1:w2/RqYPw7PbTYfUMS2aToD5DMKLBnQed+fkTEYTKAqQ=
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52/go.mod h1:PrNR8tMXO26YNs8K9653XCUH7u2Kv4OdfFC3Ke1GsX0=
-github.com/getlantern/broflake v0.0.0-20260417230047-38c1be9d5596 h1:GOBIUbTocst8THjzHMruS//yscy+hwXVQk8k3Arutc0=
-github.com/getlantern/broflake v0.0.0-20260417230047-38c1be9d5596/go.mod h1:/BvO5fiSg0r9zIN40RIzyGKRlbvg8A29WGXcNAxYit0=
+github.com/getlantern/broflake v0.0.0-20260421172440-caea0799b63a h1:WQ11Ms5jGvBaH6v/u1QBvmnnzRY0ckMiifCnDM/x6TI=
+github.com/getlantern/broflake v0.0.0-20260421172440-caea0799b63a/go.mod h1:bZGGfTwne9NIsy3Kc1avcXNWn/yA8ghUwlXdS2z+AlA=
 github.com/getlantern/context v0.0.0-20190109183933-c447772a6520/go.mod h1:L+mq6/vvYHKjCX2oez0CgEAJmbq1fbb/oNJIWQkBybY=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
@@ -261,8 +261,8 @@ github.com/getlantern/ops v0.0.0-20190325191751-d70cb0d6f85f/go.mod h1:D5ao98qkA
 github.com/getlantern/ops v0.0.0-20220713155959-1315d978fff7/go.mod h1:D5ao98qkA6pxftxoqzibIBBrLSUli+kYnJqrgBf9cIA=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534/go.mod h1:ZsLfOY6gKQOTyEcPYNA9ws5/XHZQFroxqCOhHjGcs9Y=
-github.com/getlantern/quic-go-unbounded-fork v0.56.1-unbounded h1:cW8oimnpBMnq8lrEoKhIXxqVe30eN53/YCmTwBwhbtE=
-github.com/getlantern/quic-go-unbounded-fork v0.56.1-unbounded/go.mod h1:9gx5KsFQtw2oZ6GZTyh+7YEvOxWCL9WZAepnHxgAo6c=
+github.com/getlantern/quic-go-unbounded-fork v0.59.0-unbounded h1:1vTizA6U8YdyvZT0RIsEaY5fuhuZumnR8myyCF3qiZs=
+github.com/getlantern/quic-go-unbounded-fork v0.59.0-unbounded/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=
@@ -756,6 +756,8 @@ github.com/testcontainers/testcontainers-go v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+
 github.com/testcontainers/testcontainers-go v0.40.0/go.mod h1:FSXV5KQtX2HAMlm7U3APNyLkkap35zNLxukw9oBi/MY=
 github.com/tevino/abool/v2 v2.1.0 h1:7w+Vf9f/5gmKT4m4qkayb33/92M+Um45F2BkHOR+L/c=
 github.com/tevino/abool/v2 v2.1.0/go.mod h1:+Lmlqk6bHDWHqN1cbxqhwEAwMPXgc8I1SDEamtseuXY=
+github.com/theodorsm/covert-dtls v1.5.0 h1:kGUnCuGB65kLrga0e1mYv8t2RA4vfRMN0iYlakY0z/c=
+github.com/theodorsm/covert-dtls v1.5.0/go.mod h1:MTb9IO4aqSxrcrh569UGO4PlC1Yel37M440z+gcm13E=
 github.com/things-go/go-socks5 v0.0.5 h1:qvKaGcBkfDrUL33SchHN93srAmYGzb4CxSM2DPYufe8=
 github.com/things-go/go-socks5 v0.0.5/go.mod h1:mtzInf8v5xmsBpHZVbIw2YQYhc4K0jRwzfsH64Uh0IQ=
 github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=


### PR DESCRIPTION
## Summary

Picks up the content of unbounded PRs that landed on broflake's main over the past day:

- **#241** — the Unbounded outbound implementation itself (now on lantern-box main, but the consumer-side broflake pin is still behind)
- **#350 + #353** — covert-dtls randomization + data-plane byte counters + QUIC listener spin-loop fix
- **#354** — pion/webrtc v4.2.11 migration + quic-go v0.59.0 (with our ConnectionID bump preserved in the `v0.59.0-unbounded` fork tag)

## What changes

| Pin | Before | After |
|---|---|---|
| `github.com/getlantern/broflake` | `v0.0.0-20260417230047-38c1be9d5596` | `v0.0.0-20260421172440-caea0799b63a` (main tip) |
| `replace github.com/quic-go/quic-go` | `v0.56.1-unbounded` | `v0.59.0-unbounded` |
| `replace github.com/quic-go/qpack` | (not present) | `v0.5.1` |

### Why the fork replace moves to `v0.59.0-unbounded`

`v0.56.1-unbounded` was a temporary bridge tag we cut while broflake's main was still on the older v0.51 quic-go API (the new API landed in broflake via a separate branch). Now that broflake main is on v0.59 API (unbounded #354), we can use the fork tag that actually matches — `v0.59.0-unbounded`, which is upstream v0.59 with our ConnectionID bump applied.

### Why the new qpack replace

`sing-box-minimal@v1.12.21-lantern` still pins `sagernet/quic-go@v0.52.0-sing-box-mod.3`, whose `http3` package was compiled against qpack v0.5.1's API (`NewDecoder(cb)` + `DecodeFull` — both removed in v0.6.0). Without the replace, MVS picks v0.6.0 via quic-go/quic-go v0.59.0's require, and `sagernet/quic-go/http3` (used for hysteria2, DoQ, etc.) fails to compile.

**Follow-up**: drop this replace once sing-box-minimal bumps to `sagernet/quic-go v0.59.0-sing-box-mod.4` (which uses the qpack v0.6.0 API).

## Test plan

- [x] `CGO_ENABLED=1 go build -tags "with_gvisor,with_quic,with_dhcp,with_wireguard,with_utls,with_acme,with_clash_api" ./cmd` clean
- [x] End-to-end verified via desktop Lantern → widget (DO droplet) → egress (Linode us-east): WebRTC datachannel opens, QUIC handshake completes, traffic flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)