### PR TITLE
Add peerconn listener registry for inbound connection lifecycle events

### DIFF
--- a/protocol/samizdat/inbound.go
+++ b/protocol/samizdat/inbound.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/getlantern/lantern-box/constant"
 	"github.com/getlantern/lantern-box/option"
+	"github.com/getlantern/lantern-box/tracker/peerconn"
 
 	samizdat "github.com/getlantern/samizdat"
 )
@@ -164,6 +165,13 @@ func (i *Inbound) handleConnection(ctx context.Context, conn net.Conn, destinati
 	metadata.InboundType = i.Type()
 	metadata.Source = M.SocksaddrFromNet(conn.RemoteAddr()).Unwrap()
 	metadata.Destination = M.ParseSocksaddr(destination)
+
+	// Surface accept/close to the peer-connection listener (registered by
+	// the radiance peer client when Share My Connection is active). Cheap
+	// no-op when no listener is set.
+	source := metadata.Source.String()
+	peerconn.Notify(+1, source)
+	defer peerconn.Notify(-1, source)
 
 	i.logger.InfoContext(ctx, "inbound connection to ", destination)
 	done := make(chan struct{})

--- a/protocol/samizdat/inbound.go
+++ b/protocol/samizdat/inbound.go
@@ -168,10 +168,15 @@ func (i *Inbound) handleConnection(ctx context.Context, conn net.Conn, destinati
 
 	// Surface accept/close to the peer-connection listener (registered by
 	// the radiance peer client when Share My Connection is active). Cheap
-	// no-op when no listener is set.
+	// no-op when no listener is set. Acquired once so a SetListener during
+	// the connection's lifetime cannot route the close to a different
+	// listener than the accept, which would leave this connection
+	// permanently open from the accepting listener's perspective.
 	source := metadata.Source.String()
-	peerconn.Notify(+1, source)
-	defer peerconn.Notify(-1, source)
+	if notify := peerconn.Acquire(); notify != nil {
+		notify(+1, source)
+		defer notify(-1, source)
+	}
 
 	i.logger.InfoContext(ctx, "inbound connection to ", destination)
 	done := make(chan struct{})

--- a/tracker/peerconn/listener.go
+++ b/tracker/peerconn/listener.go
@@ -1,0 +1,58 @@
+// Package peerconn exposes a process-wide listener registry for inbound
+// connection lifecycle events across lantern-box protocols.
+//
+// This is the hook the radiance peer client (Share My Connection) uses to
+// emit per-connection accept/close events to the rest of the application
+// — the globe visualization, abuse-detection aggregation, and metrics that
+// need a stream rather than a snapshot. It deliberately sits outside any
+// individual protocol package so the same listener fires for samizdat
+// today and TLS-masq / algeneva / water as those inbounds gain peer-share
+// support.
+//
+// Why not adapter.ConnectionTracker? sing-box's tracker abstraction lives
+// behind libbox's internal box.Router, with no public hook for callers
+// constructing a libbox.BoxService to AppendTracker post-creation. A
+// process-wide listener side-steps that: lantern-box inbound code calls
+// Notify directly, the radiance peer client registers a listener before
+// starting libbox.
+package peerconn
+
+import "sync"
+
+// Listener receives connection lifecycle notifications from lantern-box
+// inbound protocols.
+//
+//   state  +1 on accept, -1 on close
+//   source remote peer's "ip:port" string (empty if unavailable)
+//
+// The listener is invoked synchronously on the inbound's accept/close path,
+// so implementations should not block on heavy work — fan out to a buffered
+// channel or goroutine if more than a few microseconds is expected.
+type Listener func(state int, source string)
+
+var (
+	listenerMu sync.RWMutex
+	listener   Listener
+)
+
+// SetListener registers (or with a nil argument, unregisters) the global
+// listener. Single-active: a second SetListener call replaces the first.
+// Called from the radiance peer client at Start, cleared at Stop.
+func SetListener(l Listener) {
+	listenerMu.Lock()
+	defer listenerMu.Unlock()
+	listener = l
+}
+
+// Notify dispatches a state transition to the registered listener if one
+// is set. No-op when nothing is registered, so lantern-box uses that don't
+// care about peer-share connection events (cmd_run, the standalone CLI,
+// the radiance VPN client) pay zero cost beyond a mutex read.
+func Notify(state int, source string) {
+	listenerMu.RLock()
+	l := listener
+	listenerMu.RUnlock()
+	if l != nil {
+		l(state, source)
+	}
+}

--- a/tracker/peerconn/listener.go
+++ b/tracker/peerconn/listener.go
@@ -22,8 +22,8 @@ import "sync"
 // Listener receives connection lifecycle notifications from lantern-box
 // inbound protocols.
 //
-//   state  +1 on accept, -1 on close
-//   source remote peer's "ip:port" string (empty if unavailable)
+//	state  +1 on accept, -1 on close
+//	source remote peer's "ip:port" string (empty if unavailable)
 //
 // The listener is invoked synchronously on the inbound's accept/close path,
 // so implementations should not block on heavy work — fan out to a buffered
@@ -44,10 +44,13 @@ func SetListener(l Listener) {
 	listener = l
 }
 
-// Notify dispatches a state transition to the registered listener if one
-// is set. No-op when nothing is registered, so lantern-box uses that don't
-// care about peer-share connection events (cmd_run, the standalone CLI,
-// the radiance VPN client) pay zero cost beyond a mutex read.
+// Notify dispatches a single state transition to the registered listener if
+// one is set. No-op when nothing is registered, so lantern-box uses that
+// don't care about peer-share connection events (cmd_run, the standalone
+// CLI, the radiance VPN client) pay zero cost beyond a mutex read.
+//
+// Callers emitting both halves of one connection's lifecycle must use
+// Acquire instead.
 func Notify(state int, source string) {
 	listenerMu.RLock()
 	l := listener
@@ -55,4 +58,23 @@ func Notify(state int, source string) {
 	if l != nil {
 		l(state, source)
 	}
+}
+
+// Acquire returns the registered listener, or nil if none is set.
+//
+// A connection emitting a matched accept/close pair must Acquire once and use
+// the returned listener for both halves. Reading the registry twice lets a
+// SetListener land in between, so the accept reaches one listener and the
+// close reaches another: the first is left holding a connection that never
+// closes, the second sees a close it never opened. Consumers keeping
+// per-connection state — counts, open-connection maps, abuse buckets keyed on
+// the accept — corrupt silently when that happens.
+//
+// The tradeoff is that a pair already in flight completes against the
+// listener that accepted it, so SetListener(nil) does not cancel the close
+// half. Consumers needing a hard stop must gate inside their own callback.
+func Acquire() Listener {
+	listenerMu.RLock()
+	defer listenerMu.RUnlock()
+	return listener
 }

--- a/tracker/peerconn/listener_test.go
+++ b/tracker/peerconn/listener_test.go
@@ -1,0 +1,77 @@
+package peerconn
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNotify_NoListener_NoOp(t *testing.T) {
+	t.Cleanup(func() { SetListener(nil) })
+	SetListener(nil)
+	// Just must not panic. Cheap path the standalone CLI exercises on every
+	// connection.
+	Notify(+1, "1.2.3.4:5555")
+	Notify(-1, "1.2.3.4:5555")
+}
+
+func TestSetListener_FiresOnNotify(t *testing.T) {
+	t.Cleanup(func() { SetListener(nil) })
+
+	type call struct {
+		state  int
+		source string
+	}
+	var (
+		mu    sync.Mutex
+		calls []call
+	)
+	SetListener(func(state int, source string) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, call{state, source})
+	})
+
+	Notify(+1, "10.0.0.1:443")
+	Notify(-1, "10.0.0.1:443")
+	Notify(+1, "10.0.0.2:443")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []call{
+		{+1, "10.0.0.1:443"},
+		{-1, "10.0.0.1:443"},
+		{+1, "10.0.0.2:443"},
+	}, calls)
+}
+
+func TestSetListener_LastWriterWins(t *testing.T) {
+	t.Cleanup(func() { SetListener(nil) })
+
+	var firstHits, secondHits atomic.Int32
+	SetListener(func(_ int, _ string) { firstHits.Add(1) })
+	Notify(+1, "")
+	SetListener(func(_ int, _ string) { secondHits.Add(1) })
+	Notify(+1, "")
+	Notify(-1, "")
+
+	assert.Equal(t, int32(1), firstHits.Load(),
+		"first listener should see only the pre-replace Notify")
+	assert.Equal(t, int32(2), secondHits.Load(),
+		"second listener should see the two post-replace Notifys")
+}
+
+func TestSetListener_NilUnregisters(t *testing.T) {
+	t.Cleanup(func() { SetListener(nil) })
+
+	var hits atomic.Int32
+	SetListener(func(_ int, _ string) { hits.Add(1) })
+	Notify(+1, "")
+	SetListener(nil)
+	Notify(+1, "")
+	Notify(-1, "")
+	assert.Equal(t, int32(1), hits.Load(),
+		"after SetListener(nil) further Notifys must not fire")
+}

