### PR TITLE
group: retry across outbounds on dial/listen failure

### DIFF
--- a/protocol/group/fallback_test.go
+++ b/protocol/group/fallback_test.go
@@ -9,36 +9,7 @@ import (
 	"github.com/sagernet/sing-box/log"
 	"github.com/sagernet/sing/common/metadata"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
-
-type mockOutbound struct {
-	mock.Mock
-	adapter.Outbound
-	tag string
-}
-
-func (m *mockOutbound) DialContext(ctx context.Context, network string, destination metadata.Socksaddr) (net.Conn, error) {
-	args := m.Called()
-	conn, _ := args.Get(0).(net.Conn)
-	return conn, args.Error(1)
-}
-func (m *mockOutbound) ListenPacket(ctx context.Context, destination metadata.Socksaddr) (net.PacketConn, error) {
-	args := m.Called()
-	pc, _ := args.Get(0).(net.PacketConn)
-	return pc, args.Error(1)
-}
-
-type mockOutboundManager struct {
-	mock.Mock
-	adapter.OutboundManager
-	outbounds map[string]adapter.Outbound
-}
-
-func (m *mockOutboundManager) Outbound(tag string) (adapter.Outbound, bool) {
-	o, ok := m.outbounds[tag]
-	return o, ok
-}
 
 func newTestFB() (*Fallback, *mockOutbound, *mockOutbound) {
 	primary := new(mockOutbound)

--- a/protocol/group/mock_outbound_test.go
+++ b/protocol/group/mock_outbound_test.go
@@ -1,0 +1,42 @@
+package group
+
+import (
+	"context"
+	"net"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing/common/metadata"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockOutbound struct {
+	mock.Mock
+	adapter.Outbound
+	tag string
+}
+
+func (m *mockOutbound) Tag() string       { return m.tag }
+func (m *mockOutbound) Network() []string { return []string{"tcp", "udp"} }
+
+func (m *mockOutbound) DialContext(ctx context.Context, network string, destination metadata.Socksaddr) (net.Conn, error) {
+	args := m.Called()
+	conn, _ := args.Get(0).(net.Conn)
+	return conn, args.Error(1)
+}
+
+func (m *mockOutbound) ListenPacket(ctx context.Context, destination metadata.Socksaddr) (net.PacketConn, error) {
+	args := m.Called()
+	pc, _ := args.Get(0).(net.PacketConn)
+	return pc, args.Error(1)
+}
+
+type mockOutboundManager struct {
+	mock.Mock
+	adapter.OutboundManager
+	outbounds map[string]adapter.Outbound
+}
+
+func (m *mockOutboundManager) Outbound(tag string) (adapter.Outbound, bool) {
+	o, ok := m.outbounds[tag]
+	return o, ok
+}

--- a/protocol/group/mutableurltest.go
+++ b/protocol/group/mutableurltest.go
@@ -44,9 +44,14 @@ func RegisterMutableURLTest(registry *outbound.Registry) {
 	outbound.Register[option.MutableURLTestOutboundOptions](registry, constant.TypeMutableURLTest, NewMutableURLTest)
 }
 
+// ErrAllOutboundsFailed is returned by [MutableURLTest.DialContext] and [MutableURLTest.ListenPacket]
+// after every attempted outbound has failed.
+var ErrAllOutboundsFailed = errors.New("all outbounds failed")
+
+const maxDialRetries = 3
+
 var (
 	_ adapter.MutableOutboundGroup = (*MutableURLTest)(nil)
-	_ A.OutboundGroup              = (*MutableURLTest)(nil)
 	_ A.InterfaceUpdateListener    = (*MutableURLTest)(nil)
 	_ A.ConnectionHandlerEx        = (*MutableURLTest)(nil)
 	_ A.PacketConnectionHandlerEx  = (*MutableURLTest)(nil)
@@ -161,24 +166,16 @@ func (s *MutableURLTest) DialContext(ctx context.Context, network string, destin
 		attribute.String("type", s.Type()),
 	))
 	defer span.End()
-
-	s.group.keepAlive()
-	outbound, err := s.selectOutbound(network)
+	conn, tag, err := tryEachOutbound(ctx, s, network, "dial_failed",
+		func(o A.Outbound) (net.Conn, error) { return o.DialContext(ctx, network, destination) },
+	)
 	if err != nil {
-		span.RecordError(err)
 		return nil, err
 	}
-	conn, err := outbound.DialContext(ctx, network, destination)
-	if err != nil {
-		s.logger.ErrorContext(ctx, err)
-		s.group.markFailedAndReselect(outbound)
-		span.RecordError(err)
-		return nil, err
+	if tc, ok := conn.(*adapter.TaggedConn); ok {
+		return tc, nil
 	}
-	if taggedConn, ok := conn.(*adapter.TaggedConn); ok {
-		return taggedConn, nil
-	}
-	return adapter.NewTaggedConn(conn, realTag(outbound)), nil
+	return adapter.NewTaggedConn(conn, tag), nil
 }
 
 func (s *MutableURLTest) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
@@ -189,27 +186,72 @@ func (s *MutableURLTest) ListenPacket(ctx context.Context, destination M.Socksad
 		attribute.String("type", s.Type()),
 	))
 	defer span.End()
-
-	s.group.keepAlive()
-	outbound, err := s.selectOutbound("udp")
+	conn, tag, err := tryEachOutbound(ctx, s, "udp", "listen_failed",
+		func(o A.Outbound) (net.PacketConn, error) { return o.ListenPacket(ctx, destination) },
+	)
 	if err != nil {
-		span.RecordError(err)
 		return nil, err
 	}
-	conn, err := outbound.ListenPacket(ctx, destination)
-	if err != nil {
-		s.logger.ErrorContext(ctx, err)
-		s.group.markFailedAndReselect(outbound)
-		span.RecordError(err)
-		return nil, err
+	if tc, ok := conn.(*adapter.TaggedPacketConn); ok {
+		return tc, nil
 	}
-	if taggedConn, ok := conn.(*adapter.TaggedPacketConn); ok {
-		return taggedConn, nil
-	}
-	return adapter.NewTaggedPacketConn(conn, realTag(outbound)), nil
+	return adapter.NewTaggedPacketConn(conn, tag), nil
 }
 
-func (s *MutableURLTest) selectOutbound(network string) (A.Outbound, error) {
+// tryEachOutbound attempts to dial or listen with each candidate outbound for the given network,
+// up to maxDialRetries times.
+func tryEachOutbound[T any](
+	ctx context.Context,
+	s *MutableURLTest,
+	network string,
+	failEvent string,
+	dial func(A.Outbound) (T, error),
+) (T, string, error) {
+	s.group.keepAlive()
+	var (
+		tried   = make(map[string]bool)
+		lastErr error
+		zero    T
+	)
+	span := trace.SpanFromContext(ctx)
+	for n := range maxDialRetries {
+		outbound, err := s.selectOutbound(network, tried)
+		if err != nil {
+			if !errors.Is(err, errNetworkNotSupported) && lastErr != nil {
+				err = fmt.Errorf("%w: %w", ErrAllOutboundsFailed, lastErr)
+			}
+			span.RecordError(err)
+			return zero, "", err
+		}
+		tag := realTag(outbound)
+		conn, err := dial(outbound)
+		if err == nil {
+			return conn, tag, nil
+		}
+		s.logger.ErrorContext(ctx, err)
+		span.AddEvent(failEvent, trace.WithAttributes(
+			attribute.String("outbound", tag),
+			attribute.Int("attempt", n+1),
+			attribute.String("error", err.Error()),
+		))
+		s.group.markFailedAndReselect(outbound)
+		lastErr = err
+		if ctx.Err() != nil {
+			span.RecordError(ctx.Err())
+			return zero, "", ctx.Err()
+		}
+		tried[tag] = true
+	}
+	err := fmt.Errorf("%w: %w", ErrAllOutboundsFailed, lastErr)
+	span.RecordError(err)
+	return zero, "", err
+}
+
+var errNetworkNotSupported = errors.New("network not supported")
+
+// selectOutbound returns the best candidate outbound for network whose realTag
+// is not in excludedTags. excludedTags may be nil.
+func (s *MutableURLTest) selectOutbound(network string, excluded map[string]bool) (A.Outbound, error) {
 	var outbound A.Outbound
 	switch network {
 	case "tcp":
@@ -217,13 +259,18 @@ func (s *MutableURLTest) selectOutbound(network string) (A.Outbound, error) {
 	case "udp":
 		outbound = s.group.selectedOutboundUDP.Load()
 	default:
-		return nil, fmt.Errorf("network %s not supported", network)
+		return nil, fmt.Errorf("%w: %s", errNetworkNotSupported, network)
+	}
+	if outbound != nil {
+		if rTag := realTag(outbound); rTag == "" || excluded[rTag] {
+			outbound = nil
+		}
 	}
 	if outbound == nil {
-		outbound = s.group.pickBestOutbound(network, nil)
+		outbound = s.group.pickBestOutbound(network, nil, excluded)
 	}
 	recoveryStarted := false
-	if outbound == nil && len(s.group.tags) > 0 {
+	if outbound == nil && len(excluded) == 0 && len(s.group.tags) > 0 {
 		recoveryStarted = true
 		s.logger.Warn("no outbound available, starting async URL test for recovery")
 		go s.group.CheckOutbounds(true)
@@ -598,22 +645,26 @@ func (g *urlTestGroup) updateSelected() {
 		return
 	}
 	tcpOutbound := g.selectedOutboundTCP.Load()
-	if outbound := g.pickBestOutbound("tcp", tcpOutbound); outbound != tcpOutbound {
+	if outbound := g.pickBestOutbound("tcp", tcpOutbound, nil); outbound != tcpOutbound {
 		g.selectedOutboundTCP.Store(outbound)
 	}
 
 	udpOutbound := g.selectedOutboundUDP.Load()
-	if outbound := g.pickBestOutbound("udp", udpOutbound); outbound != udpOutbound {
+	if outbound := g.pickBestOutbound("udp", udpOutbound, nil); outbound != udpOutbound {
 		g.selectedOutboundUDP.Store(outbound)
 	}
 }
 
-func (g *urlTestGroup) pickBestOutbound(network string, current A.Outbound) A.Outbound {
+// pickBestOutbound returns the lowest-latency outbound supporting network,
+// preferring current within tolerance. Outbounds whose realTag is in excluded
+// are skipped (excluded may be nil). Falls back to any non-current candidate
+// when no outbound has URL-test history.
+func (g *urlTestGroup) pickBestOutbound(network string, current A.Outbound, excluded map[string]bool) A.Outbound {
 	var (
 		minDelay    uint16
 		minOutbound A.Outbound
 	)
-	if current != nil {
+	if current != nil && !excluded[realTag(current)] {
 		if history := g.history.LoadURLTestHistory(realTag(current)); history != nil {
 			minOutbound = current
 			minDelay = history.Delay
@@ -624,7 +675,7 @@ func (g *urlTestGroup) pickBestOutbound(network string, current A.Outbound) A.Ou
 			continue
 		}
 		rTag := realTag(outbound)
-		if rTag == "" {
+		if rTag == "" || excluded[rTag] {
 			continue
 		}
 		history := g.history.LoadURLTestHistory(rTag)
@@ -646,7 +697,11 @@ func (g *urlTestGroup) pickBestOutbound(network string, current A.Outbound) A.Ou
 		if outbound == current {
 			continue
 		}
-		if slices.Contains(outbound.Network(), network) && realTag(outbound) != "" {
+		rTag := realTag(outbound)
+		if rTag == "" || excluded[rTag] {
+			continue
+		}
+		if slices.Contains(outbound.Network(), network) {
 			return outbound
 		}
 	}

--- a/protocol/group/mutableurltest.go
+++ b/protocol/group/mutableurltest.go
@@ -48,7 +48,10 @@ func RegisterMutableURLTest(registry *outbound.Registry) {
 // after every attempted outbound has failed.
 var ErrAllOutboundsFailed = errors.New("all outbounds failed")
 
-const maxDialRetries = 3
+// maxOutboundAttempts caps the number of outbounds DialContext / ListenPacket
+// will try in a single call. Bounds worst-case latency when many outbounds are
+// down (~maxOutboundAttempts * TCPTimeout instead of unbounded).
+const maxOutboundAttempts = 3
 
 var (
 	_ adapter.MutableOutboundGroup = (*MutableURLTest)(nil)
@@ -214,7 +217,7 @@ func tryEachOutbound[T any](
 		zero    T
 	)
 	span := trace.SpanFromContext(ctx)
-	for n := range maxDialRetries {
+	for n := range maxOutboundAttempts {
 		outbound, err := s.selectOutbound(network, tried)
 		if err != nil {
 			if !errors.Is(err, errNetworkNotSupported) && lastErr != nil {
@@ -223,14 +226,18 @@ func tryEachOutbound[T any](
 			span.RecordError(err)
 			return zero, "", err
 		}
-		tag := realTag(outbound)
+		triedTag := realTag(outbound)
 		conn, err := dial(outbound)
 		if err == nil {
-			return conn, tag, nil
+			// Re-evaluate post-attempt so the returned tag reflects the
+			// nested group's current selection rather than the stale pre-dial
+			// snapshot.
+			return conn, realTag(outbound), nil
 		}
-		s.logger.ErrorContext(ctx, err)
+		s.logger.DebugContext(ctx, "outbound attempt failed",
+			"outbound", triedTag, "attempt", n+1, "error", err)
 		span.AddEvent(failEvent, trace.WithAttributes(
-			attribute.String("outbound", tag),
+			attribute.String("outbound", triedTag),
 			attribute.Int("attempt", n+1),
 			attribute.String("error", err.Error()),
 		))
@@ -240,7 +247,7 @@ func tryEachOutbound[T any](
 			span.RecordError(ctx.Err())
 			return zero, "", ctx.Err()
 		}
-		tried[tag] = true
+		tried[triedTag] = true
 	}
 	err := fmt.Errorf("%w: %w", ErrAllOutboundsFailed, lastErr)
 	span.RecordError(err)

--- a/protocol/group/urltest_test.go
+++ b/protocol/group/urltest_test.go
@@ -1,15 +1,21 @@
 package group
 
 import (
-	"fmt"
+	"context"
+	"errors"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/sagernet/sing-box/adapter"
+	O "github.com/sagernet/sing-box/adapter/outbound"
 	"github.com/sagernet/sing-box/common/urltest"
+	sbLog "github.com/sagernet/sing-box/log"
 	"github.com/sagernet/sing/common"
+	"github.com/sagernet/sing/common/metadata"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/getlantern/lantern-box/constant"
 	"github.com/getlantern/lantern-box/internal/sync"
 )
 
@@ -40,30 +46,11 @@ func TestUpdateSelected(t *testing.T) {
 		})
 	}
 
-	pfmt := func(o adapter.Outbound) string {
-		if o == nil {
-			return "<nil>"
-		}
-		h := testGroup.history.LoadURLTestHistory(o.Tag())
-		if h != nil {
-			return fmt.Sprintf("%s(%d)", o.Tag(), h.Delay)
-		}
-		return o.Tag()
-	}
-
 	o, _ := testGroup.outbounds.Load("golduck")
 	testGroup.selectedOutboundTCP.Store(o)
 	testGroup.selectedOutboundUDP.Store(o)
 
-	fmt.Printf("Before updateSelected: tcp=%v, udp=%v\n",
-		pfmt(testGroup.selectedOutboundTCP.Load()),
-		pfmt(testGroup.selectedOutboundUDP.Load()),
-	)
 	testGroup.updateSelected()
-	fmt.Printf("After updateSelected: tcp=%v, udp=%v\n",
-		pfmt(testGroup.selectedOutboundTCP.Load()),
-		pfmt(testGroup.selectedOutboundUDP.Load()),
-	)
 
 	want := []string{"kangaskhan", "koffing", "lickitung", "growlithe"}
 	assert.Contains(t, want, testGroup.selectedOutboundTCP.Load().Tag())
@@ -111,6 +98,156 @@ func TestMarkFailedAndReselect_SwitchesToHealthyOutbound(t *testing.T) {
 	require.Equal("beta", g.selectedOutboundUDP.Load().Tag())
 }
 
+func TestMutableURLTest_DialContext_RetriesEachOutbound(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	delays := map[string]uint16{"alpha": 50, "beta": 1000, "gamma": 2000}
+	outboundByTag := make(map[string]*mockOutbound, len(delays))
+	g := &urlTestGroup{
+		ctx:       ctx,
+		logger:    sbLog.NewNOPFactory().Logger(),
+		tags:      []string{},
+		outbounds: sync.TypedMap[string, adapter.Outbound]{},
+		tolerance: 50,
+		history:   urltest.NewHistoryStorage(),
+	}
+	for tag, delay := range delays {
+		ob := &mockOutbound{tag: tag}
+		g.tags = append(g.tags, tag)
+		g.outbounds.Store(tag, ob)
+		g.history.StoreURLTestHistory(tag, &adapter.URLTestHistory{Time: time.Now(), Delay: delay})
+		outboundByTag[tag] = ob
+	}
+	g.selectedOutboundTCP.Store(outboundByTag["alpha"])
+
+	s := &MutableURLTest{
+		Adapter: O.NewAdapter(constant.TypeMutableURLTest, "test", []string{"tcp", "udp"}, nil),
+		ctx:     ctx,
+		logger:  sbLog.NewNOPFactory().Logger(),
+		group:   g,
+	}
+
+	outboundByTag["alpha"].On("DialContext").Return(nil, assert.AnError)
+	outboundByTag["beta"].On("DialContext").Return(nil, assert.AnError)
+	outboundByTag["gamma"].On("DialContext").Return(&net.IPConn{}, nil)
+
+	conn, err := s.DialContext(ctx, "tcp", metadata.Socksaddr{})
+	assert.NoError(t, err)
+	assert.NotNil(t, conn)
+	for tag, ob := range outboundByTag {
+		ob.AssertExpectations(t)
+		assert.Equalf(t, 1, callCount(ob, "DialContext"), "outbound %s should have been dialed exactly once", tag)
+	}
+}
+
+func TestMutableURLTest_DialContext_AllFail(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	delays := map[string]uint16{"alpha": 50, "beta": 1000}
+	outboundByTag := make(map[string]*mockOutbound, len(delays))
+	g := &urlTestGroup{
+		ctx:       ctx,
+		logger:    sbLog.NewNOPFactory().Logger(),
+		tags:      []string{},
+		outbounds: sync.TypedMap[string, adapter.Outbound]{},
+		tolerance: 50,
+		history:   urltest.NewHistoryStorage(),
+	}
+	for tag, delay := range delays {
+		ob := &mockOutbound{tag: tag}
+		g.tags = append(g.tags, tag)
+		g.outbounds.Store(tag, ob)
+		g.history.StoreURLTestHistory(tag, &adapter.URLTestHistory{Time: time.Now(), Delay: delay})
+		outboundByTag[tag] = ob
+	}
+	g.selectedOutboundTCP.Store(outboundByTag["alpha"])
+
+	s := &MutableURLTest{
+		Adapter: O.NewAdapter(constant.TypeMutableURLTest, "test", []string{"tcp", "udp"}, nil),
+		ctx:     ctx,
+		logger:  sbLog.NewNOPFactory().Logger(),
+		group:   g,
+	}
+
+	for _, ob := range outboundByTag {
+		ob.On("DialContext").Return(nil, assert.AnError)
+	}
+
+	conn, err := s.DialContext(ctx, "tcp", metadata.Socksaddr{})
+	assert.Error(t, err)
+	assert.Nil(t, conn)
+	assert.True(t, errors.Is(err, ErrAllOutboundsFailed),
+		"err should be ErrAllOutboundsFailed so callers can trigger a URL test; got: %v", err)
+	assert.True(t, errors.Is(err, assert.AnError),
+		"the last underlying dial error should still be wrapped; got: %v", err)
+	for tag, ob := range outboundByTag {
+		assert.Equalf(t, 1, callCount(ob, "DialContext"), "outbound %s should have been dialed exactly once", tag)
+	}
+}
+
+func TestMutableURLTest_DialContext_RetryCap(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// More outbounds than maxDialRetries so the cap is the binding constraint.
+	tags := []string{"a", "b", "c", "d", "e"}
+	outboundByTag := make(map[string]*mockOutbound, len(tags))
+	g := &urlTestGroup{
+		ctx:       ctx,
+		logger:    sbLog.NewNOPFactory().Logger(),
+		tags:      []string{},
+		outbounds: sync.TypedMap[string, adapter.Outbound]{},
+		tolerance: 50,
+		history:   urltest.NewHistoryStorage(),
+	}
+	for i, tag := range tags {
+		ob := &mockOutbound{tag: tag}
+		g.tags = append(g.tags, tag)
+		g.outbounds.Store(tag, ob)
+		g.history.StoreURLTestHistory(tag, &adapter.URLTestHistory{
+			Time:  time.Now(),
+			Delay: uint16(100 * (i + 1)),
+		})
+		outboundByTag[tag] = ob
+	}
+	g.selectedOutboundTCP.Store(outboundByTag["a"])
+
+	s := &MutableURLTest{
+		Adapter: O.NewAdapter(constant.TypeMutableURLTest, "test", []string{"tcp", "udp"}, nil),
+		ctx:     ctx,
+		logger:  sbLog.NewNOPFactory().Logger(),
+		group:   g,
+	}
+	for _, ob := range outboundByTag {
+		ob.On("DialContext").Return(nil, assert.AnError)
+	}
+
+	conn, err := s.DialContext(ctx, "tcp", metadata.Socksaddr{})
+	assert.Error(t, err)
+	assert.Nil(t, conn)
+	assert.True(t, errors.Is(err, ErrAllOutboundsFailed),
+		"err should be ErrAllOutboundsFailed; got: %v", err)
+
+	total := 0
+	for _, ob := range outboundByTag {
+		total += callCount(ob, "DialContext")
+	}
+	assert.Equalf(t, maxDialRetries, total,
+		"DialContext should have been attempted exactly maxDialRetries times across all outbounds; got %d", total)
+}
+
+func callCount(m *mockOutbound, method string) int {
+	n := 0
+	for _, c := range m.Calls {
+		if c.Method == method {
+			n++
+		}
+	}
+	return n
+}
+
 func TestPickBestOutbound_FallbackSkipsCurrent(t *testing.T) {
 	g := &urlTestGroup{
 		tags:      []string{"alpha", "beta"},
@@ -123,7 +260,7 @@ func TestPickBestOutbound_FallbackSkipsCurrent(t *testing.T) {
 	g.outbounds.Store("alpha", alpha)
 	g.outbounds.Store("beta", beta)
 
-	picked := g.pickBestOutbound("tcp", alpha)
+	picked := g.pickBestOutbound("tcp", alpha, nil)
 	assert.Equal(t, "beta", picked.Tag(),
 		"fallback path should skip current and return the other outbound")
 }

--- a/protocol/group/urltest_test.go
+++ b/protocol/group/urltest_test.go
@@ -57,14 +57,6 @@ func TestUpdateSelected(t *testing.T) {
 	assert.Contains(t, want, testGroup.selectedOutboundUDP.Load().Tag())
 }
 
-func (m *mockOutbound) Tag() string {
-	return m.tag
-}
-
-func (m *mockOutbound) Network() []string {
-	return []string{"tcp", "udp"}
-}
-
 func TestMarkFailedAndReselect_SwitchesToHealthyOutbound(t *testing.T) {
 	g := &urlTestGroup{
 		tags:      []string{},
@@ -98,144 +90,141 @@ func TestMarkFailedAndReselect_SwitchesToHealthyOutbound(t *testing.T) {
 	require.Equal("beta", g.selectedOutboundUDP.Load().Tag())
 }
 
-func TestMutableURLTest_DialContext_RetriesEachOutbound(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+// retryMode parameterizes the table-driven tests across DialContext (tcp) and
+// ListenPacket (udp), which share the same retry machinery.
+type retryMode struct {
+	method      string
+	setSelected func(g *urlTestGroup, o adapter.Outbound)
+	invoke      func(s *MutableURLTest, ctx context.Context) (any, error)
+}
 
-	delays := map[string]uint16{"alpha": 50, "beta": 1000, "gamma": 2000}
-	outboundByTag := make(map[string]*mockOutbound, len(delays))
+var retryModes = []retryMode{
+	{
+		method:      "DialContext",
+		setSelected: func(g *urlTestGroup, o adapter.Outbound) { g.selectedOutboundTCP.Store(o) },
+		invoke: func(s *MutableURLTest, ctx context.Context) (any, error) {
+			return s.DialContext(ctx, "tcp", metadata.Socksaddr{})
+		},
+	},
+	{
+		method:      "ListenPacket",
+		setSelected: func(g *urlTestGroup, o adapter.Outbound) { g.selectedOutboundUDP.Store(o) },
+		invoke: func(s *MutableURLTest, ctx context.Context) (any, error) {
+			return s.ListenPacket(ctx, metadata.Socksaddr{})
+		},
+	},
+}
+
+func newRetryRig(mode retryMode, ctx context.Context, delays map[string]uint16, firstSelected string) (*MutableURLTest, map[string]*mockOutbound) {
 	g := &urlTestGroup{
 		ctx:       ctx,
 		logger:    sbLog.NewNOPFactory().Logger(),
-		tags:      []string{},
 		outbounds: sync.TypedMap[string, adapter.Outbound]{},
 		tolerance: 50,
 		history:   urltest.NewHistoryStorage(),
 	}
+	outbounds := make(map[string]*mockOutbound, len(delays))
 	for tag, delay := range delays {
 		ob := &mockOutbound{tag: tag}
 		g.tags = append(g.tags, tag)
 		g.outbounds.Store(tag, ob)
 		g.history.StoreURLTestHistory(tag, &adapter.URLTestHistory{Time: time.Now(), Delay: delay})
-		outboundByTag[tag] = ob
+		outbounds[tag] = ob
 	}
-	g.selectedOutboundTCP.Store(outboundByTag["alpha"])
-
+	if first, ok := outbounds[firstSelected]; ok {
+		mode.setSelected(g, first)
+	}
 	s := &MutableURLTest{
 		Adapter: O.NewAdapter(constant.TypeMutableURLTest, "test", []string{"tcp", "udp"}, nil),
 		ctx:     ctx,
 		logger:  sbLog.NewNOPFactory().Logger(),
 		group:   g,
 	}
-
-	outboundByTag["alpha"].On("DialContext").Return(nil, assert.AnError)
-	outboundByTag["beta"].On("DialContext").Return(nil, assert.AnError)
-	outboundByTag["gamma"].On("DialContext").Return(&net.IPConn{}, nil)
-
-	conn, err := s.DialContext(ctx, "tcp", metadata.Socksaddr{})
-	assert.NoError(t, err)
-	assert.NotNil(t, conn)
-	for tag, ob := range outboundByTag {
-		ob.AssertExpectations(t)
-		assert.Equalf(t, 1, callCount(ob, "DialContext"), "outbound %s should have been dialed exactly once", tag)
-	}
+	return s, outbounds
 }
 
-func TestMutableURLTest_DialContext_AllFail(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+func TestMutableURLTest_RetriesEachOutbound(t *testing.T) {
+	for _, mode := range retryModes {
+		t.Run(mode.method, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-	delays := map[string]uint16{"alpha": 50, "beta": 1000}
-	outboundByTag := make(map[string]*mockOutbound, len(delays))
-	g := &urlTestGroup{
-		ctx:       ctx,
-		logger:    sbLog.NewNOPFactory().Logger(),
-		tags:      []string{},
-		outbounds: sync.TypedMap[string, adapter.Outbound]{},
-		tolerance: 50,
-		history:   urltest.NewHistoryStorage(),
-	}
-	for tag, delay := range delays {
-		ob := &mockOutbound{tag: tag}
-		g.tags = append(g.tags, tag)
-		g.outbounds.Store(tag, ob)
-		g.history.StoreURLTestHistory(tag, &adapter.URLTestHistory{Time: time.Now(), Delay: delay})
-		outboundByTag[tag] = ob
-	}
-	g.selectedOutboundTCP.Store(outboundByTag["alpha"])
+			delays := map[string]uint16{"alpha": 50, "beta": 1000, "gamma": 2000}
+			s, outbounds := newRetryRig(mode, ctx, delays, "alpha")
 
-	s := &MutableURLTest{
-		Adapter: O.NewAdapter(constant.TypeMutableURLTest, "test", []string{"tcp", "udp"}, nil),
-		ctx:     ctx,
-		logger:  sbLog.NewNOPFactory().Logger(),
-		group:   g,
-	}
+			outbounds["alpha"].On(mode.method).Return(nil, assert.AnError)
+			outbounds["beta"].On(mode.method).Return(nil, assert.AnError)
+			outbounds["gamma"].On(mode.method).Return(&net.IPConn{}, nil)
 
-	for _, ob := range outboundByTag {
-		ob.On("DialContext").Return(nil, assert.AnError)
-	}
-
-	conn, err := s.DialContext(ctx, "tcp", metadata.Socksaddr{})
-	assert.Error(t, err)
-	assert.Nil(t, conn)
-	assert.True(t, errors.Is(err, ErrAllOutboundsFailed),
-		"err should be ErrAllOutboundsFailed so callers can trigger a URL test; got: %v", err)
-	assert.True(t, errors.Is(err, assert.AnError),
-		"the last underlying dial error should still be wrapped; got: %v", err)
-	for tag, ob := range outboundByTag {
-		assert.Equalf(t, 1, callCount(ob, "DialContext"), "outbound %s should have been dialed exactly once", tag)
-	}
-}
-
-func TestMutableURLTest_DialContext_RetryCap(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// More outbounds than maxDialRetries so the cap is the binding constraint.
-	tags := []string{"a", "b", "c", "d", "e"}
-	outboundByTag := make(map[string]*mockOutbound, len(tags))
-	g := &urlTestGroup{
-		ctx:       ctx,
-		logger:    sbLog.NewNOPFactory().Logger(),
-		tags:      []string{},
-		outbounds: sync.TypedMap[string, adapter.Outbound]{},
-		tolerance: 50,
-		history:   urltest.NewHistoryStorage(),
-	}
-	for i, tag := range tags {
-		ob := &mockOutbound{tag: tag}
-		g.tags = append(g.tags, tag)
-		g.outbounds.Store(tag, ob)
-		g.history.StoreURLTestHistory(tag, &adapter.URLTestHistory{
-			Time:  time.Now(),
-			Delay: uint16(100 * (i + 1)),
+			conn, err := mode.invoke(s, ctx)
+			assert.NoError(t, err)
+			assert.NotNil(t, conn)
+			for tag, ob := range outbounds {
+				ob.AssertExpectations(t)
+				assert.Equalf(t, 1, callCount(ob, mode.method),
+					"outbound %s should have been attempted exactly once", tag)
+			}
 		})
-		outboundByTag[tag] = ob
 	}
-	g.selectedOutboundTCP.Store(outboundByTag["a"])
+}
 
-	s := &MutableURLTest{
-		Adapter: O.NewAdapter(constant.TypeMutableURLTest, "test", []string{"tcp", "udp"}, nil),
-		ctx:     ctx,
-		logger:  sbLog.NewNOPFactory().Logger(),
-		group:   g,
-	}
-	for _, ob := range outboundByTag {
-		ob.On("DialContext").Return(nil, assert.AnError)
-	}
+func TestMutableURLTest_AllFail(t *testing.T) {
+	for _, mode := range retryModes {
+		t.Run(mode.method, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-	conn, err := s.DialContext(ctx, "tcp", metadata.Socksaddr{})
-	assert.Error(t, err)
-	assert.Nil(t, conn)
-	assert.True(t, errors.Is(err, ErrAllOutboundsFailed),
-		"err should be ErrAllOutboundsFailed; got: %v", err)
+			delays := map[string]uint16{"alpha": 50, "beta": 1000}
+			s, outbounds := newRetryRig(mode, ctx, delays, "alpha")
+			for _, ob := range outbounds {
+				ob.On(mode.method).Return(nil, assert.AnError)
+			}
 
-	total := 0
-	for _, ob := range outboundByTag {
-		total += callCount(ob, "DialContext")
+			conn, err := mode.invoke(s, ctx)
+			assert.Error(t, err)
+			assert.Nil(t, conn)
+			assert.True(t, errors.Is(err, ErrAllOutboundsFailed),
+				"err should be ErrAllOutboundsFailed so callers can trigger a URL test; got: %v", err)
+			assert.True(t, errors.Is(err, assert.AnError),
+				"the last underlying error should still be wrapped; got: %v", err)
+			for tag, ob := range outbounds {
+				assert.Equalf(t, 1, callCount(ob, mode.method),
+					"outbound %s should have been attempted exactly once", tag)
+			}
+		})
 	}
-	assert.Equalf(t, maxDialRetries, total,
-		"DialContext should have been attempted exactly maxDialRetries times across all outbounds; got %d", total)
+}
+
+func TestMutableURLTest_RetryCap(t *testing.T) {
+	for _, mode := range retryModes {
+		t.Run(mode.method, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			// More outbounds than maxOutboundAttempts so the cap is the binding constraint.
+			delays := map[string]uint16{}
+			for i, tag := range []string{"a", "b", "c", "d", "e"} {
+				delays[tag] = uint16(100 * (i + 1))
+			}
+			s, outbounds := newRetryRig(mode, ctx, delays, "a")
+			for _, ob := range outbounds {
+				ob.On(mode.method).Return(nil, assert.AnError)
+			}
+
+			conn, err := mode.invoke(s, ctx)
+			assert.Error(t, err)
+			assert.Nil(t, conn)
+			assert.True(t, errors.Is(err, ErrAllOutboundsFailed),
+				"err should be ErrAllOutboundsFailed; got: %v", err)
+
+			total := 0
+			for _, ob := range outbounds {
+				total += callCount(ob, mode.method)
+			}
+			assert.Equalf(t, maxOutboundAttempts, total,
+				"attempts should equal maxOutboundAttempts; got %d", total)
+		})
+	}
 }
 
 func callCount(m *mockOutbound, method string) int {


### PR DESCRIPTION
This pull request introduces robust retry logic for outbound connection attempts in the `MutableURLTest` group, ensuring that failures are handled gracefully and that the system can recover or report errors more reliably. The changes include new error types, a retry mechanism with a cap, improved outbound selection logic, and comprehensive unit tests to verify behavior under various failure scenarios.

**Key changes:**

### Retry and Error Handling Improvements

* Added a new error variable `ErrAllOutboundsFailed` to signal when all outbound connection attempts have failed, and introduced a `maxDialRetries` constant to cap the number of retries.
* Refactored `DialContext` and `ListenPacket` methods to use a new `tryEachOutbound` helper function, which attempts to connect using multiple outbounds up to the retry limit, recording errors and skipping failed ones. [[1]](diffhunk://#diff-e63f934b51f6c1473bc1cee5d3b5dc65796eff8adb4631bb591214ce21d172dbL164-R178) [[2]](diffhunk://#diff-e63f934b51f6c1473bc1cee5d3b5dc65796eff8adb4631bb591214ce21d172dbR189-R273)
* The `tryEachOutbound` function tracks which outbounds have been tried, ensures each is only tried once per attempt, and wraps errors appropriately to preserve both the retry-failure and the last underlying error.

### Outbound Selection Logic

* Updated `selectOutbound` and `pickBestOutbound` to accept a set of excluded tags, ensuring failed or already-tried outbounds are skipped during selection. This improves failover and prevents repeated attempts to the same failing outbound. [[1]](diffhunk://#diff-e63f934b51f6c1473bc1cee5d3b5dc65796eff8adb4631bb591214ce21d172dbR189-R273) [[2]](diffhunk://#diff-e63f934b51f6c1473bc1cee5d3b5dc65796eff8adb4631bb591214ce21d172dbL601-R667) [[3]](diffhunk://#diff-e63f934b51f6c1473bc1cee5d3b5dc65796eff8adb4631bb591214ce21d172dbL627-R678) [[4]](diffhunk://#diff-e63f934b51f6c1473bc1cee5d3b5dc65796eff8adb4631bb591214ce21d172dbL649-R704)
* Added a new error `errNetworkNotSupported` for unsupported networks, and improved error wrapping in selection logic.

### Unit Test Enhancements

* Added new tests to cover retry behavior:
  - Verifies that `DialContext` retries each outbound up to the cap and succeeds if any outbound works.
  - Ensures the error `ErrAllOutboundsFailed` is returned when all outbounds fail, and that the last error is preserved.
  - Confirms that the retry cap is enforced even when more outbounds are available.
* Updated existing tests to account for the new `pickBestOutbound` signature and logic.
* Removed unused formatting/debug code from tests for clarity.

---

**References:**  
- Retry and error handling: [[1]](diffhunk://#diff-e63f934b51f6c1473bc1cee5d3b5dc65796eff8adb4631bb591214ce21d172dbR47-L49) [[2]](diffhunk://#diff-e63f934b51f6c1473bc1cee5d3b5dc65796eff8adb4631bb591214ce21d172dbL164-R178) [[3]](diffhunk://#diff-e63f934b51f6c1473bc1cee5d3b5dc65796eff8adb4631bb591214ce21d172dbR189-R273)  
- Outbound selection logic: [[1]](diffhunk://#diff-e63f934b51f6c1473bc1cee5d3b5dc65796eff8adb4631bb591214ce21d172dbR189-R273) [[2]](diffhunk://#diff-e63f934b51f6c1473bc1cee5d3b5dc65796eff8adb4631bb591214ce21d172dbL601-R667) [[3]](diffhunk://#diff-e63f934b51f6c1473bc1cee5d3b5dc65796eff8adb4631bb591214ce21d172dbL627-R678) [[4]](diffhunk://#diff-e63f934b51f6c1473bc1cee5d3b5dc65796eff8adb4631bb591214ce21d172dbL649-R704)  
- Unit tests: [[1]](diffhunk://#diff-f88618cb1ca0e9da4e898c54af8576eebc7165eb35ab1a0537774133131deb7dR101-R250) [[2]](diffhunk://#diff-f88618cb1ca0e9da4e898c54af8576eebc7165eb35ab1a0537774133131deb7dL126-R263) [[3]](diffhunk://#diff-f88618cb1ca0e9da4e898c54af8576eebc7165eb35ab1a0537774133131deb7dL43-L66)