### PR TITLE
packer: drop DigitalOcean builder

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -13,9 +13,9 @@ on:
         required: true
         type: string
       builders:
-        description: "Comma-separated builders (digitalocean,linode,oracle-oci,alicloud-ecs)"
+        description: "Comma-separated builders (linode,oracle-oci,alicloud-ecs)"
         required: false
-        default: "digitalocean,linode,oracle-oci,alicloud-ecs"
+        default: "linode,oracle-oci,alicloud-ecs"
         type: string
 
 permissions:
@@ -55,7 +55,7 @@ jobs:
           INPUT_BUILDERS: ${{ inputs.builders }}
         run: |
           if [ "$EVENT_NAME" = "release" ]; then
-            builders="digitalocean,linode,oracle-oci,alicloud-ecs"
+            builders="linode,oracle-oci,alicloud-ecs"
           else
             builders="$INPUT_BUILDERS"
           fi
@@ -78,40 +78,6 @@ jobs:
     timeout-minutes: 5
     needs: prepare
     steps:
-      - name: Prune old DigitalOcean snapshots
-        if: contains(needs.prepare.outputs.matrix, 'digitalocean')
-        env:
-          DIGITALOCEAN_API_TOKEN: ${{ secrets.DO_API_TOKEN }}
-        run: |
-          KEEP=3
-          echo "Fetching DigitalOcean snapshots..."
-          snapshots=$(curl -sS -f -H "Authorization: Bearer $DIGITALOCEAN_API_TOKEN" \
-            "https://api.digitalocean.com/v2/snapshots?resource_type=droplet&per_page=200" \
-            | jq -r '.snapshots[] | select(.name | startswith("lantern-box-")) | "\(.created_at)\t\(.id)\t\(.name)"' \
-            | sort -r)
-          total=$(echo "$snapshots" | grep -c . || true)
-          echo "Found $total lantern-box snapshots (keeping $KEEP most recent)"
-          if [ "$total" -le "$KEEP" ]; then
-            echo "Nothing to prune."
-          else
-            failures=0
-            echo "$snapshots" | tail -n +$((KEEP + 1)) | while IFS=$'\t' read -r created id name; do
-              echo "Deleting $name ($id, created $created)..."
-              http_code=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE -H "Authorization: Bearer $DIGITALOCEAN_API_TOKEN" \
-                "https://api.digitalocean.com/v2/snapshots/$id")
-              if [ "$http_code" = "404" ]; then
-                echo "  Already gone (404), skipping."
-              elif [ "$http_code" -ge 400 ]; then
-                echo "::error::Failed to delete DO snapshot $name ($id): HTTP $http_code"
-                failures=$((failures + 1))
-              fi
-            done
-            if [ "$failures" -gt 0 ]; then
-              echo "::error::$failures snapshot(s) failed to delete"
-              exit 1
-            fi
-          fi
-
       - name: Prune old Linode images
         if: contains(needs.prepare.outputs.matrix, 'linode')
         env:
@@ -232,7 +198,7 @@ jobs:
               done
               echo "flag=$joined" >> "$GITHUB_OUTPUT"
               ;;
-            digitalocean|linode|alicloud-ecs)
+            linode|alicloud-ecs)
               echo "flag=${BUILDER}.lantern-box" >> "$GITHUB_OUTPUT"
               ;;
             *)
@@ -341,7 +307,6 @@ jobs:
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
           ONLY: ${{ steps.only.outputs.flag }}
-          DIGITALOCEAN_API_TOKEN: ${{ secrets.DO_API_TOKEN }}
           LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
           OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
           OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}

--- a/deploy/packer/README.md
+++ b/deploy/packer/README.md
@@ -24,7 +24,7 @@ packer init .
 # Build for a single provider
 packer build \
   -var "lantern_box_version=0.5.0" \
-  -only="digitalocean.lantern-box" \
+  -only="linode.lantern-box" \
   .
 
 # Build for all providers
@@ -41,7 +41,6 @@ In CI, the `datacap` binary is built from `getlantern/lantern-cloud` and baked i
 
 | Variable | Description |
 |---|---|
-| `DIGITALOCEAN_API_TOKEN` | DigitalOcean API token |
 | `LINODE_TOKEN` | Linode/Akamai API token |
 | `FURY_TOKEN` | Gemfury token for .deb repo |
 | `OCI_TENANCY_OCID` | OCI tenancy OCID |
@@ -74,17 +73,6 @@ In CI, the `datacap` binary is built from `getlantern/lantern-cloud` and baked i
 2. Pass a cloud-init user-data file that writes the config and starts the service
 
 See `cloud-init.yaml.example` for the template.
-
-### DigitalOcean example
-
-```bash
-doctl compute droplet create my-proxy \
-  --image <snapshot-id> \
-  --region sfo3 \
-  --size s-1vcpu-1gb \
-  --user-data-file cloud-init.yaml \
-  --wait
-```
 
 ### Linode example
 

