### PR TITLE
otelcol: ship cloud-init journald to SigNoz

### DIFF
--- a/deploy/packer/otelcol.yaml
+++ b/deploy/packer/otelcol.yaml
@@ -42,6 +42,27 @@ receivers:
         from: attributes.body
         to: body
 
+  # Cloud-init journald logs (the `logger -t cloud-init …` step + ERR-trap
+  # output from lantern-cloud's cloudinit_packer.go). Without this receiver
+  # those messages stay on-host in /var/log/cloud-init-output.log and
+  # journald only — invisible to SigNoz. That gap is exactly why the
+  # May 8 dpkg-flag regression needed an SSH session to diagnose; with
+  # this in place, a future cloud-init halt surfaces directly in the
+  # logs pipeline tagged with the same OTEL_RESOURCE_ATTRIBUTES we set
+  # on metrics (route.id, deployment.environment, cloud.provider, etc.),
+  # so operators can grep for it without leaving SigNoz.
+  #
+  # Filtered to `cloud-init` to avoid shipping every systemd unit's
+  # output (sshd, unattended-upgrades, etc.). The receiver runs as the
+  # otelcol-contrib user, which needs `systemd-journal` group access
+  # (granted via systemd drop-in in deploy/packer/provision.sh).
+  journald:
+    units: [cloud-init.service, cloud-final.service]
+    # Match anything tagged via `logger -t cloud-init …` even when emitted
+    # outside the cloud-init systemd unit (e.g. the ERR trap firing late).
+    matches:
+      - SYSLOG_IDENTIFIER: cloud-init
+
 processors:
   batch:
     send_batch_size: 1024
@@ -75,6 +96,6 @@ service:
       processors: [memory_limiter, resourcedetection, batch]
       exporters: [otlphttp]
     logs:
-      receivers: [filelog/lantern-box]
+      receivers: [filelog/lantern-box, journald]
       processors: [memory_limiter, resourcedetection, batch]
       exporters: [otlphttp]

--- a/deploy/packer/provision.sh
+++ b/deploy/packer/provision.sh
@@ -207,6 +207,7 @@ missing=""
 for path in \
   /etc/systemd/system/lantern-box.service.d/otel.conf \
   /etc/systemd/system/otelcol-contrib.service.d/env.conf \
+  /etc/systemd/system/otelcol-contrib.service.d/journald.conf \
   /etc/lantern-box \
   /var/lib/lantern-box \
   /etc/otelcol-contrib/config.yaml \
@@ -223,6 +224,17 @@ if ! command -v tailscale >/dev/null 2>&1; then
 fi
 if ! command -v otelcol-contrib >/dev/null 2>&1; then
   echo "otelcol-contrib not found on PATH" >&2
+  exit 1
+fi
+
+# Validate otelcol config at image-build time so malformed YAML, unknown
+# receivers/exporters, or missing pipeline references fail the packer
+# build instead of silently breaking otelcol-contrib's first start on
+# every VPS provisioned from this image. Cheap (sub-second), runs once
+# per image build, catches the cheapest class of mistake at the cheapest
+# point in the lifecycle.
+if ! otelcol-contrib validate --config /etc/otelcol-contrib/config.yaml; then
+  echo "otelcol-contrib config validation failed" >&2
   exit 1
 fi
 echo "    image contents verified"

--- a/deploy/packer/provision.sh
+++ b/deploy/packer/provision.sh
@@ -117,6 +117,17 @@ cat > /etc/systemd/system/otelcol-contrib.service.d/env.conf <<'DROPIN'
 EnvironmentFile=/etc/otelcol-contrib/otelcol.env
 DROPIN
 
+# Grant otelcol-contrib read access to journald so the `journald` receiver
+# (see deploy/packer/otelcol.yaml) can ship cloud-init's `logger -t cloud-init …`
+# step logs + ERR-trap output to SigNoz. Without this the service would log
+# "permission denied" trying to open /run/log/journal and silently drop all
+# cloud-init diagnostic messages — which is precisely what happened during
+# the May 8 dpkg-flag regression that needed an SSH session to diagnose.
+cat > /etc/systemd/system/otelcol-contrib.service.d/journald.conf <<'DROPIN'
+[Service]
+SupplementaryGroups=systemd-journal
+DROPIN
+
 # Create empty env file for lantern-box OTel — cloud-init populates it
 # with OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS, and
 # OTEL_RESOURCE_ATTRIBUTES before starting the service.


### PR DESCRIPTION
## Summary

Cloud-init's diagnostic logging (the `logger -t cloud-init "step: …"` checkpoints and the `set -e` ERR trap) writes to journald, but otelcol-contrib on the packer image only scrapes `/var/log/lantern-box/*.log` and host metrics — **journald is never forwarded**. Every cloud-init halt on a bandit VPS has been invisible to centralized logging.

That gap forced an SSH-and-cat-`/var/log/cloud-init-output.log` session to diagnose the May 8 dpkg-flag regression in lantern-cloud #2721. With this PR, future cloud-init halts surface in SigNoz tagged with the same `OTEL_RESOURCE_ATTRIBUTES` the metrics carry (`route.id`, `deployment.environment`, `cloud.provider`, etc.), so operators can grep for it from the dashboard.

## What changes

### 1. `deploy/packer/otelcol.yaml`

Add a `journald` receiver scoped to `cloud-init.service` and `cloud-final.service`, plus a `matches: [SYSLOG_IDENTIFIER: cloud-init]` clause to catch `logger -t cloud-init …` messages even when emitted outside those units (e.g. late ERR-trap firing). Wire it into the existing `logs` pipeline alongside `filelog/lantern-box`.

### 2. `deploy/packer/provision.sh`

Three changes, in one place each:

- Add `SupplementaryGroups=systemd-journal` via a new systemd drop-in for otelcol-contrib. The receiver runs as the `otelcol-contrib` user; without journal-group membership it would silently hit permission-denied opening `/run/log/journal`.
- Add `/etc/systemd/system/otelcol-contrib.service.d/journald.conf` to the existing image-verification block so a regression that drops the drop-in fails the packer build rather than producing a silently-broken image.
- Add an explicit `otelcol-contrib validate --config /etc/otelcol-contrib/config.yaml` step inside the verification block. Catches malformed YAML, unknown receivers/exporters, and missing pipeline references at image build time. Sub-second cost; the existing build flow only checks the binary is on PATH, not that the config it'll load is valid.

## Rollout

No code change in lantern-box itself. After merge:

1. Cut a new release tag (e.g. v0.0.82). Triggers `build-images.yaml` which rebakes the packer image with the new `otelcol.yaml` + drop-ins + the new validate step.
2. `BanditVPSReleasePollerWorker` picks up the new tag in `bandit_vps_latest_upstream_release`.
3. New bandit-VPS provisions get the fixed image → otelcol forwards cloud-init journald to SigNoz.
4. Existing fleet stays as-is until autoreplace cycles them.

## Verification

After rollout, the next time a bandit VPS provisions:

```
service.name = 'lantern-box' AND SYSLOG_IDENTIFIER = 'cloud-init'
```

should show the `step: …` checkpoint sequence in SigNoz logs for that route.

## Test plan

- [x] \`bash -n provision.sh\` — shell syntax clean.
- [x] YAML parse of \`otelcol.yaml\` — valid.
- [x] Added explicit \`otelcol-contrib validate\` inside provision.sh verification block — runs during every packer image build.
- [ ] After release + provision: a fresh \`vps-*\` host's \`cloud-init starting\` step log appears in SigNoz logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)