### PR TITLE
group: reselect immediately after dial/listen failure

### DIFF
--- a/protocol/group/mutableurltest.go
+++ b/protocol/group/mutableurltest.go
@@ -587,7 +587,7 @@ func (g *urlTestGroup) urlTest(ctx context.Context, force bool) (map[string]uint
 // markFailedAndReselect drops the URL-test history for outbound and recomputes
 // the selection.
 func (g *urlTestGroup) markFailedAndReselect(outbound A.Outbound) {
-	g.history.DeleteURLTestHistory(outbound.Tag())
+	g.history.DeleteURLTestHistory(realTag(outbound))
 	g.updateSelected()
 }
 

--- a/protocol/group/mutableurltest.go
+++ b/protocol/group/mutableurltest.go
@@ -171,7 +171,7 @@ func (s *MutableURLTest) DialContext(ctx context.Context, network string, destin
 	conn, err := outbound.DialContext(ctx, network, destination)
 	if err != nil {
 		s.logger.ErrorContext(ctx, err)
-		s.group.history.DeleteURLTestHistory(outbound.Tag())
+		s.group.markFailedAndReselect(outbound)
 		span.RecordError(err)
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (s *MutableURLTest) ListenPacket(ctx context.Context, destination M.Socksad
 	conn, err := outbound.ListenPacket(ctx, destination)
 	if err != nil {
 		s.logger.ErrorContext(ctx, err)
-		s.group.history.DeleteURLTestHistory(outbound.Tag())
+		s.group.markFailedAndReselect(outbound)
 		span.RecordError(err)
 		return nil, err
 	}
@@ -584,6 +584,13 @@ func (g *urlTestGroup) urlTest(ctx context.Context, force bool) (map[string]uint
 	return result, nil
 }
 
+// markFailedAndReselect drops the URL-test history for outbound and recomputes
+// the selection.
+func (g *urlTestGroup) markFailedAndReselect(outbound A.Outbound) {
+	g.history.DeleteURLTestHistory(outbound.Tag())
+	g.updateSelected()
+}
+
 func (g *urlTestGroup) updateSelected() {
 	if len(g.tags) == 0 {
 		g.selectedOutboundTCP.Store(nil)
@@ -632,7 +639,13 @@ func (g *urlTestGroup) pickBestOutbound(network string, current A.Outbound) A.Ou
 	if minOutbound != nil {
 		return minOutbound
 	}
+	// Reaching this loop means no candidate has URL-test history. Skip current:
+	// any other choice is no worse, and avoids re-picking an outbound just
+	// deleted by markFailedAndReselect.
 	for _, outbound := range g.outbounds.Iter() {
+		if outbound == current {
+			continue
+		}
 		if slices.Contains(outbound.Network(), network) && realTag(outbound) != "" {
 			return outbound
 		}

--- a/protocol/group/urltest_test.go
+++ b/protocol/group/urltest_test.go
@@ -1,0 +1,129 @@
+package group
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/common/urltest"
+	"github.com/sagernet/sing/common"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/getlantern/lantern-box/internal/sync"
+)
+
+func TestUpdateSelected(t *testing.T) {
+	outbounds := map[string]uint16{
+		"kangaskhan": 36,
+		"koffing":    52,
+		"lickitung":  55,
+		"growlithe":  56,
+		"machamp":    138,
+		"golduck":    142,
+		"hitmonlee":  204,
+	}
+	testGroup := &urlTestGroup{
+		tags:                []string{},
+		outbounds:           sync.TypedMap[string, adapter.Outbound]{},
+		tolerance:           50,
+		history:             urltest.NewHistoryStorage(),
+		selectedOutboundTCP: common.TypedValue[adapter.Outbound]{},
+		selectedOutboundUDP: common.TypedValue[adapter.Outbound]{},
+	}
+	for tag, delay := range outbounds {
+		testGroup.tags = append(testGroup.tags, tag)
+		testGroup.outbounds.Store(tag, &mockOutbound{tag: tag})
+		testGroup.history.StoreURLTestHistory(tag, &adapter.URLTestHistory{
+			Time:  time.Now(),
+			Delay: delay,
+		})
+	}
+
+	pfmt := func(o adapter.Outbound) string {
+		if o == nil {
+			return "<nil>"
+		}
+		h := testGroup.history.LoadURLTestHistory(o.Tag())
+		if h != nil {
+			return fmt.Sprintf("%s(%d)", o.Tag(), h.Delay)
+		}
+		return o.Tag()
+	}
+
+	o, _ := testGroup.outbounds.Load("golduck")
+	testGroup.selectedOutboundTCP.Store(o)
+	testGroup.selectedOutboundUDP.Store(o)
+
+	fmt.Printf("Before updateSelected: tcp=%v, udp=%v\n",
+		pfmt(testGroup.selectedOutboundTCP.Load()),
+		pfmt(testGroup.selectedOutboundUDP.Load()),
+	)
+	testGroup.updateSelected()
+	fmt.Printf("After updateSelected: tcp=%v, udp=%v\n",
+		pfmt(testGroup.selectedOutboundTCP.Load()),
+		pfmt(testGroup.selectedOutboundUDP.Load()),
+	)
+
+	want := []string{"kangaskhan", "koffing", "lickitung", "growlithe"}
+	assert.Contains(t, want, testGroup.selectedOutboundTCP.Load().Tag())
+	assert.Contains(t, want, testGroup.selectedOutboundUDP.Load().Tag())
+}
+
+func (m *mockOutbound) Tag() string {
+	return m.tag
+}
+
+func (m *mockOutbound) Network() []string {
+	return []string{"tcp", "udp"}
+}
+
+func TestMarkFailedAndReselect_SwitchesToHealthyOutbound(t *testing.T) {
+	g := &urlTestGroup{
+		tags:      []string{},
+		outbounds: sync.TypedMap[string, adapter.Outbound]{},
+		tolerance: 50,
+		history:   urltest.NewHistoryStorage(),
+	}
+	// Wide delay gaps so pickBestOutbound is deterministic regardless of map
+	// iteration order: beta beats gamma by more than tolerance either way.
+	delays := map[string]uint16{"alpha": 50, "beta": 1000, "gamma": 2000}
+	outboundByTag := make(map[string]adapter.Outbound, len(delays))
+	for tag, delay := range delays {
+		ob := &mockOutbound{tag: tag}
+		g.tags = append(g.tags, tag)
+		g.outbounds.Store(tag, ob)
+		g.history.StoreURLTestHistory(tag, &adapter.URLTestHistory{
+			Time:  time.Now(),
+			Delay: delay,
+		})
+		outboundByTag[tag] = ob
+	}
+	g.selectedOutboundTCP.Store(outboundByTag["alpha"])
+	g.selectedOutboundUDP.Store(outboundByTag["alpha"])
+
+	g.markFailedAndReselect(outboundByTag["alpha"])
+
+	require := assert.New(t)
+	require.Nil(g.history.LoadURLTestHistory("alpha"))
+	require.Equal("beta", g.selectedOutboundTCP.Load().Tag(),
+		"expected reselection to next-best outbound after failure")
+	require.Equal("beta", g.selectedOutboundUDP.Load().Tag())
+}
+
+func TestPickBestOutbound_FallbackSkipsCurrent(t *testing.T) {
+	g := &urlTestGroup{
+		tags:      []string{"alpha", "beta"},
+		outbounds: sync.TypedMap[string, adapter.Outbound]{},
+		tolerance: 50,
+		history:   urltest.NewHistoryStorage(),
+	}
+	alpha := &mockOutbound{tag: "alpha"}
+	beta := &mockOutbound{tag: "beta"}
+	g.outbounds.Store("alpha", alpha)
+	g.outbounds.Store("beta", beta)
+
+	picked := g.pickBestOutbound("tcp", alpha)
+	assert.Equal(t, "beta", picked.Tag(),
+		"fallback path should skip current and return the other outbound")
+}


### PR DESCRIPTION
## Summary

When the selected child of a mutableurltest group fails on DialContext/ListenPacket, recompute the group's selection immediately so subsequent dials don't keep landing on the dead outbound until the next periodic urltest tick.

### Why

MutableURLTest.DialContext (and ListenPacket) already deleted the failing outbound's URL-test history on error, but selectedOutboundTCP/selectedOutboundUDP continued to point at it. selectOutbound only falls back to pickBestOutbound when the cached selection is nil, so every subsequent dial picked the same dead outbound and failed the same way until the next urltest tick — up to interval (default 3 minutes) of repeated failures.

This shows up in user reports as transient "everything broke for ~30–60s" episodes — most visibly as DNS, since dns_remote rides detour: "auto" and a wedged auto-selected proxy stalls all DoH queries until reselection happens.

### What changed

- New markFailedAndReselect(outbound) helper on urlTestGroup: deletes URL-test history (existing behavior) and calls updateSelected() (new) so the cached TCP/UDP selections move off the failed outbound.
- DialContext and ListenPacket error paths call it instead of just deleting history.
- pickBestOutbound's no-history fallback skips current, so the just-failed outbound isn't re-picked when no candidate has history.