--- a/tracker/peerconn/listener_test.go
+++ b/tracker/peerconn/listener_test.go
@@ -60,7 +60,7 @@ func TestSetListener_LastWriterWins(t *testing.T) {
 	assert.Equal(t, int32(1), firstHits.Load(),
 		"first listener should see only the pre-replace Notify")
 	assert.Equal(t, int32(2), secondHits.Load(),
-		"second listener should see the two post-replace Notifys")
+		"second listener should see the two post-replace Notifies")
 }
 
 func TestSetListener_NilUnregisters(t *testing.T) {
@@ -73,5 +73,76 @@ func TestSetListener_NilUnregisters(t *testing.T) {
 	Notify(+1, "")
 	Notify(-1, "")
 	assert.Equal(t, int32(1), hits.Load(),
-		"after SetListener(nil) further Notifys must not fire")
+		"after SetListener(nil) further Notifies must not fire")
+}
+
+func TestAcquire_NoListener_ReturnsNil(t *testing.T) {
+	t.Cleanup(func() { SetListener(nil) })
+	SetListener(nil)
+
+	assert.Nil(t, Acquire(), "Acquire must report the absence of a listener "+
+		"so callers can skip both halves rather than emitting an unpaired accept")
+}
+
+// The close half of a connection must reach whichever listener accepted it.
+// Acquiring once is what guarantees that; reading the registry per half would
+// hand the close to whatever listener happened to be registered by then,
+// leaving the accepting listener with a connection that never closes.
+func TestAcquire_PairSurvivesListenerReplacement(t *testing.T) {
+	t.Cleanup(func() { SetListener(nil) })
+
+	var (
+		mu             sync.Mutex
+		firstStates    []int
+		replacedStates []int
+	)
+	SetListener(func(state int, _ string) {
+		mu.Lock()
+		defer mu.Unlock()
+		firstStates = append(firstStates, state)
+	})
+
+	notify := Acquire()
+	notify(+1, "10.0.0.1:443")
+	SetListener(func(state int, _ string) {
+		mu.Lock()
+		defer mu.Unlock()
+		replacedStates = append(replacedStates, state)
+	})
+	notify(-1, "10.0.0.1:443")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []int{+1, -1}, firstStates,
+		"both halves must reach the listener that accepted the connection")
+	assert.Empty(t, replacedStates,
+		"the replacement listener must not see a close for a connection it never accepted")
+}
+
+// Documents the deliberate consequence of pairing: unregistering mid-connection
+// no longer suppresses the close half, because dropping it would strand the
+// accept the consumer has already recorded. Consumers wanting a hard stop gate
+// inside their own callback.
+func TestAcquire_PairCompletesAfterUnregister(t *testing.T) {
+	t.Cleanup(func() { SetListener(nil) })
+
+	var (
+		mu     sync.Mutex
+		states []int
+	)
+	SetListener(func(state int, _ string) {
+		mu.Lock()
+		defer mu.Unlock()
+		states = append(states, state)
+	})
+
+	notify := Acquire()
+	notify(+1, "")
+	SetListener(nil)
+	notify(-1, "")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []int{+1, -1}, states,
+		"an accepted connection must still report its close after SetListener(nil)")
 }


