### PR TITLE
Bump broflake to ce5f75a (unbounded slog sweep)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ replace github.com/refraction-networking/water => github.com/getlantern/water v0
 require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52
-	github.com/getlantern/broflake v0.0.0-20260421172440-caea0799b63a
+	github.com/getlantern/broflake v0.0.0-20260501210609-ce5f75aa2054
 	github.com/getlantern/geo v0.0.0-20241129152027-2fc88c10f91e
 	github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90
 	github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/gaukas/wazerofs v0.1.0 h1:wIkW1bAxSnpaaVkQ5LOb1tm1BXdVap3eKjJpVWIqt2E
 github.com/gaukas/wazerofs v0.1.0/go.mod h1:+JECB9Fwt0taPqSgHckG9lmT3tcoVK+9VJozTsq9UlI=
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 h1:w2/RqYPw7PbTYfUMS2aToD5DMKLBnQed+fkTEYTKAqQ=
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52/go.mod h1:PrNR8tMXO26YNs8K9653XCUH7u2Kv4OdfFC3Ke1GsX0=
-github.com/getlantern/broflake v0.0.0-20260421172440-caea0799b63a h1:WQ11Ms5jGvBaH6v/u1QBvmnnzRY0ckMiifCnDM/x6TI=
-github.com/getlantern/broflake v0.0.0-20260421172440-caea0799b63a/go.mod h1:bZGGfTwne9NIsy3Kc1avcXNWn/yA8ghUwlXdS2z+AlA=
+github.com/getlantern/broflake v0.0.0-20260501210609-ce5f75aa2054 h1:nrRMiRRjzR43yihrVxdnmmt66ZqjRhHE73TyHW1ySgg=
+github.com/getlantern/broflake v0.0.0-20260501210609-ce5f75aa2054/go.mod h1:bZGGfTwne9NIsy3Kc1avcXNWn/yA8ghUwlXdS2z+AlA=
 github.com/getlantern/context v0.0.0-20190109183933-c447772a6520/go.mod h1:L+mq6/vvYHKjCX2oez0CgEAJmbq1fbb/oNJIWQkBybY=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=


### PR DESCRIPTION
## Summary

- Bumps `github.com/getlantern/broflake` from `caea0799b63a` (Apr 21) → `ce5f75aa2054` (May 1)
- Picks up [unbounded#357](https://github.com/getlantern/unbounded/pull/357): logging migration from `common.Debugf`/`common.Debug` to `log/slog`
- DANGER banners in unbounded's standalone egress/proxy commands are now `slog.Warn` (security severity, visible regardless of consumer's slog level)
- Standalone-binary `main()` entrypoints in unbounded now configure slog at `LevelDebug` to preserve the prior always-on stderr behavior

No API changes — purely a logging-layer migration. lantern-box's existing imports of `github.com/getlantern/broflake/...` are unaffected.

## Test plan

- [x] `go build ./...` clean
- [x] `go mod tidy` ran; only `go.mod` and `go.sum` changed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)