### PR TITLE
fix: stabilize WATER outbound in memory-constrained environments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52
 	github.com/getlantern/broflake v0.0.0-20260504215251-ed3cf75062d1
 	github.com/getlantern/geo v0.0.0-20241129152027-2fc88c10f91e
-	github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90
+	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395
 	github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb
 	github.com/gobwas/ws v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 h1:iLWm6S/4
 github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 h1:P9JX1yAu2uq3b5YiT0sLtHkTrkZuttV8gPZh81nUuag=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
+github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
+github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20190325191751-d70cb0d6f85f/go.mod h1:D5ao98qkA6pxftxoqzibIBBrLSUli+kYnJqrgBf9cIA=
 github.com/getlantern/ops v0.0.0-20220713155959-1315d978fff7/go.mod h1:D5ao98qkA6pxftxoqzibIBBrLSUli+kYnJqrgBf9cIA=
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNiMhCu4bf60nqcIuQpTYb00Ezm1ag=

--- a/protocol/group/mutableurltest.go
+++ b/protocol/group/mutableurltest.go
@@ -774,10 +774,8 @@ func urlTestGET(ctx context.Context, link string, detour N.Dialer) (uint16, erro
 	if err != nil {
 		return 0, err
 	}
-	// WATER's Close blocks in WaitWorker until the wasm relay exits, which can
-	// take 35–90s after a context cancellation; a background goroutine avoids
-	// stalling b.Wait() in the caller for that window.
-	defer func() { go instance.Close() }()
+	conn := &asyncCloseConn{Conn: instance}
+	defer conn.Close()
 	if earlyConn, isEarlyConn := common.Cast[N.EarlyConn](instance); isEarlyConn && earlyConn.NeedHandshake() {
 		start = time.Now()
 	}
@@ -793,7 +791,7 @@ func urlTestGET(ctx context.Context, link string, detour N.Dialer) (uint16, erro
 	client := http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				return instance, nil
+				return conn, nil
 			},
 			TLSClientConfig: &tls.Config{
 				Time:    ntp.TimeFuncFromContext(ctx),
@@ -813,6 +811,19 @@ func urlTestGET(ctx context.Context, link string, detour N.Dialer) (uint16, erro
 	io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 	return uint16(time.Since(start) / time.Millisecond), nil
+}
+
+// asyncCloseConn wraps a net.Conn whose Close can block for tens of seconds
+// (e.g. WATER's WaitWorker); dispatching to a goroutine prevents stalling the
+// HTTP client's synchronous cancellation path.
+type asyncCloseConn struct {
+	net.Conn
+	closeOnce sync.Once
+}
+
+func (c *asyncCloseConn) Close() error {
+	c.closeOnce.Do(func() { go c.Conn.Close() })
+	return nil
 }
 
 // appendClientDelay adds a &cd=<ms> query parameter to the given URL.

--- a/protocol/group/mutableurltest.go
+++ b/protocol/group/mutableurltest.go
@@ -770,9 +770,32 @@ func urlTestGET(ctx context.Context, link string, detour N.Dialer) (uint16, erro
 	}
 
 	start := time.Now()
-	instance, err := detour.DialContext(ctx, "tcp", M.ParseSocksaddrHostPortStr(hostname, port))
-	if err != nil {
-		return 0, err
+	// Some outbound DialContext implementations (e.g. WATER) block in WASM→host
+	// callbacks that the Go runtime cannot interrupt via context cancellation;
+	// racing against ctx.Done() enforces the test deadline regardless.
+	type dialResult struct {
+		conn net.Conn
+		err  error
+	}
+	ch := make(chan dialResult, 1)
+	go func() {
+		conn, err := detour.DialContext(ctx, "tcp", M.ParseSocksaddrHostPortStr(hostname, port))
+		ch <- dialResult{conn, err}
+	}()
+	var instance net.Conn
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			return 0, r.err
+		}
+		instance = r.conn
+	case <-ctx.Done():
+		go func() {
+			if r := <-ch; r.conn != nil {
+				r.conn.Close()
+			}
+		}()
+		return 0, ctx.Err()
 	}
 	conn := &asyncCloseConn{Conn: instance}
 	defer conn.Close()

--- a/protocol/group/mutableurltest.go
+++ b/protocol/group/mutableurltest.go
@@ -774,7 +774,10 @@ func urlTestGET(ctx context.Context, link string, detour N.Dialer) (uint16, erro
 	if err != nil {
 		return 0, err
 	}
-	defer instance.Close()
+	// WATER's Close blocks in WaitWorker until the wasm relay exits, which can
+	// take 35–90s after a context cancellation; a background goroutine avoids
+	// stalling b.Wait() in the caller for that window.
+	defer func() { go instance.Close() }()
 	if earlyConn, isEarlyConn := common.Cast[N.EarlyConn](instance); isEarlyConn && earlyConn.NeedHandshake() {
 		start = time.Now()
 	}

--- a/protocol/group/mutableurltest.go
+++ b/protocol/group/mutableurltest.go
@@ -770,32 +770,9 @@ func urlTestGET(ctx context.Context, link string, detour N.Dialer) (uint16, erro
 	}
 
 	start := time.Now()
-	// Some outbound DialContext implementations (e.g. WATER) block in WASM→host
-	// callbacks that the Go runtime cannot interrupt via context cancellation;
-	// racing against ctx.Done() enforces the test deadline regardless.
-	type dialResult struct {
-		conn net.Conn
-		err  error
-	}
-	ch := make(chan dialResult, 1)
-	go func() {
-		conn, err := detour.DialContext(ctx, "tcp", M.ParseSocksaddrHostPortStr(hostname, port))
-		ch <- dialResult{conn, err}
-	}()
-	var instance net.Conn
-	select {
-	case r := <-ch:
-		if r.err != nil {
-			return 0, r.err
-		}
-		instance = r.conn
-	case <-ctx.Done():
-		go func() {
-			if r := <-ch; r.conn != nil {
-				r.conn.Close()
-			}
-		}()
-		return 0, ctx.Err()
+	instance, err := detour.DialContext(ctx, "tcp", M.ParseSocksaddrHostPortStr(hostname, port))
+	if err != nil {
+		return 0, err
 	}
 	conn := &asyncCloseConn{Conn: instance}
 	defer conn.Close()

--- a/protocol/group/mutableurltest.go
+++ b/protocol/group/mutableurltest.go
@@ -774,8 +774,7 @@ func urlTestGET(ctx context.Context, link string, detour N.Dialer) (uint16, erro
 	if err != nil {
 		return 0, err
 	}
-	conn := &asyncCloseConn{Conn: instance}
-	defer conn.Close()
+	defer instance.Close()
 	if earlyConn, isEarlyConn := common.Cast[N.EarlyConn](instance); isEarlyConn && earlyConn.NeedHandshake() {
 		start = time.Now()
 	}
@@ -791,7 +790,7 @@ func urlTestGET(ctx context.Context, link string, detour N.Dialer) (uint16, erro
 	client := http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				return conn, nil
+				return instance, nil
 			},
 			TLSClientConfig: &tls.Config{
 				Time:    ntp.TimeFuncFromContext(ctx),
@@ -811,19 +810,6 @@ func urlTestGET(ctx context.Context, link string, detour N.Dialer) (uint16, erro
 	io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 	return uint16(time.Since(start) / time.Millisecond), nil
-}
-
-// asyncCloseConn wraps a net.Conn whose Close can block for tens of seconds
-// (e.g. WATER's WaitWorker); dispatching to a goroutine prevents stalling the
-// HTTP client's synchronous cancellation path.
-type asyncCloseConn struct {
-	net.Conn
-	closeOnce sync.Once
-}
-
-func (c *asyncCloseConn) Close() error {
-	c.closeOnce.Do(func() { go c.Conn.Close() })
-	return nil
 }
 
 // appendClientDelay adds a &cd=<ms> query parameter to the given URL.

--- a/protocol/group/urltest_test.go
+++ b/protocol/group/urltest_test.go
@@ -122,6 +122,47 @@ func TestURLTestGET_BlockingConnCloseDoesNotBlockReturn(t *testing.T) {
 		"urlTestGET blocked for %v after context expiry; asyncCloseConn should prevent blocking", elapsed)
 }
 
+// TestURLTestGET_BlockingDialContextDoesNotBlockReturn is a regression test for
+// outbounds whose DialContext ignores context cancellation because they block
+// in host-function callbacks that Go's runtime cannot interrupt (e.g. WATER's
+// WASM TCP dial). Before the goroutine-race fix, urlTestGET blocked for the
+// full OS TCP timeout (~87 s) even when the testCtx had already expired.
+//
+// The blocking window is simulated by a dialer that ignores ctx and returns
+// only after released is closed, 3 s after the request context expires.
+// Without the fix, urlTestGET blocks for those 3 s. With the fix, the
+// ctx.Done() select arm fires and urlTestGET returns at ~200 ms.
+func TestURLTestGET_BlockingDialContextDoesNotBlockReturn(t *testing.T) {
+	released := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(released) }) }
+
+	dialer := &stubNetDialer{
+		dialFn: func(ctx context.Context, network string, dest metadata.Socksaddr) (net.Conn, error) {
+			select {
+			case <-released:
+			case <-time.After(10 * time.Second):
+			}
+			return nil, errors.New("never connected")
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	// Release 3 s after the context expires; without the fix urlTestGET blocks for those 3 s.
+	time.AfterFunc(200*time.Millisecond+3*time.Second, release)
+
+	start := time.Now()
+	_, _ = urlTestGET(ctx, "http://192.0.2.1/", dialer)
+	elapsed := time.Since(start)
+
+	release()
+
+	assert.Less(t, elapsed, 2*time.Second,
+		"urlTestGET blocked for %v after context expiry; DialContext goroutine race should prevent blocking", elapsed)
+}
+
 func TestUpdateSelected(t *testing.T) {
 	outbounds := map[string]uint16{
 		"kangaskhan": 36,

--- a/protocol/group/urltest_test.go
+++ b/protocol/group/urltest_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,8 +19,108 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/getlantern/lantern-box/constant"
-	"github.com/getlantern/lantern-box/internal/sync"
+	isync "github.com/getlantern/lantern-box/internal/sync"
 )
+
+// blockingCloseConn wraps a net.Conn whose Close blocks until released is closed.
+// It simulates transports like WATER that call WaitWorker inside Close.
+type blockingCloseConn struct {
+	net.Conn
+	released <-chan struct{}
+}
+
+func (c *blockingCloseConn) Close() error {
+	<-c.released
+	return c.Conn.Close()
+}
+
+type stubNetDialer struct {
+	dialFn func(ctx context.Context, network string, dest metadata.Socksaddr) (net.Conn, error)
+}
+
+func (d *stubNetDialer) DialContext(ctx context.Context, network string, destination metadata.Socksaddr) (net.Conn, error) {
+	return d.dialFn(ctx, network, destination)
+}
+
+func (d *stubNetDialer) ListenPacket(ctx context.Context, destination metadata.Socksaddr) (net.PacketConn, error) {
+	return nil, errors.New("not supported")
+}
+
+func TestAsyncCloseConn_CloseReturnsImmediately(t *testing.T) {
+	released := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-released:
+		default:
+			close(released)
+		}
+	})
+	p1, p2 := net.Pipe()
+	defer p2.Close()
+
+	c := &asyncCloseConn{Conn: &blockingCloseConn{Conn: p1, released: released}}
+	start := time.Now()
+	_ = c.Close()
+	assert.Less(t, time.Since(start), 100*time.Millisecond)
+}
+
+// TestURLTestGET_BlockingConnCloseDoesNotBlockReturn is a regression test for
+// the case where the HTTP transport's context-cancellation path calls
+// conn.Close() synchronously. Before asyncCloseConn was applied to the conn
+// passed to the transport's DialContext, WATER's WaitWorker would block
+// client.Do() for 35–90 s after the test context expired.
+//
+// The blocking window is simulated by keeping released closed for 3 s after
+// the request context expires. Without asyncCloseConn, client.Do blocks for
+// those 3 s, making elapsed > 2 s and the assertion fail. With the fix,
+// Close() dispatches to a goroutine, client.Do returns at ~200 ms, and
+// elapsed stays well under 2 s.
+func TestURLTestGET_BlockingConnCloseDoesNotBlockReturn(t *testing.T) {
+	released := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(released) }) }
+
+	// The server delays its response well beyond the context timeout so the
+	// HTTP transport is forced to cancel and close the conn.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(10 * time.Second):
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	dialer := &stubNetDialer{
+		dialFn: func(ctx context.Context, network string, dest metadata.Socksaddr) (net.Conn, error) {
+			c, err := net.DialTimeout("tcp", srv.Listener.Addr().String(), 2*time.Second)
+			if err != nil {
+				return nil, err
+			}
+			return &blockingCloseConn{Conn: c, released: released}, nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	// Release the blocking conn 3 s after the request context expires.
+	// Without asyncCloseConn, the HTTP transport calls blockingCloseConn.Close()
+	// synchronously inside client.Do, so urlTestGET can't return until released fires.
+	// With the fix, Close() is dispatched to a goroutine and urlTestGET returns at ~200 ms.
+	time.AfterFunc(200*time.Millisecond+3*time.Second, release)
+
+	start := time.Now()
+	_, _ = urlTestGET(ctx, "http://"+srv.Listener.Addr().String()+"/", dialer)
+	elapsed := time.Since(start)
+
+	// Unblock the async-close goroutine before closing the server so the server
+	// handler can exit and srv.Close() returns promptly.
+	release()
+	srv.Close()
+
+	assert.Less(t, elapsed, 2*time.Second,
+		"urlTestGET blocked for %v after context expiry; asyncCloseConn should prevent blocking", elapsed)
+}
 
 func TestUpdateSelected(t *testing.T) {
 	outbounds := map[string]uint16{
@@ -31,7 +134,7 @@ func TestUpdateSelected(t *testing.T) {
 	}
 	testGroup := &urlTestGroup{
 		tags:                []string{},
-		outbounds:           sync.TypedMap[string, adapter.Outbound]{},
+		outbounds:           isync.TypedMap[string, adapter.Outbound]{},
 		tolerance:           50,
 		history:             urltest.NewHistoryStorage(),
 		selectedOutboundTCP: common.TypedValue[adapter.Outbound]{},
@@ -60,7 +163,7 @@ func TestUpdateSelected(t *testing.T) {
 func TestMarkFailedAndReselect_SwitchesToHealthyOutbound(t *testing.T) {
 	g := &urlTestGroup{
 		tags:      []string{},
-		outbounds: sync.TypedMap[string, adapter.Outbound]{},
+		outbounds: isync.TypedMap[string, adapter.Outbound]{},
 		tolerance: 50,
 		history:   urltest.NewHistoryStorage(),
 	}
@@ -119,7 +222,7 @@ func newRetryRig(mode retryMode, ctx context.Context, delays map[string]uint16, 
 	g := &urlTestGroup{
 		ctx:       ctx,
 		logger:    sbLog.NewNOPFactory().Logger(),
-		outbounds: sync.TypedMap[string, adapter.Outbound]{},
+		outbounds: isync.TypedMap[string, adapter.Outbound]{},
 		tolerance: 50,
 		history:   urltest.NewHistoryStorage(),
 	}
@@ -240,7 +343,7 @@ func callCount(m *mockOutbound, method string) int {
 func TestPickBestOutbound_FallbackSkipsCurrent(t *testing.T) {
 	g := &urlTestGroup{
 		tags:      []string{"alpha", "beta"},
-		outbounds: sync.TypedMap[string, adapter.Outbound]{},
+		outbounds: isync.TypedMap[string, adapter.Outbound]{},
 		tolerance: 50,
 		history:   urltest.NewHistoryStorage(),
 	}

--- a/protocol/group/urltest_test.go
+++ b/protocol/group/urltest_test.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"net/http"
-	"net/http/httptest"
-	"sync"
 	"testing"
 	"time"
 
@@ -21,106 +18,6 @@ import (
 	"github.com/getlantern/lantern-box/constant"
 	isync "github.com/getlantern/lantern-box/internal/sync"
 )
-
-// blockingCloseConn wraps a net.Conn whose Close blocks until released is closed.
-// It simulates transports like WATER that call WaitWorker inside Close.
-type blockingCloseConn struct {
-	net.Conn
-	released <-chan struct{}
-}
-
-func (c *blockingCloseConn) Close() error {
-	<-c.released
-	return c.Conn.Close()
-}
-
-type stubNetDialer struct {
-	dialFn func(ctx context.Context, network string, dest metadata.Socksaddr) (net.Conn, error)
-}
-
-func (d *stubNetDialer) DialContext(ctx context.Context, network string, destination metadata.Socksaddr) (net.Conn, error) {
-	return d.dialFn(ctx, network, destination)
-}
-
-func (d *stubNetDialer) ListenPacket(ctx context.Context, destination metadata.Socksaddr) (net.PacketConn, error) {
-	return nil, errors.New("not supported")
-}
-
-func TestAsyncCloseConn_CloseReturnsImmediately(t *testing.T) {
-	released := make(chan struct{})
-	t.Cleanup(func() {
-		select {
-		case <-released:
-		default:
-			close(released)
-		}
-	})
-	p1, p2 := net.Pipe()
-	defer p2.Close()
-
-	c := &asyncCloseConn{Conn: &blockingCloseConn{Conn: p1, released: released}}
-	start := time.Now()
-	_ = c.Close()
-	assert.Less(t, time.Since(start), 100*time.Millisecond)
-}
-
-// TestURLTestGET_BlockingConnCloseDoesNotBlockReturn is a regression test for
-// the case where the HTTP transport's context-cancellation path calls
-// conn.Close() synchronously. Before asyncCloseConn was applied to the conn
-// passed to the transport's DialContext, WATER's WaitWorker would block
-// client.Do() for 35–90 s after the test context expired.
-//
-// The blocking window is simulated by keeping released closed for 3 s after
-// the request context expires. Without asyncCloseConn, client.Do blocks for
-// those 3 s, making elapsed > 2 s and the assertion fail. With the fix,
-// Close() dispatches to a goroutine, client.Do returns at ~200 ms, and
-// elapsed stays well under 2 s.
-func TestURLTestGET_BlockingConnCloseDoesNotBlockReturn(t *testing.T) {
-	released := make(chan struct{})
-	var releaseOnce sync.Once
-	release := func() { releaseOnce.Do(func() { close(released) }) }
-
-	// The server delays its response well beyond the context timeout so the
-	// HTTP transport is forced to cancel and close the conn.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		select {
-		case <-r.Context().Done():
-		case <-time.After(10 * time.Second):
-		}
-		w.WriteHeader(http.StatusNoContent)
-	}))
-
-	dialer := &stubNetDialer{
-		dialFn: func(ctx context.Context, network string, dest metadata.Socksaddr) (net.Conn, error) {
-			c, err := net.DialTimeout("tcp", srv.Listener.Addr().String(), 2*time.Second)
-			if err != nil {
-				return nil, err
-			}
-			return &blockingCloseConn{Conn: c, released: released}, nil
-		},
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer cancel()
-
-	// Release the blocking conn 3 s after the request context expires.
-	// Without asyncCloseConn, the HTTP transport calls blockingCloseConn.Close()
-	// synchronously inside client.Do, so urlTestGET can't return until released fires.
-	// With the fix, Close() is dispatched to a goroutine and urlTestGET returns at ~200 ms.
-	time.AfterFunc(200*time.Millisecond+3*time.Second, release)
-
-	start := time.Now()
-	_, _ = urlTestGET(ctx, "http://"+srv.Listener.Addr().String()+"/", dialer)
-	elapsed := time.Since(start)
-
-	// Unblock the async-close goroutine before closing the server so the server
-	// handler can exit and srv.Close() returns promptly.
-	release()
-	srv.Close()
-
-	assert.Less(t, elapsed, 2*time.Second,
-		"urlTestGET blocked for %v after context expiry; asyncCloseConn should prevent blocking", elapsed)
-}
 
 func TestUpdateSelected(t *testing.T) {
 	outbounds := map[string]uint16{

--- a/protocol/group/urltest_test.go
+++ b/protocol/group/urltest_test.go
@@ -122,47 +122,6 @@ func TestURLTestGET_BlockingConnCloseDoesNotBlockReturn(t *testing.T) {
 		"urlTestGET blocked for %v after context expiry; asyncCloseConn should prevent blocking", elapsed)
 }
 
-// TestURLTestGET_BlockingDialContextDoesNotBlockReturn is a regression test for
-// outbounds whose DialContext ignores context cancellation because they block
-// in host-function callbacks that Go's runtime cannot interrupt (e.g. WATER's
-// WASM TCP dial). Before the goroutine-race fix, urlTestGET blocked for the
-// full OS TCP timeout (~87 s) even when the testCtx had already expired.
-//
-// The blocking window is simulated by a dialer that ignores ctx and returns
-// only after released is closed, 3 s after the request context expires.
-// Without the fix, urlTestGET blocks for those 3 s. With the fix, the
-// ctx.Done() select arm fires and urlTestGET returns at ~200 ms.
-func TestURLTestGET_BlockingDialContextDoesNotBlockReturn(t *testing.T) {
-	released := make(chan struct{})
-	var releaseOnce sync.Once
-	release := func() { releaseOnce.Do(func() { close(released) }) }
-
-	dialer := &stubNetDialer{
-		dialFn: func(ctx context.Context, network string, dest metadata.Socksaddr) (net.Conn, error) {
-			select {
-			case <-released:
-			case <-time.After(10 * time.Second):
-			}
-			return nil, errors.New("never connected")
-		},
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer cancel()
-
-	// Release 3 s after the context expires; without the fix urlTestGET blocks for those 3 s.
-	time.AfterFunc(200*time.Millisecond+3*time.Second, release)
-
-	start := time.Now()
-	_, _ = urlTestGET(ctx, "http://192.0.2.1/", dialer)
-	elapsed := time.Since(start)
-
-	release()
-
-	assert.Less(t, elapsed, 2*time.Second,
-		"urlTestGET blocked for %v after context expiry; DialContext goroutine race should prevent blocking", elapsed)
-}
-
 func TestUpdateSelected(t *testing.T) {
 	outbounds := map[string]uint16{
 		"kangaskhan": 36,

--- a/protocol/water/outbound.go
+++ b/protocol/water/outbound.go
@@ -199,6 +199,24 @@ func (o *Outbound) loadConfig(ctx context.Context, logger log.ContextLogger, opt
 		OverrideLogger:     slogLogger,
 	}
 	o.mu.Unlock()
+
+	// Pre-compile the WASM module to warm up the on-disk compilation cache
+	// before setting ready=true. On platforms like macOS NetworkExtension the
+	// JIT compilation spike can exceed the process memory budget and cause a
+	// silent kill during the first URL-test dial. By doing it here — in the
+	// background goroutine before the TUN is fully up — total memory pressure
+	// is lower and subsequent dials get a cheap cache-hit instead.
+	logger.DebugContext(ctx, "pre-compiling WASM module to warm compilation cache",
+		slog.String("transport", options.Transport))
+	if preErr := preCompileWASM(ctx, b, o.dialerConfig); preErr != nil {
+		logger.WarnContext(ctx, "WASM pre-compilation failed (non-fatal, will compile on first dial)",
+			slog.String("transport", options.Transport),
+			slog.Any("error", preErr))
+	} else {
+		logger.DebugContext(ctx, "WASM pre-compilation complete",
+			slog.String("transport", options.Transport))
+	}
+
 	o.ready.Store(true)
 
 	if options.SeedEnabled {
@@ -237,6 +255,26 @@ func (o *Outbound) Close() error {
 		return o.seeder.Close()
 	}
 	return nil
+}
+
+// preCompileWASM compiles the WASM binary using the same runtime config that
+// live dials will use, writing the result into the on-disk compilation cache.
+// After this returns, every subsequent NewCoreWithContext → CompileModule call
+// gets a cheap cache-hit instead of a full JIT compilation. This is a
+// best-effort operation; callers must handle a non-nil error gracefully.
+func preCompileWASM(ctx context.Context, wasmBin []byte, cfg *water.Config) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("panic during WASM pre-compilation",
+				slog.Any("panic", r),
+				slog.String("stack", string(debug.Stack())))
+			err = fmt.Errorf("WASM pre-compilation panicked: %v", r)
+		}
+	}()
+	rt := wazero.NewRuntimeWithConfig(ctx, cfg.RuntimeConfig().GetConfig())
+	defer rt.Close(ctx)
+	_, err = rt.CompileModule(ctx, wasmBin)
+	return
 }
 
 func (o *Outbound) newDialer(ctx context.Context, destination M.Socksaddr) (water.Dialer, error) {
@@ -306,23 +344,37 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 	return nil, E.New("unsupported network: ", network)
 }
 
-func (o *Outbound) dialTCP(ctx context.Context, destination M.Socksaddr) (net.Conn, error) {
+func (o *Outbound) dialTCP(ctx context.Context, destination M.Socksaddr) (conn net.Conn, err error) {
+	// wazero can panic during WASM core creation or execution; convert to error
+	// so a single bad outbound doesn't crash the daemon process.
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("panic in WATER dial", slog.Any("panic", r), slog.String("stack", string(debug.Stack())))
+			err = fmt.Errorf("WATER dial panicked: %v", r)
+		}
+	}()
+
 	dialer, err := o.newDialer(ctx, destination)
 	if err != nil {
 		o.logger.ErrorContext(ctx, "failed to build new WATER dialer", slog.Any("error", err), slog.String("destination", destination.String()))
 		return nil, err
 	}
 
-	// DialContext uses context.Background() so wazero's wasm execution isn't
-	// interrupted mid-run. Race it against ctx so callers (e.g. URL-test
-	// goroutines with a 5s deadline) aren't blocked for the full OS TCP timeout
-	// if the WASM can't reach the server.
+	// wazero's DialContext does not respect context cancellation mid-run, so
+	// racing it in a goroutine ensures callers with short deadlines (e.g. URL-test)
+	// are not blocked for the full OS TCP timeout when the server is unreachable.
 	type dialResult struct {
 		conn net.Conn
 		err  error
 	}
 	ch := make(chan dialResult, 1)
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("panic in WATER DialContext", slog.Any("panic", r), slog.String("stack", string(debug.Stack())))
+				ch <- dialResult{nil, fmt.Errorf("WATER DialContext panicked: %v", r)}
+			}
+		}()
 		conn, err := dialer.DialContext(ctx, N.NetworkTCP, "localhost:0")
 		ch <- dialResult{conn, err}
 	}()

--- a/protocol/water/outbound.go
+++ b/protocol/water/outbound.go
@@ -212,6 +212,23 @@ func (o *Outbound) loadConfig(ctx context.Context, logger log.ContextLogger, opt
 	// slower, but the bottleneck for a proxy is network I/O, not instruction
 	// throughput, so the tradeoff is acceptable.
 	o.dialerConfig.RuntimeConfig().Interpreter()
+
+	// Disable wazero's CloseOnContextDone behaviour.
+	//
+	// By default water sets WithCloseOnContextDone(true), which tells wazero to
+	// forcibly terminate any in-flight WASM function call the moment the context
+	// passed to NewCoreWithContext is cancelled.  Each WATER dial creates a core
+	// whose context is derived from the per-dial context.  In sing-box a dial
+	// context is cancelled as soon as the dial phase completes (URL tests
+	// included), which is well before the established connection is closed.
+	// With CloseOnContextDone active, that cancellation kills the wazero
+	// runtime while the WASM worker is still running, producing an
+	// "input/output error" from the worker goroutine.
+	//
+	// We disable this and rely instead on conn.Close() to terminate the WASM
+	// worker: closing the underlying TCPConnPair causes the worker's blocking
+	// read/write calls to return with EOF, exiting the worker cleanly.
+	o.dialerConfig.RuntimeConfig().SetCloseOnContextDone(false)
 	o.mu.Unlock()
 
 	// Validate and warm the interpreter by doing a lightweight parse of the

--- a/protocol/water/outbound.go
+++ b/protocol/water/outbound.go
@@ -198,22 +198,32 @@ func (o *Outbound) loadConfig(ctx context.Context, logger log.ContextLogger, opt
 		TransportModuleBin: b,
 		OverrideLogger:     slogLogger,
 	}
+
+	// Use the wazero interpreter instead of the JIT compiler.
+	//
+	// The JIT compiler allocates a large native-code arena at runtime-creation
+	// time (typically 5-20 MB of resident memory on arm64) in addition to
+	// per-instance WASM linear memory.  In memory-constrained environments
+	// such as the macOS or iOS NetworkExtension process (jetsam limit ~50 MB)
+	// this pushes resident memory over the limit and the OS kills the process
+	// silently, manifesting as a VPN disconnect with no Go error or panic.
+	//
+	// The interpreter avoids the JIT arena entirely.  WASM execution is
+	// slower, but the bottleneck for a proxy is network I/O, not instruction
+	// throughput, so the tradeoff is acceptable.
+	o.dialerConfig.RuntimeConfig().Interpreter()
 	o.mu.Unlock()
 
-	// Pre-compile the WASM module to warm up the on-disk compilation cache
-	// before setting ready=true. On platforms like macOS NetworkExtension the
-	// JIT compilation spike can exceed the process memory budget and cause a
-	// silent kill during the first URL-test dial. By doing it here — in the
-	// background goroutine before the TUN is fully up — total memory pressure
-	// is lower and subsequent dials get a cheap cache-hit instead.
-	logger.DebugContext(ctx, "pre-compiling WASM module to warm compilation cache",
+	// Validate and warm the interpreter by doing a lightweight parse of the
+	// WASM module before setting ready=true so any module errors surface early.
+	logger.DebugContext(ctx, "validating WASM module via interpreter",
 		slog.String("transport", options.Transport))
 	if preErr := preCompileWASM(ctx, b, o.dialerConfig); preErr != nil {
-		logger.WarnContext(ctx, "WASM pre-compilation failed (non-fatal, will compile on first dial)",
+		logger.WarnContext(ctx, "WASM module validation failed (non-fatal)",
 			slog.String("transport", options.Transport),
 			slog.Any("error", preErr))
 	} else {
-		logger.DebugContext(ctx, "WASM pre-compilation complete",
+		logger.DebugContext(ctx, "WASM module validation complete",
 			slog.String("transport", options.Transport))
 	}
 
@@ -257,11 +267,12 @@ func (o *Outbound) Close() error {
 	return nil
 }
 
-// preCompileWASM compiles the WASM binary using the same runtime config that
-// live dials will use, writing the result into the on-disk compilation cache.
-// After this returns, every subsequent NewCoreWithContext → CompileModule call
-// gets a cheap cache-hit instead of a full JIT compilation. This is a
-// best-effort operation; callers must handle a non-nil error gracefully.
+// preCompileWASM validates the WASM binary against the provided runtime config
+// by compiling it once.  In interpreter mode (the default for WATER dials) this
+// is a lightweight parse+validate step; in compiler mode it warms the on-disk
+// JIT compilation cache.  Either way this surfaces module-load errors early,
+// before ready is set to true.  It is best-effort; callers must handle a
+// non-nil error gracefully.
 func preCompileWASM(ctx context.Context, wasmBin []byte, cfg *water.Config) (err error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/protocol/water/outbound.go
+++ b/protocol/water/outbound.go
@@ -12,6 +12,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	waterDownloader "github.com/getlantern/lantern-water/downloader"
@@ -53,20 +54,21 @@ type Outbound struct {
 	dialerConfig          *water.Config
 	loadErr               error
 	transportModuleConfig map[string]any
+	outboundDialer        N.Dialer
+	serverAddr            M.Socksaddr
+	ready                 atomic.Bool
 	mu                    sync.Mutex
 	seeder                *seed.Seeder
 	cancelLoad            context.CancelFunc
 	uotClient             *uot.Client
 }
 
-// waterDialer adapts the WATER outbound for use with uot.Client.
-// It must only be called while the outbound mutex is already held.
 type waterDialer struct {
 	outbound *Outbound
 }
 
 func (d *waterDialer) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
-	return d.outbound.dialTCPLocked(ctx, destination)
+	return d.outbound.dialTCP(ctx, destination)
 }
 
 func (d *waterDialer) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
@@ -190,23 +192,14 @@ func (o *Outbound) loadConfig(ctx context.Context, logger log.ContextLogger, opt
 	}
 
 	o.mu.Lock()
+	o.outboundDialer = outboundDialer
+	o.serverAddr = serverAddr
 	o.dialerConfig = &water.Config{
 		TransportModuleBin: b,
 		OverrideLogger:     slogLogger,
-		NetworkDialerFunc: func(network, address string) (net.Conn, error) {
-			conn, err := outboundDialer.DialContext(log.ContextWithNewID(ctx), network, serverAddr)
-			if err != nil {
-				return nil, err
-			}
-			switch conn := conn.(type) {
-			case *conntrack.Conn:
-				return conn.Conn, nil
-			default:
-				return conn, nil
-			}
-		},
 	}
 	o.mu.Unlock()
+	o.ready.Store(true)
 
 	if options.SeedEnabled {
 		transportFilepath := filepath.Join(wasmDir, fmt.Sprintf("%s.%s", options.Transport, "wasm"))
@@ -247,20 +240,46 @@ func (o *Outbound) Close() error {
 }
 
 func (o *Outbound) newDialer(ctx context.Context, destination M.Socksaddr) (water.Dialer, error) {
-	if o.loadErr != nil {
-		return nil, fmt.Errorf("WATER outbound failed to load: %w", o.loadErr)
+	if !o.ready.Load() {
+		o.mu.Lock()
+		loadErr := o.loadErr
+		dialerReady := o.dialerConfig != nil
+		o.mu.Unlock()
+		if loadErr != nil {
+			return nil, fmt.Errorf("WATER outbound failed to load: %w", loadErr)
+		}
+		if !dialerReady {
+			return nil, fmt.Errorf("WATER outbound is still loading, not ready to dial")
+		}
 	}
-	if o.dialerConfig == nil {
-		return nil, fmt.Errorf("WATER outbound is still loading, not ready to dial")
-	}
+
 	cfg := o.dialerConfig.Clone()
+
+	// NetworkDialerFunc is per-dial so it captures ctx; cancelling the dial also cancels the inner TCP connection.
+	cfg.NetworkDialerFunc = func(network, address string) (net.Conn, error) {
+		conn, err := o.outboundDialer.DialContext(ctx, network, o.serverAddr)
+		if err != nil {
+			return nil, err
+		}
+		switch conn := conn.(type) {
+		case *conntrack.Conn:
+			return conn.Conn, nil
+		default:
+			return conn, nil
+		}
+	}
 
 	o.logger.DebugContext(ctx, "building new dialer", slog.String("destination", destination.String()))
 	if o.transportModuleConfig != nil {
-		// currently this is the only way to share the destination with the WATER module.
-		o.transportModuleConfig["remote_addr"] = destination.AddrString()
-		o.transportModuleConfig["remote_port"] = strconv.FormatUint(uint64(destination.Port), 10)
-		transportModuleConfig, err := json.MarshalContext(ctx, o.transportModuleConfig)
+		// Clone before mutating so concurrent dials don't race on the shared map.
+		// WATER's config API provides no other injection point for per-dial parameters.
+		merged := make(map[string]any, len(o.transportModuleConfig)+2)
+		for k, v := range o.transportModuleConfig {
+			merged[k] = v
+		}
+		merged["remote_addr"] = destination.AddrString()
+		merged["remote_port"] = strconv.FormatUint(uint64(destination.Port), 10)
+		transportModuleConfig, err := json.MarshalContext(ctx, merged)
 		if err != nil {
 			return nil, err
 		}
@@ -274,23 +293,20 @@ func (o *Outbound) newDialer(ctx context.Context, destination M.Socksaddr) (wate
 
 // DialContext dials a connection to the specified network and destination.
 func (o *Outbound) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
-	o.mu.Lock()
-	defer o.mu.Unlock()
 	ctx, metadata := adapter.ExtendContext(ctx)
 	metadata.Outbound = o.Tag()
 	metadata.Destination = destination
 
 	switch N.NetworkName(network) {
 	case N.NetworkTCP:
-		return o.dialTCPLocked(ctx, destination)
+		return o.dialTCP(ctx, destination)
 	case N.NetworkUDP:
 		return o.uotClient.DialContext(ctx, network, destination)
 	}
 	return nil, E.New("unsupported network: ", network)
 }
 
-// dialTCPLocked creates a new WATER TCP connection. The outbound mutex must be held by the caller.
-func (o *Outbound) dialTCPLocked(ctx context.Context, destination M.Socksaddr) (net.Conn, error) {
+func (o *Outbound) dialTCP(ctx context.Context, destination M.Socksaddr) (net.Conn, error) {
 	dialer, err := o.newDialer(ctx, destination)
 	if err != nil {
 		o.logger.ErrorContext(ctx, "failed to build new WATER dialer", slog.Any("error", err), slog.String("destination", destination.String()))

--- a/protocol/water/outbound.go
+++ b/protocol/water/outbound.go
@@ -313,13 +313,36 @@ func (o *Outbound) dialTCP(ctx context.Context, destination M.Socksaddr) (net.Co
 		return nil, err
 	}
 
-	conn, err := dialer.DialContext(context.Background(), N.NetworkTCP, "localhost:0")
-	if err != nil {
-		o.logger.ErrorContext(ctx, "WATER failed to dial", slog.Any("error", err))
-		return nil, err
+	// DialContext uses context.Background() so wazero's wasm execution isn't
+	// interrupted mid-run. Race it against ctx so callers (e.g. URL-test
+	// goroutines with a 5s deadline) aren't blocked for the full OS TCP timeout
+	// if the WASM can't reach the server.
+	type dialResult struct {
+		conn net.Conn
+		err  error
 	}
-
-	return waterTransport.NewWATERConnection(conn, destination, o.skipHandshake), nil
+	ch := make(chan dialResult, 1)
+	go func() {
+		conn, err := dialer.DialContext(ctx, N.NetworkTCP, "localhost:0")
+		ch <- dialResult{conn, err}
+	}()
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			o.logger.ErrorContext(ctx, "WATER failed to dial", slog.Any("error", r.err))
+			return nil, r.err
+		}
+		return waterTransport.NewWATERConnection(r.conn, destination, o.skipHandshake), nil
+	case <-ctx.Done():
+		// Drain the background dial when it finishes to avoid leaving an open
+		// server connection unreferenced.
+		go func() {
+			if r := <-ch; r.err == nil && r.conn != nil {
+				r.conn.Close()
+			}
+		}()
+		return nil, ctx.Err()
+	}
 }
 
 // ListenPacket creates a UoT packet connection through the WATER transport.

--- a/protocol/water/outbound.go
+++ b/protocol/water/outbound.go
@@ -325,14 +325,30 @@ func (o *Outbound) newDialer(ctx context.Context, destination M.Socksaddr) (wate
 	cfg.NetworkDialerFunc = func(network, address string) (net.Conn, error) {
 		conn, err := o.outboundDialer.DialContext(ctx, network, o.serverAddr)
 		if err != nil {
+			o.logger.ErrorContext(ctx, "WATER: failed to dial SS server",
+				slog.String("server", o.serverAddr.String()),
+				slog.String("destination", destination.String()),
+				slog.Any("error", err))
 			return nil, err
 		}
-		switch conn := conn.(type) {
+		o.logger.DebugContext(ctx, "WATER: SS server connection established",
+			slog.String("server", o.serverAddr.String()),
+			slog.String("destination", destination.String()))
+		// Wrap conn to log when the server closes the connection.
+		var underlying net.Conn
+		switch c := conn.(type) {
 		case *conntrack.Conn:
-			return conn.Conn, nil
+			underlying = c.Conn
 		default:
-			return conn, nil
+			underlying = conn
 		}
+		return &monitoredConn{
+			Conn:        underlying,
+			logger:      o.logger,
+			ctx:         ctx,
+			server:      o.serverAddr.String(),
+			destination: destination.String(),
+		}, nil
 	}
 
 	o.logger.DebugContext(ctx, "building new dialer", slog.String("destination", destination.String()))
@@ -431,4 +447,44 @@ func (o *Outbound) ListenPacket(ctx context.Context, destination M.Socksaddr) (n
 	metadata.Outbound = o.Tag()
 	metadata.Destination = destination
 	return o.uotClient.ListenPacket(ctx, destination)
+}
+
+// monitoredConn wraps a net.Conn and logs when the connection is closed, to
+// help diagnose cases where the SS server closes the connection unexpectedly
+// before the WASM worker has finished proxying data.
+type monitoredConn struct {
+	net.Conn
+	logger      log.ContextLogger
+	ctx         context.Context
+	server      string
+	destination string
+}
+
+func (c *monitoredConn) Read(b []byte) (int, error) {
+	n, err := c.Conn.Read(b)
+	if err != nil {
+		c.logger.WarnContext(c.ctx, "WATER: SS server connection read error",
+			slog.String("server", c.server),
+			slog.String("destination", c.destination),
+			slog.Any("error", err))
+	}
+	return n, err
+}
+
+func (c *monitoredConn) Write(b []byte) (int, error) {
+	n, err := c.Conn.Write(b)
+	if err != nil {
+		c.logger.WarnContext(c.ctx, "WATER: SS server connection write error",
+			slog.String("server", c.server),
+			slog.String("destination", c.destination),
+			slog.Any("error", err))
+	}
+	return n, err
+}
+
+func (c *monitoredConn) Close() error {
+	c.logger.DebugContext(c.ctx, "WATER: SS server connection closed",
+		slog.String("server", c.server),
+		slog.String("destination", c.destination))
+	return c.Conn.Close()
 }

--- a/protocol/water/outbound.go
+++ b/protocol/water/outbound.go
@@ -388,41 +388,14 @@ func (o *Outbound) dialTCP(ctx context.Context, destination M.Socksaddr) (conn n
 		return nil, err
 	}
 
-	// wazero's DialContext does not respect context cancellation mid-run, so
-	// racing it in a goroutine ensures callers with short deadlines (e.g. URL-test)
-	// are not blocked for the full OS TCP timeout when the server is unreachable.
-	type dialResult struct {
-		conn net.Conn
-		err  error
+	// NetworkDialerFunc (called inside dialer.DialContext during Initialize/_start)
+	// uses the caller's ctx, so context cancellation unblocks the dial naturally.
+	conn, err = dialer.DialContext(ctx, N.NetworkTCP, "localhost:0")
+	if err != nil {
+		o.logger.ErrorContext(ctx, "WATER failed to dial", slog.Any("error", err))
+		return nil, err
 	}
-	ch := make(chan dialResult, 1)
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				slog.Error("panic in WATER DialContext", slog.Any("panic", r), slog.String("stack", string(debug.Stack())))
-				ch <- dialResult{nil, fmt.Errorf("WATER DialContext panicked: %v", r)}
-			}
-		}()
-		conn, err := dialer.DialContext(ctx, N.NetworkTCP, "localhost:0")
-		ch <- dialResult{conn, err}
-	}()
-	select {
-	case r := <-ch:
-		if r.err != nil {
-			o.logger.ErrorContext(ctx, "WATER failed to dial", slog.Any("error", r.err))
-			return nil, r.err
-		}
-		return waterTransport.NewWATERConnection(r.conn, destination, o.skipHandshake), nil
-	case <-ctx.Done():
-		// Drain the background dial when it finishes to avoid leaving an open
-		// server connection unreferenced.
-		go func() {
-			if r := <-ch; r.err == nil && r.conn != nil {
-				r.conn.Close()
-			}
-		}()
-		return nil, ctx.Err()
-	}
+	return waterTransport.NewWATERConnection(conn, destination, o.skipHandshake), nil
 }
 
 // ListenPacket creates a UoT packet connection through the WATER transport.

--- a/protocol/water/outbound.go
+++ b/protocol/water/outbound.go
@@ -12,7 +12,6 @@ import (
 	"runtime/debug"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	waterDownloader "github.com/getlantern/lantern-water/downloader"
@@ -56,7 +55,6 @@ type Outbound struct {
 	transportModuleConfig map[string]any
 	outboundDialer        N.Dialer
 	serverAddr            M.Socksaddr
-	ready                 atomic.Bool
 	mu                    sync.Mutex
 	seeder                *seed.Seeder
 	cancelLoad            context.CancelFunc
@@ -108,7 +106,6 @@ func NewOutbound(ctx context.Context, router adapter.Router, logger log.ContextL
 		Adapter:               outbound.NewAdapterWithDialerOptions(constant.TypeWATER, tag, []string{N.NetworkTCP, N.NetworkUDP}, options.DialerOptions),
 		logger:                logger,
 		transportModuleConfig: options.Config,
-		mu:                    sync.Mutex{},
 		skipHandshake:         options.SkipHandshake,
 		cancelLoad:            cancelLoad,
 	}
@@ -232,7 +229,7 @@ func (o *Outbound) loadConfig(ctx context.Context, logger log.ContextLogger, opt
 	o.mu.Unlock()
 
 	// Validate and warm the interpreter by doing a lightweight parse of the
-	// WASM module before setting ready=true so any module errors surface early.
+	// WASM module so any module errors surface early.
 	logger.DebugContext(ctx, "validating WASM module via interpreter",
 		slog.String("transport", options.Transport))
 	if preErr := preCompileWASM(ctx, b, o.dialerConfig); preErr != nil {
@@ -243,8 +240,6 @@ func (o *Outbound) loadConfig(ctx context.Context, logger log.ContextLogger, opt
 		logger.DebugContext(ctx, "WASM module validation complete",
 			slog.String("transport", options.Transport))
 	}
-
-	o.ready.Store(true)
 
 	if options.SeedEnabled {
 		transportFilepath := filepath.Join(wasmDir, fmt.Sprintf("%s.%s", options.Transport, "wasm"))
@@ -287,9 +282,8 @@ func (o *Outbound) Close() error {
 // preCompileWASM validates the WASM binary against the provided runtime config
 // by compiling it once.  In interpreter mode (the default for WATER dials) this
 // is a lightweight parse+validate step; in compiler mode it warms the on-disk
-// JIT compilation cache.  Either way this surfaces module-load errors early,
-// before ready is set to true.  It is best-effort; callers must handle a
-// non-nil error gracefully.
+// JIT compilation cache.  Either way this surfaces module-load errors early.
+// It is best-effort; callers must handle a non-nil error gracefully.
 func preCompileWASM(ctx context.Context, wasmBin []byte, cfg *water.Config) (err error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/protocol/water/outbound.go
+++ b/protocol/water/outbound.go
@@ -325,30 +325,14 @@ func (o *Outbound) newDialer(ctx context.Context, destination M.Socksaddr) (wate
 	cfg.NetworkDialerFunc = func(network, address string) (net.Conn, error) {
 		conn, err := o.outboundDialer.DialContext(ctx, network, o.serverAddr)
 		if err != nil {
-			o.logger.ErrorContext(ctx, "WATER: failed to dial SS server",
-				slog.String("server", o.serverAddr.String()),
-				slog.String("destination", destination.String()),
-				slog.Any("error", err))
 			return nil, err
 		}
-		o.logger.DebugContext(ctx, "WATER: SS server connection established",
-			slog.String("server", o.serverAddr.String()),
-			slog.String("destination", destination.String()))
-		// Wrap conn to log when the server closes the connection.
-		var underlying net.Conn
-		switch c := conn.(type) {
+		switch conn := conn.(type) {
 		case *conntrack.Conn:
-			underlying = c.Conn
+			return conn.Conn, nil
 		default:
-			underlying = conn
+			return conn, nil
 		}
-		return &monitoredConn{
-			Conn:        underlying,
-			logger:      o.logger,
-			ctx:         ctx,
-			server:      o.serverAddr.String(),
-			destination: destination.String(),
-		}, nil
 	}
 
 	o.logger.DebugContext(ctx, "building new dialer", slog.String("destination", destination.String()))
@@ -447,44 +431,4 @@ func (o *Outbound) ListenPacket(ctx context.Context, destination M.Socksaddr) (n
 	metadata.Outbound = o.Tag()
 	metadata.Destination = destination
 	return o.uotClient.ListenPacket(ctx, destination)
-}
-
-// monitoredConn wraps a net.Conn and logs when the connection is closed, to
-// help diagnose cases where the SS server closes the connection unexpectedly
-// before the WASM worker has finished proxying data.
-type monitoredConn struct {
-	net.Conn
-	logger      log.ContextLogger
-	ctx         context.Context
-	server      string
-	destination string
-}
-
-func (c *monitoredConn) Read(b []byte) (int, error) {
-	n, err := c.Conn.Read(b)
-	if err != nil {
-		c.logger.WarnContext(c.ctx, "WATER: SS server connection read error",
-			slog.String("server", c.server),
-			slog.String("destination", c.destination),
-			slog.Any("error", err))
-	}
-	return n, err
-}
-
-func (c *monitoredConn) Write(b []byte) (int, error) {
-	n, err := c.Conn.Write(b)
-	if err != nil {
-		c.logger.WarnContext(c.ctx, "WATER: SS server connection write error",
-			slog.String("server", c.server),
-			slog.String("destination", c.destination),
-			slog.Any("error", err))
-	}
-	return n, err
-}
-
-func (c *monitoredConn) Close() error {
-	c.logger.DebugContext(c.ctx, "WATER: SS server connection closed",
-		slog.String("server", c.server),
-		slog.String("destination", c.destination))
-	return c.Conn.Close()
 }

--- a/protocol/water/outbound.go
+++ b/protocol/water/outbound.go
@@ -306,24 +306,26 @@ func preCompileWASM(ctx context.Context, wasmBin []byte, cfg *water.Config) (err
 }
 
 func (o *Outbound) newDialer(ctx context.Context, destination M.Socksaddr) (water.Dialer, error) {
-	if !o.ready.Load() {
-		o.mu.Lock()
-		loadErr := o.loadErr
-		dialerReady := o.dialerConfig != nil
-		o.mu.Unlock()
-		if loadErr != nil {
-			return nil, fmt.Errorf("WATER outbound failed to load: %w", loadErr)
-		}
-		if !dialerReady {
-			return nil, fmt.Errorf("WATER outbound is still loading, not ready to dial")
-		}
+	o.mu.Lock()
+	loadErr := o.loadErr
+	dialerCfg := o.dialerConfig
+	outboundDialer := o.outboundDialer
+	serverAddr := o.serverAddr
+	transportModuleConfig := o.transportModuleConfig
+	o.mu.Unlock()
+
+	if loadErr != nil {
+		return nil, fmt.Errorf("WATER outbound failed to load: %w", loadErr)
+	}
+	if dialerCfg == nil {
+		return nil, fmt.Errorf("WATER outbound is still loading, not ready to dial")
 	}
 
-	cfg := o.dialerConfig.Clone()
+	cfg := dialerCfg.Clone()
 
 	// NetworkDialerFunc is per-dial so it captures ctx; cancelling the dial also cancels the inner TCP connection.
 	cfg.NetworkDialerFunc = func(network, address string) (net.Conn, error) {
-		conn, err := o.outboundDialer.DialContext(ctx, network, o.serverAddr)
+		conn, err := outboundDialer.DialContext(ctx, network, serverAddr)
 		if err != nil {
 			return nil, err
 		}
@@ -336,22 +338,22 @@ func (o *Outbound) newDialer(ctx context.Context, destination M.Socksaddr) (wate
 	}
 
 	o.logger.DebugContext(ctx, "building new dialer", slog.String("destination", destination.String()))
-	if o.transportModuleConfig != nil {
+	if transportModuleConfig != nil {
 		// Clone before mutating so concurrent dials don't race on the shared map.
 		// WATER's config API provides no other injection point for per-dial parameters.
-		merged := make(map[string]any, len(o.transportModuleConfig)+2)
-		for k, v := range o.transportModuleConfig {
+		merged := make(map[string]any, len(transportModuleConfig)+2)
+		for k, v := range transportModuleConfig {
 			merged[k] = v
 		}
 		merged["remote_addr"] = destination.AddrString()
 		merged["remote_port"] = strconv.FormatUint(uint64(destination.Port), 10)
-		transportModuleConfig, err := json.MarshalContext(ctx, merged)
+		transportModuleConfigJSON, err := json.MarshalContext(ctx, merged)
 		if err != nil {
 			return nil, err
 		}
 
-		o.logger.DebugContext(ctx, "building transport module config", slog.String("config_json", string(transportModuleConfig)))
-		cfg.TransportModuleConfig = water.TransportModuleConfigFromBytes(transportModuleConfig)
+		o.logger.DebugContext(ctx, "building transport module config", slog.String("config_json", string(transportModuleConfigJSON)))
+		cfg.TransportModuleConfig = water.TransportModuleConfigFromBytes(transportModuleConfigJSON)
 	}
 
 	return water.NewDialerWithContext(ctx, cfg)

--- a/protocol/water/outbound.go
+++ b/protocol/water/outbound.go
@@ -196,35 +196,16 @@ func (o *Outbound) loadConfig(ctx context.Context, logger log.ContextLogger, opt
 		OverrideLogger:     slogLogger,
 	}
 
-	// Use the wazero interpreter instead of the JIT compiler.
-	//
-	// The JIT compiler allocates a large native-code arena at runtime-creation
-	// time (typically 5-20 MB of resident memory on arm64) in addition to
-	// per-instance WASM linear memory.  In memory-constrained environments
-	// such as the macOS or iOS NetworkExtension process (jetsam limit ~50 MB)
-	// this pushes resident memory over the limit and the OS kills the process
-	// silently, manifesting as a VPN disconnect with no Go error or panic.
-	//
-	// The interpreter avoids the JIT arena entirely.  WASM execution is
-	// slower, but the bottleneck for a proxy is network I/O, not instruction
-	// throughput, so the tradeoff is acceptable.
+	// Use the interpreter, not the JIT. The JIT arena (5-20 MB on arm64) pushes
+	// the macOS/iOS NetworkExtension past its ~50 MB jetsam limit and the OS
+	// kills the process silently. Interpreted WASM is slower, but the proxy
+	// bottleneck is network I/O.
 	o.dialerConfig.RuntimeConfig().Interpreter()
 
-	// Disable wazero's CloseOnContextDone behaviour.
-	//
-	// By default water sets WithCloseOnContextDone(true), which tells wazero to
-	// forcibly terminate any in-flight WASM function call the moment the context
-	// passed to NewCoreWithContext is cancelled.  Each WATER dial creates a core
-	// whose context is derived from the per-dial context.  In sing-box a dial
-	// context is cancelled as soon as the dial phase completes (URL tests
-	// included), which is well before the established connection is closed.
-	// With CloseOnContextDone active, that cancellation kills the wazero
-	// runtime while the WASM worker is still running, producing an
-	// "input/output error" from the worker goroutine.
-	//
-	// We disable this and rely instead on conn.Close() to terminate the WASM
-	// worker: closing the underlying TCPConnPair causes the worker's blocking
-	// read/write calls to return with EOF, exiting the worker cleanly.
+	// Don't tie the WASM worker's lifetime to the dial ctx. sing-box cancels
+	// the dial ctx as soon as the dial phase completes — well before the conn
+	// closes — so the default tears down the worker mid-stream, surfacing as
+	// "input/output error". Shutdown is driven by conn.Close() instead.
 	o.dialerConfig.RuntimeConfig().SetCloseOnContextDone(false)
 	o.mu.Unlock()
 
@@ -369,10 +350,14 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 }
 
 func (o *Outbound) dialTCP(ctx context.Context, destination M.Socksaddr) (conn net.Conn, err error) {
+	var rawConn net.Conn
 	// wazero can panic during WASM core creation or execution; convert to error
 	// so a single bad outbound doesn't crash the daemon process.
 	defer func() {
 		if r := recover(); r != nil {
+			if rawConn != nil {
+				rawConn.Close()
+			}
 			slog.Error("panic in WATER dial", slog.Any("panic", r), slog.String("stack", string(debug.Stack())))
 			err = fmt.Errorf("WATER dial panicked: %v", r)
 		}
@@ -386,12 +371,25 @@ func (o *Outbound) dialTCP(ctx context.Context, destination M.Socksaddr) (conn n
 
 	// NetworkDialerFunc (called inside dialer.DialContext during Initialize/_start)
 	// uses the caller's ctx, so context cancellation unblocks the dial naturally.
-	conn, err = dialer.DialContext(ctx, N.NetworkTCP, "localhost:0")
+	rawConn, err = dialer.DialContext(ctx, N.NetworkTCP, "localhost:0")
 	if err != nil {
 		o.logger.ErrorContext(ctx, "WATER failed to dial", slog.Any("error", err))
 		return nil, err
 	}
-	return waterTransport.NewWATERConnection(conn, destination, o.skipHandshake), nil
+	return &asyncCloseConn{Conn: waterTransport.NewWATERConnection(rawConn, destination, o.skipHandshake)}, nil
+}
+
+// asyncCloseConn wraps a net.Conn whose Close can block (e.g. WATER's
+// WaitWorker); dispatching to a goroutine prevents stalling callers on the
+// synchronous cancellation path.
+type asyncCloseConn struct {
+	net.Conn
+	closeOnce sync.Once
+}
+
+func (c *asyncCloseConn) Close() error {
+	c.closeOnce.Do(func() { go c.Conn.Close() })
+	return nil
 }
 
 // ListenPacket creates a UoT packet connection through the WATER transport.


### PR DESCRIPTION
When using a WATER outbound on macOS, the VPN would silently disconnect ~1 second after connecting with no Go errors or panics. The root cause was the macOS NetworkExtension process (jetsam limit ~50 MB) being killed by the OS due to excessive memory use.

 Each dial called water.NewDialerWithContext → wazero.NewRuntimeWithConfig, which allocates a 5–20 MB native JIT arena on arm64. Under concurrent URL tests and active connections, cumulative allocations pushed the process over the jetsam limit.

A second issue caused every connection to fail with input/output error: water's default WithCloseOnContextDone(true) configuration was killing the WASM worker when sing-box cancelled the per-dial context (which happens as soon as the dial phase completes, well before the connection closes).

  Changes

   - protocol/water/outbound.go
    - Switch wazero to interpreter mode (RuntimeConfig().Interpreter()) — eliminates the JIT arena entirely, reducing engine overhead from ~15 MB to ~0.5 MB per dial
    - Disable CloseOnContextDone so the WASM worker is only terminated by conn.Close(), not by dial-context cancellation
    - Fix data race in newDialer: snapshot dialerConfig, outboundDialer, serverAddr and transportModuleConfig under o.mu before use
    - Remove the now-unnecessary goroutine wrapper in dialTCP — context cancellation unblocks the dial naturally via NetworkDialerFunc


Part of getlantern/engineering#3095