### PR TITLE
bump broflake for clientcore err_class instrumentation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ replace github.com/refraction-networking/water => github.com/getlantern/water v0
 require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52
-	github.com/getlantern/broflake v0.0.0-20260501210609-ce5f75aa2054
+	github.com/getlantern/broflake v0.0.0-20260504215251-ed3cf75062d1
 	github.com/getlantern/geo v0.0.0-20241129152027-2fc88c10f91e
 	github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90
 	github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/gaukas/wazerofs v0.1.0 h1:wIkW1bAxSnpaaVkQ5LOb1tm1BXdVap3eKjJpVWIqt2E
 github.com/gaukas/wazerofs v0.1.0/go.mod h1:+JECB9Fwt0taPqSgHckG9lmT3tcoVK+9VJozTsq9UlI=
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 h1:w2/RqYPw7PbTYfUMS2aToD5DMKLBnQed+fkTEYTKAqQ=
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52/go.mod h1:PrNR8tMXO26YNs8K9653XCUH7u2Kv4OdfFC3Ke1GsX0=
-github.com/getlantern/broflake v0.0.0-20260501210609-ce5f75aa2054 h1:nrRMiRRjzR43yihrVxdnmmt66ZqjRhHE73TyHW1ySgg=
-github.com/getlantern/broflake v0.0.0-20260501210609-ce5f75aa2054/go.mod h1:bZGGfTwne9NIsy3Kc1avcXNWn/yA8ghUwlXdS2z+AlA=
+github.com/getlantern/broflake v0.0.0-20260504215251-ed3cf75062d1 h1:3WYvObOo8gpKwjcLrV6O/vRp+ubKdjpvJwZrRkbbDWw=
+github.com/getlantern/broflake v0.0.0-20260504215251-ed3cf75062d1/go.mod h1:bZGGfTwne9NIsy3Kc1avcXNWn/yA8ghUwlXdS2z+AlA=
 github.com/getlantern/context v0.0.0-20190109183933-c447772a6520/go.mod h1:L+mq6/vvYHKjCX2oez0CgEAJmbq1fbb/oNJIWQkBybY=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=


### PR DESCRIPTION
## Summary

Bumps `github.com/getlantern/broflake` to the post-#360 pseudo-version (no tag — broflake's `go.mod` already uses pseudo-versions, so a hash-based bump is what we want).

## What this picks up

- [getlantern/unbounded#360](https://github.com/getlantern/unbounded/pull/360) — `clientcore`: classify QUIC connection errors for triage. Adds `err_class` and `lifetime_s` structured-log fields to every "QUIC connection ended" record. Maps quic-go errors into `idle_timeout`, `handshake_timeout`, `application_close_remote`, `application_close_local`, `transport_error`, `stateless_reset`, `context_canceled`, etc.
- [getlantern/unbounded#359](https://github.com/getlantern/unbounded/pull/359) — `egress`: integration test for connection migration. Test-only; no runtime change.

## Why

Two PRs ago the laptop's `lantern.log` had the same opaque `"QUIC connection error (<err>), closing!"` line for every failure mode. After this bump ships on a Lantern client, the per-connection record will look like:

```
level=DEBUG pkg=broflake msg="QUIC connection ended"
  err=...
  err_class=idle_timeout|application_close_remote|context_canceled|...
  lifetime_s=42.3
```

Grep + `sort | uniq -c` on `err_class` gives a histogram. After ~24-48h of usage, that histogram tells us whether `idle_timeout` dominates (→ confirms the consumer-side QUIC-state GC theory for the prod migration failures Nelson reported, fix is bumping `MaxIdleTimeout` in `common/QUICCfg`) or whether something else is the dominant failure mode (different fix).

## Test plan

- [x] `go mod tidy` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean (the existing pre-existing `unsafe.Pointer` warning in `protocol/amnezia/endpoint.go:50` is unchanged)
- [ ] After this lands and is bumped through radiance + lantern, grep the laptop's `lantern.log` for `QUIC connection ended` and break down by `err_class` over a couple days

🤖 Generated with [Claude Code](https://claude.com/claude-code)