### PR DESCRIPTION
## Summary

Adds a process-wide listener registry for inbound connection lifecycle events under `tracker/peerconn`. Used by the radiance peer client (Share My Connection) to surface accept/close events to the rest of the application — Flutter globe visualization, future abuse aggregation, metrics that need a stream rather than a snapshot.

## Why this and not adapter.ConnectionTracker

sing-box's tracker abstraction would be the obvious fit but lives behind libbox's internal `box.Router` with no public hook for callers constructing a `libbox.BoxService` to register a tracker post-creation. Plumbing one through would require sing-box-minimal changes. This is a smaller hook: single global listener, last-writer-wins, nil to clear.

The registry is callable from any lantern-box inbound — samizdat is wired in this commit; TLS-masq, algeneva, water, etc. is a two-line addition (notify on accept, defer notify on close), keeping the hook protocol-agnostic across lantern-box.

## Cost when unused

Zero beyond a mutex read per connection. Standalone CLI / VPN-only consumers (cmd_run, the radiance VPN client) pay nothing meaningful.

## Test plan

- [x] `go test ./tracker/peerconn/...` — 4 unit tests covering nil listener, fire on notify, last-writer-wins, nil unregisters
- [x] `go test ./protocol/samizdat/...` — existing samizdat tests unaffected
- [ ] End-to-end: with the matching radiance branch (`fisk/peer-connection-events`), connection events flow from accept loop → globe (verified locally)

## Related

- radiance: `getlantern/radiance#TBD` (consumes this listener)
- lantern: `getlantern/lantern#TBD` (Flutter UI subscribes to the FlutterEvent stream this ultimately feeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added peer connection tracking for inbound connections.
  * Connection acceptance and closure events can now be reported with the connection’s source address.
  * Added support for registering, replacing, and removing a single active connection event listener.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->