### PR TITLE
unbounded: passive dial watchdog for slow-peer detection

### DIFF
--- a/protocol/unbounded/outbound.go
+++ b/protocol/unbounded/outbound.go
@@ -82,6 +82,13 @@ type Outbound struct {
 	ui           UBClientcore.UI
 	ql           *UBClientcore.QUICLayer
 	uot          *uot.Client
+
+	// Constructed in NewOutbound; observes successful dial latencies and
+	// emits structured warnings when the current pairing's dials look
+	// pathological. Purely passive in this PR — the soft-reset action is
+	// gated on a follow-up that adds a re-pairing API in broflake. See
+	// watchdog.go for the trip heuristic.
+	watchdog *dialWatchdog
 }
 
 // tlsProvider carries the inputs needed to generate a TLS config lazily at
@@ -165,6 +172,7 @@ func NewOutbound(
 		Dialer:  (*uotDialer)(o),
 		Version: uot.Version,
 	}
+	o.watchdog = newDialWatchdog()
 	return o, nil
 }
 
@@ -249,9 +257,11 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 				"err", err)
 			return nil, err
 		}
+		elapsed := time.Since(started)
 		o.logger.DebugContext(ctx, "unbounded TCP dial ok",
 			"dest", dest,
-			"elapsed", time.Since(started))
+			"elapsed", elapsed)
+		o.recordWatchdog(ctx, elapsed)
 		return conn, nil
 	case N.NetworkUDP:
 		o.logger.DebugContext(ctx, "unbounded UoT dial start", "dest", dest)
@@ -263,9 +273,11 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 				"err", err)
 			return nil, err
 		}
+		elapsed := time.Since(started)
 		o.logger.DebugContext(ctx, "unbounded UoT dial ok",
 			"dest", dest,
-			"elapsed", time.Since(started))
+			"elapsed", elapsed)
+		o.recordWatchdog(ctx, elapsed)
 		return conn, nil
 	}
 	return nil, fmt.Errorf("unbounded: unsupported network %q", network)
@@ -290,10 +302,37 @@ func (o *Outbound) ListenPacket(ctx context.Context, destination M.Socksaddr) (n
 			"err", err)
 		return nil, err
 	}
+	elapsed := time.Since(started)
 	o.logger.DebugContext(ctx, "unbounded UoT ListenPacket ok",
 		"dest", dest,
-		"elapsed", time.Since(started))
+		"elapsed", elapsed)
+	o.recordWatchdog(ctx, elapsed)
 	return pc, nil
+}
+
+// recordWatchdog feeds a successful dial's elapsed time into the per-outbound
+// dialWatchdog and surfaces any verdict change at the appropriate log level.
+// Failed dials are deliberately NOT recorded: they conflate destination
+// availability with peer quality and would noise up the trip heuristic.
+func (o *Outbound) recordWatchdog(ctx context.Context, elapsed time.Duration) {
+	if o.watchdog == nil {
+		return
+	}
+	ev := o.watchdog.record(elapsed)
+	switch {
+	case ev.tripped:
+		o.logger.WarnContext(ctx, "unbounded peer flagged unhealthy",
+			"reason", ev.reason,
+			"median_slow", ev.medianSlow,
+			"trips_total", ev.tripsTotal,
+			"window_size", ev.sampleCount,
+		)
+	case ev.rearmed:
+		o.logger.InfoContext(ctx, "unbounded peer recovered (fast dial seen)",
+			"elapsed", elapsed,
+			"trips_total", ev.tripsTotal,
+		)
+	}
 }
 
 // signalingClient returns the HTTP client broflake uses to reach freddie.

