### PR TITLE
reflex: lower default silence timeout to 2s ± 600ms

### DIFF
--- a/option/reflex.go
+++ b/option/reflex.go
@@ -56,8 +56,12 @@ type ReflexInboundOptions struct {
 	// Typical value: "2s". Jittered by SilenceJitter to avoid timing fingerprint.
 	SilenceTimeout string `json:"silence_timeout,omitempty"`
 
-	// SilenceJitter is the maximum random duration added to SilenceTimeout per
-	// connection. Defaults to "600ms" when SilenceTimeout is set.
+	// SilenceJitter is the half-width of a symmetric random offset applied to
+	// SilenceTimeout per connection. The actual wait is uniformly distributed
+	// in [SilenceTimeout - SilenceJitter, SilenceTimeout + SilenceJitter), so
+	// SilenceJitter must be strictly less than SilenceTimeout (otherwise the
+	// minimum wait could reach zero and the silence window would be skipped).
+	// Defaults to "600ms" when SilenceTimeout is set.
 	SilenceJitter string `json:"silence_jitter,omitempty"`
 
 	// MasqueradeUpstream is the host:port of a real TLS service to which

--- a/option/reflex.go
+++ b/option/reflex.go
@@ -53,11 +53,11 @@ type ReflexInboundOptions struct {
 	// ClientHello. Probes never see Reflex.
 	//
 	// Set to "0" or leave empty to disable (probing exposure for Reflex).
-	// Typical value: "5s". Jittered by SilenceJitter to avoid timing fingerprint.
+	// Typical value: "2s". Jittered by SilenceJitter to avoid timing fingerprint.
 	SilenceTimeout string `json:"silence_timeout,omitempty"`
 
 	// SilenceJitter is the maximum random duration added to SilenceTimeout per
-	// connection. Defaults to "2s" when SilenceTimeout is set.
+	// connection. Defaults to "600ms" when SilenceTimeout is set.
 	SilenceJitter string `json:"silence_jitter,omitempty"`
 
 	// MasqueradeUpstream is the host:port of a real TLS service to which

--- a/protocol/reflex/inbound.go
+++ b/protocol/reflex/inbound.go
@@ -23,7 +23,7 @@ import (
 
 // defaultSilenceJitter is applied when SilenceTimeout is set but
 // SilenceJitter is not explicitly configured.
-const defaultSilenceJitter = 2 * time.Second
+const defaultSilenceJitter = 600 * time.Millisecond
 
 func RegisterInbound(registry *inbound.Registry) {
 	inbound.Register[option.ReflexInboundOptions](registry, constant.TypeReflex, NewInbound)


### PR DESCRIPTION
## Summary

- Server's silence window before emitting ClientHello drops from **5s ± 2s** (worst case ~7s) to **2s ± 600ms** (worst case ~2.6s).
- 2.6s still comfortably exceeds a typical active-probe TCP timeout, so probe resistance is preserved while first-byte latency noticeably improves.
- Both values remain fully overridable per-proxy via `SilenceTimeout` / `SilenceJitter` in the inbound options — this PR only changes the hard-coded fallback used when an operator leaves `SilenceJitter` unset.

## Changes

- `protocol/reflex/inbound.go`: `defaultSilenceJitter` 2s → 600ms.
- `option/reflex.go`: doc comments updated to reflect new typicals ("Typical value: 2s", "Defaults to 600ms").

## Pairs with

- getlantern/lantern-cloud — matching update to `cmd/api/pcfg/reflex.go` (`defaultReflexSilenceTimeout`/`defaultReflexSilenceJitter`).

## Test plan

- [x] `go build ./...`, `go test ./protocol/reflex/...` — green locally.
- [ ] CI green.
- [ ] After deploy, sanity-check Reflex connections from a client: first-byte latency should sit in the 1.4s–2.6s band instead of 3s–7s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)