### PR TITLE
storage urltest history storage under proper key

### DIFF
--- a/protocol/group/mutableurltest.go
+++ b/protocol/group/mutableurltest.go
@@ -282,7 +282,7 @@ func newURLTestGroup(
 ) *urlTestGroup {
 	ctx, cancel := context.WithCancel(ctx)
 	var history A.URLTestHistoryStorage
-	if historyFromCtx := service.PtrFromContext[urltest.HistoryStorage](ctx); historyFromCtx != nil {
+	if historyFromCtx := service.FromContext[A.URLTestHistoryStorage](ctx); historyFromCtx != nil {
 		history = historyFromCtx
 	} else if clashServer := service.FromContext[A.ClashServer](ctx); clashServer != nil {
 		history = clashServer.HistoryStorage()


### PR DESCRIPTION
Retrieve the URLTest history storage from the context in `MutableURLTest` using same key as other locations so it uses the shared instance. Use `adapter.URLTestHistoryStorage` instead of `urltest.HistoryStorage`. 