--- a/deploy/packer/cloud-init.yaml.example
+++ b/deploy/packer/cloud-init.yaml.example
@@ -28,7 +28,7 @@ write_files:
       proxyname = my-proxy-01
       pro = false
       track = stable
-      provider = digitalocean
+      provider = linode
       proxyprotocol = algeneva
 
 runcmd:

--- a/deploy/packer/lantern-box.pkr.hcl
+++ b/deploy/packer/lantern-box.pkr.hcl
@@ -1,9 +1,5 @@
 packer {
   required_plugins {
-    digitalocean = {
-      version = ">= 1.4.0"
-      source  = "github.com/digitalocean/digitalocean"
-    }
     linode = {
       version = ">= 1.1.0"
       source  = "github.com/linode/linode"
@@ -31,20 +27,6 @@ locals {
 }
 
 # ---------- Sources ----------
-
-source "digitalocean" "lantern-box" {
-  api_token    = var.do_api_token
-  image        = "ubuntu-24-04-x64"
-  region       = var.do_region
-  size         = "s-1vcpu-1gb"
-  ssh_username = "root"
-  snapshot_name = "lantern-box-${var.lantern_box_version}-{{timestamp}}"
-  snapshot_regions = [
-    "sfo3", "nyc3", "ams3", "sgp1", "lon1", "fra1", "blr1", "syd1",
-  ]
-  tags = ["lantern-box", "packer"]
-  state_timeout = "10m"
-}
 
 # OCI sources — one per region. All share auth + compartment but use
 # region-specific subnet, AD, and produce region-local images.
@@ -1001,7 +983,6 @@ source "alicloud-ecs" "lantern-box" {
 
 build {
   sources = [
-    "source.digitalocean.lantern-box",
     "source.linode.lantern-box",
     "source.oracle-oci.lantern-box-iad",
     "source.oracle-oci.lantern-box-fra",
@@ -1057,15 +1038,15 @@ build {
   }
 
   # Upload the datacap binary for this arch.
-  # OCI sources target arm64; DigitalOcean/Linode/Alicloud target amd64.
+  # OCI sources target arm64; Linode/Alicloud target amd64.
   provisioner "file" {
-    only        = ["digitalocean.lantern-box", "linode.lantern-box", "alicloud-ecs.lantern-box"]
+    only        = ["linode.lantern-box", "alicloud-ecs.lantern-box"]
     source      = "/tmp/datacap-amd64"
     destination = "/tmp/datacap"
   }
 
   provisioner "file" {
-    except      = ["digitalocean.lantern-box", "linode.lantern-box", "alicloud-ecs.lantern-box"]
+    except      = ["linode.lantern-box", "alicloud-ecs.lantern-box"]
     source      = "/tmp/datacap-arm64"
     destination = "/tmp/datacap"
   }

--- a/deploy/packer/variables.pkr.hcl
+++ b/deploy/packer/variables.pkr.hcl
@@ -3,22 +3,10 @@ variable "lantern_box_version" {
   description = "Version tag to install (e.g. 1.2.3). Downloaded from GitHub release."
 }
 
-variable "do_api_token" {
-  type      = string
-  sensitive = true
-  default   = env("DIGITALOCEAN_API_TOKEN")
-}
-
 variable "linode_token" {
   type      = string
   sensitive = true
   default   = env("LINODE_TOKEN")
-}
-
-
-variable "do_region" {
-  type    = string
-  default = "sfo3"
 }
 
 variable "linode_region" {


### PR DESCRIPTION
We're not actively using DigitalOcean in the bandit fleet — traffic flows through OCI, Linode, and Alicloud. The DO builder has also been failing every release with \`Size is not available in this region\` for \`s-1vcpu-1gb\` in the configured region, failing the overall \`build-images\` workflow even when the three active providers succeed.

Removed from:
- \`deploy/packer/lantern-box.pkr.hcl\` — required_plugins, source block, build-sources list, both datacap-provisioner only/except filters
- \`deploy/packer/variables.pkr.hcl\` — \`do_api_token\`, \`do_region\`
- \`.github/workflows/build-images.yaml\` — matrix default + release builders list, prune step, only-flag case, \`DIGITALOCEAN_API_TOKEN\` env
- \`deploy/packer/README.md\` — single-provider example, env var table, DO deploy example
- \`deploy/packer/cloud-init.yaml.example\` — example \`provider\` field

Reverting this commit restores DO support if we ever want it back.

## Test plan

- [x] No residual \`digitalocean\` / \`DIGITALOCEAN\` / \`do_api_token\` / \`do_region\` references in packer HCL or the workflow
- [x] Workflow YAML parses (no tabs, no merge markers)
- [ ] Re-run \`workflow_dispatch\` on \`build-images.yaml\` with \`version=0.0.71\` → expect a green build for linode, oracle-oci, alicloud-ecs