### PR TITLE
deps: bump keepcurrent to pick up FromTarGz extraction fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65 // indirect
 	github.com/getlantern/hex v0.0.0-20220104173244-ad7e4b9194dc // indirect
 	github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 // indirect
-	github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae // indirect
+	github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 // indirect
 	github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 // indirect
 	github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5 // indirect
 	github.com/go-chi/chi/v5 v5.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ github.com/getlantern/hex v0.0.0-20220104173244-ad7e4b9194dc/go.mod h1:D9RWpXy/E
 github.com/getlantern/hidden v0.0.0-20190325191715-f02dbb02be55/go.mod h1:6mmzY2kW1TOOrVy+r41Za2MxXM+hhqTtY3oBKd2AgFA=
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2yaur9Qk3rHYD414j3Q1rl7+L0AylxrE=
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
-github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae h1:NMq3K7h3N/usgEtUMQs8WBzvhKKOfBvHo+18pXgtpds=
-github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
+github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 h1:iLWm6S/47Hfk7FjW6yaD+1h6kO7C/iauV0DkVia/bXU=
+github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 h1:P9JX1yAu2uq3b5YiT0sLtHkTrkZuttV8gPZh81nUuag=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20190325191751-d70cb0d6f85f/go.mod h1:D5ao98qkA6pxftxoqzibIBBrLSUli+kYnJqrgBf9cIA=


### PR DESCRIPTION
Bumps \`github.com/getlantern/keepcurrent\` from \`017d542\` (2026-03-04) to \`54a4d9a\` (2026-04-22), pulling in getlantern/keepcurrent#7.

## Why

Every bandit VPS has been silently failing to load the MaxMind GeoIP2-City database since the mholt/archiver → mholt/archives migration in keepcurrent. The downstream effect is that \`tracker/metrics/tracker.go\` tagged every \`proxy.io\` data point with \`geo.country.iso_code=\"\"\` (because \`*lookup.CountryCode\` returns empty when the db never loads), and the dashboard's country filter matched zero across the entire fleet.

Two bugs fixed upstream:

1. \`archives.CompressedArchive\` was constructed with \`Archival\` set instead of \`Extraction\`. \`Extract()\` checks \`ca.Extraction\` and returns \`\"no extraction format\"\` if nil — every \`Fetch()\` failed, silently swallowed by keepcurrent's retry loop (up to 30 tries, logs only after exhaustion).
2. \`info.NameInArchive\` was compared against the caller's basename, but it's the full stored path — e.g. \`GeoLite2-City_20260116/GeoLite2-City.mmdb\` as MaxMind ships. The fix uses \`path.Base()\`, matching the archiver/v3 behavior this replaced.

## Verified end-to-end

Before shipping upstream #7, ran a minimal Go probe against a live production bandit VPS reproducing the exact \`keepcurrent.FromTarGz(FromWeb(url), \"GeoLite2-City.mmdb\").Fetch()\` call path. Pre-fix: \`err=\"no extraction format\"\`. Post-fix: extracts the 63 MB mmdb in 1.6 s.

## Next

- Merge this.
- Rebuild the lantern-box packer image so newly-provisioned bandit VPSes pick it up.
- Let the drain continue turning over the fleet.
- Dashboard country filter should start showing real data within a few hours of the new image rolling out.

## Test plan

- [x] \`go mod tidy\` clean
- [x] \`go build ./...\` clean
- [x] Verified upstream fix on a live prod VPS (details above)