--- a/protocol/unbounded/watchdog.go
+++ b/protocol/unbounded/watchdog.go
@@ -11,9 +11,8 @@ import (
 // observational: on a trip it returns information for the caller to log, but
 // takes no action against the broflake state machine. The reset-on-trip
 // behavior is deferred to a follow-up that adds a soft re-pairing API in
-// broflake (see PR #357 et al.); landing this passive observer first gives
-// us empirical data on how often the symptom actually fires before we touch
-// FSM ownership.
+// broflake; landing this passive observer first gives us empirical data on
+// how often the symptom actually fires before we touch FSM ownership.
 //
 // Design rationale (region-agnostic by construction):
 //
@@ -25,21 +24,32 @@ import (
 //     consumer's geography. Networks in restrictive regions tend to land
 //     consistently in the 1–4s band — slower than ideal but not >5s, so
 //     they don't trip.
-//   - everSeenFast is read from the rolling window, not a per-pairing flag,
-//     so re-arm happens automatically as soon as a fresh pairing produces
-//     a fast dial — no need to detect "new pairing" from the outbound layer.
-//   - The window size matches the consecutive-slow limit: with N=10 and
-//     limit=5, we trip when 5 of the last 10 dials are slow AND none are
-//     fast. That's the "any fast dial saves the pairing" property the
-//     design called for.
+//   - "Any fast dial in window" is read from the rolling buffer, not a
+//     per-pairing flag, so re-arm happens automatically as soon as a fresh
+//     pairing produces a fast dial — no need to detect "new pairing" from
+//     the outbound layer.
+//   - Window size and consecutive-slow limit (10 and 5 by default) make the
+//     "any fast dial saves the pairing" property concrete: even a single
+//     sub-1s sample anywhere in the last 10 dials prevents a trip.
 type dialWatchdog struct {
-	mu         sync.Mutex
-	samples    []time.Duration // ring buffer, capped at window
+	mu sync.Mutex
+
+	// Fixed-size circular buffer of recent dial elapsed times. We use a
+	// true ring (write index + filled flag) instead of a slice slid via
+	// append + reslice. The slice approach steadily eats the underlying
+	// array's capacity (each `samples = samples[1:]` advances the slice's
+	// start offset) and forces a reallocation roughly every `window`
+	// records. Since record() runs on every dial — potentially hundreds
+	// per minute on an active client — we want to avoid the churn.
+	ring     []time.Duration
+	writeIdx int
+	filled   bool
+
 	tripped    bool
 	tripsTotal int
 
 	// Configurable, but defaults are baked in. Exposed as fields so tests
-	// can shrink the window / thresholds without sleeping.
+	// can shrink the trip cap and thresholds without sleeping.
 	fastThreshold       time.Duration
 	slowThreshold       time.Duration
 	window              int
@@ -55,24 +65,55 @@ const (
 	watchdogMaxTripsPerLifetime = 1000 // safety cap on log-spam
 )
 
+// newDialWatchdog constructs a watchdog using the package-level defaults.
+// Tests construct via the struct literal directly to override individual
+// fields; that path goes through validate() too via a constructor wrapper
+// in the test file (newTestWatchdog).
 func newDialWatchdog() *dialWatchdog {
-	return &dialWatchdog{
+	w := &dialWatchdog{
 		fastThreshold:       watchdogFastThreshold,
 		slowThreshold:       watchdogSlowThreshold,
 		window:              watchdogWindow,
 		consecutiveSlowMin:  watchdogConsecutiveSlowMin,
 		maxTripsPerLifetime: watchdogMaxTripsPerLifetime,
 	}
+	w.init()
+	return w
 }
 
-// watchdogEvent is the verdict from a single record() call. Exactly one of
-// the boolean fields is true on any return: the caller can switch on it to
-// decide whether to log anything (and at what level).
+// init validates configuration and allocates the ring. Called once at
+// construction. Misconfiguration is clamped rather than panicked: the
+// watchdog is a debug aid, not load-bearing logic, and a zero-window or
+// inverted limit must not bring down a Lantern client.
+func (w *dialWatchdog) init() {
+	if w.window <= 0 {
+		w.window = 1
+	}
+	if w.consecutiveSlowMin <= 0 {
+		w.consecutiveSlowMin = 1
+	}
+	if w.consecutiveSlowMin > w.window {
+		w.consecutiveSlowMin = w.window
+	}
+	if w.maxTripsPerLifetime < 0 {
+		w.maxTripsPerLifetime = 0
+	}
+	w.ring = make([]time.Duration, w.window)
+	w.writeIdx = 0
+	w.filled = false
+}
+
+// watchdogEvent is the verdict from a single record() call. The two booleans
+// are state-transition signals — at most one is true on any given return,
+// and most calls return both false (no transition; suppressed write while
+// tripped, ramp-up before window is full, no-op while medium-band, etc.).
+// The caller is expected to switch on `tripped` / `rearmed` to decide
+// whether to log anything; the remaining fields are diagnostic context.
 type watchdogEvent struct {
 	tripped     bool          // a new trip just fired
 	rearmed     bool          // a fast dial cleared a previously-tripped state
 	reason      string        // human-readable trip cause, set on tripped
-	medianSlow  time.Duration // median elapsed of the slow window, set on tripped
+	medianSlow  time.Duration // median elapsed of the slow tail, set on tripped
 	tripsTotal  int           // cumulative trips this watchdog has fired
 	sampleCount int           // current ring-buffer fill
 }
@@ -86,10 +127,15 @@ func (w *dialWatchdog) record(elapsed time.Duration) watchdogEvent {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	w.samples = append(w.samples, elapsed)
-	if len(w.samples) > w.window {
-		w.samples = w.samples[1:]
+	// Write into the ring and advance.
+	w.ring[w.writeIdx] = elapsed
+	w.writeIdx++
+	if w.writeIdx >= len(w.ring) {
+		w.writeIdx = 0
+		w.filled = true
 	}
+
+	count := w.sampleCountLocked()
 
 	// Re-arm: a fast dial while tripped clears the trip flag. We log the
 	// transition once so a reader of lantern.log can see when a pairing
@@ -100,24 +146,24 @@ func (w *dialWatchdog) record(elapsed time.Duration) watchdogEvent {
 		return watchdogEvent{
 			rearmed:     true,
 			tripsTotal:  w.tripsTotal,
-			sampleCount: len(w.samples),
+			sampleCount: count,
 		}
 	}
 
 	// While currently tripped, suppress further trip events: we already
 	// emitted the warning, no signal in repeating it on every slow dial.
 	if w.tripped {
-		return watchdogEvent{tripsTotal: w.tripsTotal, sampleCount: len(w.samples)}
+		return watchdogEvent{tripsTotal: w.tripsTotal, sampleCount: count}
 	}
 
 	// Need a full window before evaluating; otherwise a startup burst of
 	// 5 slow dials would always trip on first pair.
-	if len(w.samples) < w.window {
-		return watchdogEvent{tripsTotal: w.tripsTotal, sampleCount: len(w.samples)}
+	if !w.filled {
+		return watchdogEvent{tripsTotal: w.tripsTotal, sampleCount: count}
 	}
 
 	if w.tripsTotal >= w.maxTripsPerLifetime {
-		return watchdogEvent{tripsTotal: w.tripsTotal, sampleCount: len(w.samples)}
+		return watchdogEvent{tripsTotal: w.tripsTotal, sampleCount: count}
 	}
 
 	// Trip if the most recent consecutiveSlowMin dials are all slow AND
@@ -129,15 +175,15 @@ func (w *dialWatchdog) record(elapsed time.Duration) watchdogEvent {
 	//   - The "consecutive slow" guard ensures we don't trip on an
 	//     intermittently slow pairing that's interleaving fast dials with
 	//     occasional slow ones at a tolerable rate.
-	for _, s := range w.samples {
+	for _, s := range w.ring {
 		if s < w.fastThreshold {
-			return watchdogEvent{tripsTotal: w.tripsTotal, sampleCount: len(w.samples)}
+			return watchdogEvent{tripsTotal: w.tripsTotal, sampleCount: count}
 		}
 	}
-	tail := w.samples[len(w.samples)-w.consecutiveSlowMin:]
+	tail := w.recentLocked(w.consecutiveSlowMin)
 	for _, s := range tail {
 		if s <= w.slowThreshold {
-			return watchdogEvent{tripsTotal: w.tripsTotal, sampleCount: len(w.samples)}
+			return watchdogEvent{tripsTotal: w.tripsTotal, sampleCount: count}
 		}
 	}
 
@@ -148,18 +194,43 @@ func (w *dialWatchdog) record(elapsed time.Duration) watchdogEvent {
 		reason:      "no fast dial in window and >=5 consecutive slow",
 		medianSlow:  medianDuration(tail),
 		tripsTotal:  w.tripsTotal,
-		sampleCount: len(w.samples),
+		sampleCount: count,
 	}
 }
 
-// snapshot returns a copy of the current ring buffer for diagnostic logging.
-// Caller is free to log/format without holding the watchdog mutex.
+// sampleCountLocked returns the number of valid entries in the ring.
+// Caller must hold w.mu.
+func (w *dialWatchdog) sampleCountLocked() int {
+	if w.filled {
+		return len(w.ring)
+	}
+	return w.writeIdx
+}
+
+// recentLocked returns the n most-recent samples in arrival order (oldest
+// of the n first, newest last). Caller must hold w.mu and ensure
+// n <= sampleCountLocked().
+func (w *dialWatchdog) recentLocked(n int) []time.Duration {
+	out := make([]time.Duration, n)
+	// Walk backwards from the most recently written slot.
+	for i := 0; i < n; i++ {
+		idx := (w.writeIdx - 1 - i + len(w.ring)) % len(w.ring)
+		out[n-1-i] = w.ring[idx]
+	}
+	return out
+}
+
+// snapshot returns a copy of the current ring contents in arrival order
+// (oldest first), for diagnostic logging. Caller is free to log/format
+// without holding the watchdog mutex.
 func (w *dialWatchdog) snapshot() []time.Duration {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	out := make([]time.Duration, len(w.samples))
-	copy(out, w.samples)
-	return out
+	count := w.sampleCountLocked()
+	if count == 0 {
+		return nil
+	}
+	return w.recentLocked(count)
 }
 
 func medianDuration(xs []time.Duration) time.Duration {

--- a/protocol/unbounded/watchdog.go
+++ b/protocol/unbounded/watchdog.go
@@ -1,0 +1,173 @@
+package unbounded
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// dialWatchdog tracks the elapsed time of recent successful dials through the
+// unbounded outbound and flags pairings that look unhealthy. It is purely
+// observational: on a trip it returns information for the caller to log, but
+// takes no action against the broflake state machine. The reset-on-trip
+// behavior is deferred to a follow-up that adds a soft re-pairing API in
+// broflake (see PR #357 et al.); landing this passive observer first gives
+// us empirical data on how often the symptom actually fires before we touch
+// FSM ownership.
+//
+// Design rationale (region-agnostic by construction):
+//
+//   - The thresholds (watchdogFastThreshold, watchdogSlowThreshold) are not
+//     "what is good in the US"; they are "what's clearly fast anywhere a
+//     working WebRTC datachannel would be" and "what's clearly degenerate
+//     anywhere". A pairing that hits 5+ consecutive dials in the slow band
+//     with no fast dials anywhere in the window is broken regardless of the
+//     consumer's geography. Networks in restrictive regions tend to land
+//     consistently in the 1–4s band — slower than ideal but not >5s, so
+//     they don't trip.
+//   - everSeenFast is read from the rolling window, not a per-pairing flag,
+//     so re-arm happens automatically as soon as a fresh pairing produces
+//     a fast dial — no need to detect "new pairing" from the outbound layer.
+//   - The window size matches the consecutive-slow limit: with N=10 and
+//     limit=5, we trip when 5 of the last 10 dials are slow AND none are
+//     fast. That's the "any fast dial saves the pairing" property the
+//     design called for.
+type dialWatchdog struct {
+	mu         sync.Mutex
+	samples    []time.Duration // ring buffer, capped at window
+	tripped    bool
+	tripsTotal int
+
+	// Configurable, but defaults are baked in. Exposed as fields so tests
+	// can shrink the window / thresholds without sleeping.
+	fastThreshold       time.Duration
+	slowThreshold       time.Duration
+	window              int
+	consecutiveSlowMin  int
+	maxTripsPerLifetime int
+}
+
+const (
+	watchdogFastThreshold       = 1 * time.Second
+	watchdogSlowThreshold       = 5 * time.Second
+	watchdogWindow              = 10
+	watchdogConsecutiveSlowMin  = 5
+	watchdogMaxTripsPerLifetime = 1000 // safety cap on log-spam
+)
+
+func newDialWatchdog() *dialWatchdog {
+	return &dialWatchdog{
+		fastThreshold:       watchdogFastThreshold,
+		slowThreshold:       watchdogSlowThreshold,
+		window:              watchdogWindow,
+		consecutiveSlowMin:  watchdogConsecutiveSlowMin,
+		maxTripsPerLifetime: watchdogMaxTripsPerLifetime,
+	}
+}
+
+// watchdogEvent is the verdict from a single record() call. Exactly one of
+// the boolean fields is true on any return: the caller can switch on it to
+// decide whether to log anything (and at what level).
+type watchdogEvent struct {
+	tripped     bool          // a new trip just fired
+	rearmed     bool          // a fast dial cleared a previously-tripped state
+	reason      string        // human-readable trip cause, set on tripped
+	medianSlow  time.Duration // median elapsed of the slow window, set on tripped
+	tripsTotal  int           // cumulative trips this watchdog has fired
+	sampleCount int           // current ring-buffer fill
+}
+
+// record ingests a successful dial's elapsed time and returns whether the
+// pairing's health verdict changed. Failed dials should NOT be passed in:
+// they conflate peer quality with destination availability.
+//
+// Concurrency-safe; record is called from every concurrent dial.
+func (w *dialWatchdog) record(elapsed time.Duration) watchdogEvent {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.samples = append(w.samples, elapsed)
+	if len(w.samples) > w.window {
+		w.samples = w.samples[1:]
+	}
+
+	// Re-arm: a fast dial while tripped clears the trip flag. We log the
+	// transition once so a reader of lantern.log can see when a pairing
+	// recovered (whether by broflake re-pairing under the hood, or by the
+	// peer's network conditions improving).
+	if w.tripped && elapsed < w.fastThreshold {
+		w.tripped = false
+		return watchdogEvent{
+			rearmed:     true,
+			tripsTotal:  w.tripsTotal,
+			sampleCount: len(w.samples),
+		}
+	}
+
+	// While currently tripped, suppress further trip events: we already
+	// emitted the warning, no signal in repeating it on every slow dial.
+	if w.tripped {
+		return watchdogEvent{tripsTotal: w.tripsTotal, sampleCount: len(w.samples)}
+	}
+
+	// Need a full window before evaluating; otherwise a startup burst of
+	// 5 slow dials would always trip on first pair.
+	if len(w.samples) < w.window {
+		return watchdogEvent{tripsTotal: w.tripsTotal, sampleCount: len(w.samples)}
+	}
+
+	if w.tripsTotal >= w.maxTripsPerLifetime {
+		return watchdogEvent{tripsTotal: w.tripsTotal, sampleCount: len(w.samples)}
+	}
+
+	// Trip if the most recent consecutiveSlowMin dials are all slow AND
+	// no dial in the whole window is fast. Both conditions are necessary:
+	//
+	//   - The "no fast in window" guard saves pairings that have proved
+	//     they CAN do fast dials but happen to have a slow burst at the
+	//     moment we evaluate.
+	//   - The "consecutive slow" guard ensures we don't trip on an
+	//     intermittently slow pairing that's interleaving fast dials with
+	//     occasional slow ones at a tolerable rate.
+	for _, s := range w.samples {
+		if s < w.fastThreshold {
+			return watchdogEvent{tripsTotal: w.tripsTotal, sampleCount: len(w.samples)}
+		}
+	}
+	tail := w.samples[len(w.samples)-w.consecutiveSlowMin:]
+	for _, s := range tail {
+		if s <= w.slowThreshold {
+			return watchdogEvent{tripsTotal: w.tripsTotal, sampleCount: len(w.samples)}
+		}
+	}
+
+	w.tripped = true
+	w.tripsTotal++
+	return watchdogEvent{
+		tripped:     true,
+		reason:      "no fast dial in window and >=5 consecutive slow",
+		medianSlow:  medianDuration(tail),
+		tripsTotal:  w.tripsTotal,
+		sampleCount: len(w.samples),
+	}
+}
+
+// snapshot returns a copy of the current ring buffer for diagnostic logging.
+// Caller is free to log/format without holding the watchdog mutex.
+func (w *dialWatchdog) snapshot() []time.Duration {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]time.Duration, len(w.samples))
+	copy(out, w.samples)
+	return out
+}
+
+func medianDuration(xs []time.Duration) time.Duration {
+	if len(xs) == 0 {
+		return 0
+	}
+	sorted := make([]time.Duration, len(xs))
+	copy(sorted, xs)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	return sorted[len(sorted)/2]
+}

--- a/protocol/unbounded/watchdog_test.go
+++ b/protocol/unbounded/watchdog_test.go
@@ -1,0 +1,155 @@
+package unbounded
+
+import (
+	"testing"
+	"time"
+)
+
+// newTestWatchdog builds a watchdog with shorter windows + lower trip caps
+// so tests can exercise the trip / re-arm branches without massaging real
+// time. Production callers go through newDialWatchdog().
+func newTestWatchdog() *dialWatchdog {
+	return &dialWatchdog{
+		fastThreshold:       1 * time.Second,
+		slowThreshold:       5 * time.Second,
+		window:              10,
+		consecutiveSlowMin:  5,
+		maxTripsPerLifetime: 1000,
+	}
+}
+
+// feed N samples of the same elapsed value and return the events emitted.
+func feed(t *testing.T, w *dialWatchdog, elapsed time.Duration, n int) []watchdogEvent {
+	t.Helper()
+	out := make([]watchdogEvent, n)
+	for i := 0; i < n; i++ {
+		out[i] = w.record(elapsed)
+	}
+	return out
+}
+
+// The classic "stuck on bad peer" symptom: 10 consecutive slow dials, no fast
+// dial anywhere in the window. The 10th sample should trip exactly once.
+func TestWatchdog_TripsAfterFullWindowOfSlowDialsWithNoFast(t *testing.T) {
+	w := newTestWatchdog()
+
+	events := feed(t, w, 12*time.Second, 10)
+
+	// First 9 samples build up the window without tripping (we don't
+	// evaluate until the window is full).
+	for i := 0; i < 9; i++ {
+		if events[i].tripped {
+			t.Fatalf("trip at sample %d (window not full yet); got %+v", i, events[i])
+		}
+	}
+	if !events[9].tripped {
+		t.Fatalf("expected trip on 10th sample; got %+v", events[9])
+	}
+	if events[9].tripsTotal != 1 {
+		t.Errorf("tripsTotal: want 1, got %d", events[9].tripsTotal)
+	}
+	if events[9].medianSlow == 0 {
+		t.Errorf("expected non-zero medianSlow on trip")
+	}
+
+	// Subsequent slow dials must NOT re-trip — the "while tripped, suppress"
+	// branch keeps log spam down.
+	more := feed(t, w, 12*time.Second, 5)
+	for i, e := range more {
+		if e.tripped {
+			t.Errorf("re-trip on suppressed slow dial #%d: %+v", i, e)
+		}
+	}
+}
+
+// Even one fast dial anywhere in the window saves the pairing — the
+// region-agnostic property of the design. Networks that produce a 4s + a
+// 500ms + a 12s mix should NOT trip; the fast dial is evidence the peer can
+// do better.
+func TestWatchdog_DoesNotTripIfAnyFastDialInWindow(t *testing.T) {
+	w := newTestWatchdog()
+
+	// 9 slow + 1 fast (interleaved as last) → fast guard stops the trip.
+	for i := 0; i < 9; i++ {
+		_ = w.record(12 * time.Second)
+	}
+	ev := w.record(500 * time.Millisecond)
+	if ev.tripped {
+		t.Fatalf("tripped despite a fast dial in window: %+v", ev)
+	}
+}
+
+// In a region with structurally slow paths (everything 2-4s), no dial is
+// "fast" but no consecutive run is "slow" either → no trip. This is the
+// case where region-baseline thresholds would have been wrong.
+func TestWatchdog_DoesNotTripOnConsistentlyMediumDials(t *testing.T) {
+	w := newTestWatchdog()
+	for i := 0; i < 50; i++ {
+		ev := w.record(3 * time.Second)
+		if ev.tripped {
+			t.Fatalf("tripped on medium-band dial #%d: %+v", i, ev)
+		}
+	}
+}
+
+// Trip → re-arm → trip again. The re-arm path needs to actually clear the
+// tripped flag, otherwise the second trip never fires.
+func TestWatchdog_RearmsOnFastDialAfterTrip(t *testing.T) {
+	w := newTestWatchdog()
+
+	// Trip first.
+	feed(t, w, 12*time.Second, 10)
+	if !w.tripped {
+		t.Fatal("setup: expected watchdog to be tripped")
+	}
+
+	// Fast dial → re-arm.
+	ev := w.record(300 * time.Millisecond)
+	if !ev.rearmed {
+		t.Fatalf("expected rearmed event; got %+v", ev)
+	}
+	if w.tripped {
+		t.Fatalf("watchdog still tripped after rearm: %+v", w)
+	}
+
+	// And the watchdog must be able to trip a second time after rearming.
+	// The rearming window is now 1 fast + 9 slow's worth of buffer; we need
+	// to push 10 more slow dials to evict the fast one.
+	feed(t, w, 12*time.Second, 9)  // window now: 1 fast + 9 slow → fast guard still active
+	if w.tripped {
+		t.Fatalf("tripped while fast dial still in window: %+v", w)
+	}
+	ev2 := w.record(12 * time.Second) // evicts the fast → window is all slow
+	if !ev2.tripped {
+		t.Fatalf("expected second trip after fast evicted; window=%v", w.snapshot())
+	}
+	if ev2.tripsTotal != 2 {
+		t.Errorf("tripsTotal: want 2, got %d", ev2.tripsTotal)
+	}
+}
+
+// Safety cap: don't keep emitting trip events forever even if the peer is
+// degenerately bad and we can't auto-reset (that's phase-2 work). This caps
+// log spam so a stuck client doesn't write GB of warnings overnight.
+func TestWatchdog_MaxTripsCapsTrips(t *testing.T) {
+	w := newTestWatchdog()
+	w.maxTripsPerLifetime = 2
+
+	// First trip.
+	feed(t, w, 12*time.Second, 10)
+	// Re-arm + trip.
+	w.record(300 * time.Millisecond)
+	feed(t, w, 12*time.Second, 10)
+	// Re-arm + would-be-trip-3 (should be suppressed by cap).
+	w.record(300 * time.Millisecond)
+	events := feed(t, w, 12*time.Second, 10)
+
+	for i, ev := range events {
+		if ev.tripped {
+			t.Fatalf("third trip fired despite maxTripsPerLifetime=2 at index %d: %+v", i, ev)
+		}
+	}
+	if w.tripsTotal != 2 {
+		t.Errorf("tripsTotal: want 2 (cap), got %d", w.tripsTotal)
+	}
+}

--- a/protocol/unbounded/watchdog_test.go
+++ b/protocol/unbounded/watchdog_test.go
@@ -5,17 +5,23 @@ import (
 	"time"
 )
 
-// newTestWatchdog builds a watchdog with shorter windows + lower trip caps
-// so tests can exercise the trip / re-arm branches without massaging real
-// time. Production callers go through newDialWatchdog().
+// newTestWatchdog builds a watchdog with the production thresholds and
+// window so the tests exercise the same code paths real Lantern clients
+// will. (An earlier draft set "shorter windows" here, but every test
+// reasoned in terms of the production window/limit pair, so shrinking
+// only made the tests harder to read without exercising new branches.)
+// Tests that need to bypass the trip cap can set maxTripsPerLifetime
+// after construction.
 func newTestWatchdog() *dialWatchdog {
-	return &dialWatchdog{
+	w := &dialWatchdog{
 		fastThreshold:       1 * time.Second,
 		slowThreshold:       5 * time.Second,
 		window:              10,
 		consecutiveSlowMin:  5,
 		maxTripsPerLifetime: 1000,
 	}
+	w.init()
+	return w
 }
 
 // feed N samples of the same elapsed value and return the events emitted.
@@ -133,7 +139,7 @@ func TestWatchdog_RearmsOnFastDialAfterTrip(t *testing.T) {
 // log spam so a stuck client doesn't write GB of warnings overnight.
 func TestWatchdog_MaxTripsCapsTrips(t *testing.T) {
 	w := newTestWatchdog()
-	w.maxTripsPerLifetime = 2
+	w.maxTripsPerLifetime = 2 // safe to mutate post-init: ring already allocated
 
 	// First trip.
 	feed(t, w, 12*time.Second, 10)
@@ -151,5 +157,67 @@ func TestWatchdog_MaxTripsCapsTrips(t *testing.T) {
 	}
 	if w.tripsTotal != 2 {
 		t.Errorf("tripsTotal: want 2 (cap), got %d", w.tripsTotal)
+	}
+}
+
+// init() clamps invalid configurations rather than panicking — the watchdog
+// is a debug aid, and a misconfigured one must not bring down the Lantern
+// client. Cover a few representative degenerate inputs and assert the
+// invariants we rely on (window > 0, consecutiveSlowMin in [1, window]).
+func TestWatchdog_InitClampsBadConfig(t *testing.T) {
+	cases := []struct {
+		name                 string
+		setup                func(*dialWatchdog)
+		wantWindow           int
+		wantConsecutiveMin   int
+		wantMaxTripsAtLeast0 bool
+	}{
+		{
+			name:               "zero window",
+			setup:              func(w *dialWatchdog) { w.window = 0; w.consecutiveSlowMin = 5 },
+			wantWindow:         1,
+			wantConsecutiveMin: 1, // clamped down to fit window
+		},
+		{
+			name:               "negative window",
+			setup:              func(w *dialWatchdog) { w.window = -3; w.consecutiveSlowMin = 5 },
+			wantWindow:         1,
+			wantConsecutiveMin: 1,
+		},
+		{
+			name:               "consecutiveSlowMin > window",
+			setup:              func(w *dialWatchdog) { w.window = 4; w.consecutiveSlowMin = 99 },
+			wantWindow:         4,
+			wantConsecutiveMin: 4, // clamped to window so the recent-tail slice doesn't go OOB
+		},
+		{
+			name:                 "negative maxTrips",
+			setup:                func(w *dialWatchdog) { w.window = 10; w.consecutiveSlowMin = 5; w.maxTripsPerLifetime = -1 },
+			wantWindow:           10,
+			wantConsecutiveMin:   5,
+			wantMaxTripsAtLeast0: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := &dialWatchdog{fastThreshold: 1 * time.Second, slowThreshold: 5 * time.Second}
+			tc.setup(w)
+			w.init()
+			if w.window != tc.wantWindow {
+				t.Errorf("window: want %d, got %d", tc.wantWindow, w.window)
+			}
+			if w.consecutiveSlowMin != tc.wantConsecutiveMin {
+				t.Errorf("consecutiveSlowMin: want %d, got %d", tc.wantConsecutiveMin, w.consecutiveSlowMin)
+			}
+			if tc.wantMaxTripsAtLeast0 && w.maxTripsPerLifetime < 0 {
+				t.Errorf("maxTripsPerLifetime: want >=0, got %d", w.maxTripsPerLifetime)
+			}
+			// Most important: a record() against a clamped watchdog must
+			// not panic. Feed a few samples; we don't care about the
+			// trip verdict here, only that the ring indexing is safe.
+			for i := 0; i < 20; i++ {
+				_ = w.record(2 * time.Second)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Adds a per-Outbound `dialWatchdog` that observes successful dial elapsed times, classifies the current pairing's health using region-agnostic heuristics, and emits structured warnings when a pairing looks pathologically slow.

This is **purely observational** — no action is taken on a trip beyond a structured `slog.WarnContext` write. The soft-reset action is deferred to a follow-up because the existing `QUICLayer.Close()` permanently tears down the transport (kills the outbound until process restart), and there's no public broflake API today to force a soft re-pairing without rebuilding the whole BroflakeConn / QUICLayer chain. Landing the observer first gives us empirical data on how often the symptom fires before we touch FSM ownership in broflake.

## Trip rule

A pairing is flagged unhealthy when **all** of:

- Rolling window of 10 successful dials is full
- Zero dials in the window are under 1s ("no evidence the peer is capable of fast dials")
- The most recent 5 dials are each over 5s ("clearly degenerate run, not just bursty noise")

These thresholds are region-agnostic by construction:
- A region where every dial is 2-4s never satisfies the slow guard → never trips.
- A region with mostly-fast dials gets one fast sample in the window → fast guard saves the pairing.
- The trip case is reserved for the symptom seen on the laptop earlier today: 200+ consecutive dials all > 5s with nothing under 1s.

## Re-arm

A fast dial after a trip clears the tripped flag and emits an info log. The window then evicts the fast sample naturally as new dials arrive, so the watchdog can trip again if conditions degrade.

## Lifetime cap

`maxTripsPerLifetime = 1000` caps log spam at 1000 trips per outbound. Once phase 2 lands the auto-reset, the cap will likely tighten. For now it just prevents a degenerately stuck client from filling the log overnight.

## Test plan

- [x] `go test ./protocol/unbounded/...` — 5 new tests covering full-window slow trip, fast-dial-in-window guard, medium-band non-trip, re-arm + second trip, lifetime cap. All pass.
- [x] `go vet ./protocol/unbounded/...` clean.
- [ ] After this lands and ships in a build, grep `lantern.log` for `unbounded peer flagged unhealthy` to confirm the symptom is being detected on the watch laptop. If the rate looks reasonable (not constant, not zero), proceed to phase 2.

## Phase 2 (separate)

Add a re-pairing API in broflake's `clientcore` (e.g. `BroflakeEngine.ResetCurrentPairing()`) that signals the consumer FSM to close the WebRTC datachannel from outside, letting connection migration preserve user-visible TCP connections during the re-pair. Once that exists, the watchdog's trip handler becomes one line: `go o.broflakeEngine.ResetCurrentPairing()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)