### PR TITLE
[draft] mitm-df: outbound (TLS termination, fronts table, audit log)

### DIFF
--- a/constant/proxy.go
+++ b/constant/proxy.go
@@ -3,6 +3,7 @@ package constant
 const (
 	TypeAmnezia   = "amnezia"
 	TypeALGeneva  = "algeneva"
+	TypeMITMDF    = "mitm-df"
 	TypeOutline   = "outline"
 	TypeReflex    = "reflex"
 	TypeSamizdat  = "samizdat"

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb
 	github.com/gobwas/ws v1.4.0
 	github.com/pion/transport/v4 v4.0.1
+	github.com/refraction-networking/utls v1.8.2
 	github.com/refraction-networking/water v0.7.1-alpha
 	github.com/sagernet/sing v0.7.18
 	github.com/sagernet/sing-box v1.12.22
@@ -223,7 +224,6 @@ require (
 	github.com/protolambda/ctxlock v0.1.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect
-	github.com/refraction-networking/utls v1.8.2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rs/dnscache v0.0.0-20211102005908-e0241e321417 // indirect
 	github.com/safchain/ethtool v0.3.0 // indirect

--- a/option/mitmdf.go
+++ b/option/mitmdf.go
@@ -1,0 +1,106 @@
+package option
+
+import "github.com/sagernet/sing-box/option"
+
+// MITMDFOutboundOptions configures a MITM-DomainFronting outbound.
+//
+// On dial, the outbound terminates the user's TLS handshake using a leaf
+// certificate minted on the fly by a name-constrained local CA (see
+// internal/mitmca), looks up the user's SNI against the configured fronts
+// table, and dials the matching front through the embedded sing-box
+// dialer. The egress connection is wrapped with uTLS using the configured
+// fingerprint preset, the front's SNI, and the user's negotiated ALPN.
+// Plaintext is bridged between the two TLS sides.
+//
+// Security properties — see docs/mitm-df/architecture.md and
+// getlantern/engineering#3482 for the full rationale:
+//
+//   - The CA carries an RFC 5280 NameConstraints extension restricting
+//     which DNS subtrees it can sign for. Even if the CA private key is
+//     extracted, a cert for chase.com cannot be forged.
+//   - The outbound never listens on a TCP port; the user side of every
+//     MITM session is an in-memory net.Pipe.
+//   - A deny list (DenyDomains) is enforced in the GetCertificate
+//     callback before any signature is produced — defense in depth for
+//     misrouted or maliciously-influenced flows.
+//   - Every mint is recorded to an audit log (AuditLogPath).
+//
+// The user device must trust the CA out-of-band for the user-side TLS
+// handshake to succeed.
+type MITMDFOutboundOptions struct {
+	option.DialerOptions
+	option.ServerOptions
+
+	// CA configures the name-constrained signing CA. On first run with
+	// missing files at CertPath/KeyPath, a fresh CA scoped to
+	// PermittedDomains is generated and persisted. On subsequent runs the
+	// existing CA is loaded and its PermittedDNSDomains is checked against
+	// the configured PermittedDomains (loads that don't cover the configured
+	// list are refused — downgrade protection).
+	CA MITMDFCAOptions `json:"ca"`
+
+	// Fronts maps user SNIs onto fronted destinations. The matcher is a
+	// suffix-aware exact match against FrontEntry.Names: an SNI matches an
+	// entry if it equals one of Names or has one of Names as a `.foo` DNS
+	// suffix. Entries are evaluated in order and the first match wins.
+	Fronts []MITMDFFrontEntry `json:"fronts"`
+
+	// DenyDomains are SNIs (exact or `.suffix` match, same semantics as
+	// Fronts.Names) that the outbound refuses to MITM regardless of any
+	// fronts match. Enforced in the GetCertificate callback before signing.
+	// Use for sensitive categories (banking, healthcare, government) that
+	// the route layer should never have sent here in the first place.
+	DenyDomains []string `json:"deny_domains,omitempty"`
+
+	// AuditLogPath is the path of an append-only JSONL audit log. Every
+	// MITM decision (allow, deny, no-match) is recorded with timestamp,
+	// SNI, fronted SNI, and decision. Empty disables auditing.
+	AuditLogPath string `json:"audit_log_path,omitempty"`
+
+	// Fingerprint selects the uTLS ClientHello preset for the egress
+	// handshake. One of: "chrome" (default), "firefox", "safari", "random".
+	Fingerprint string `json:"fingerprint,omitempty"`
+
+	// EgressHandshakeTimeout bounds both the user-side tls.Server handshake
+	// and the egress uTLS handshake, parseable by time.ParseDuration.
+	// Defaults to "10s".
+	EgressHandshakeTimeout string `json:"egress_handshake_timeout,omitempty"`
+}
+
+// MITMDFCAOptions configures the per-device signing CA. CertPath and
+// KeyPath are the persistence locations; PermittedDomains is the
+// NameConstraints subtree list cryptographically encoded into the cert.
+type MITMDFCAOptions struct {
+	CertPath         string   `json:"cert_path"`
+	KeyPath          string   `json:"key_path"`
+	PermittedDomains []string `json:"permitted_domains"`
+	// Validity, in time.ParseDuration form. Defaults to 30 days when empty.
+	// Only consulted at CA generation; ignored when reloading an existing CA.
+	Validity string `json:"validity,omitempty"`
+}
+
+// MITMDFFrontEntry maps a set of user-side SNIs to a single fronted
+// destination on egress.
+type MITMDFFrontEntry struct {
+	// Names is the SNI list this front handles. Matched as exact equality
+	// or as a `.suffix` DNS subtree of the user's SNI.
+	Names []string `json:"names"`
+
+	// FrontedSNI is the SNI presented to the CDN edge on the egress TLS
+	// handshake. Required.
+	FrontedSNI string `json:"fronted_sni"`
+
+	// VerifySAN, when non-empty, broadens egress cert validation to accept
+	// the peer leaf if it is valid for FrontedSNI OR any of these DNS
+	// names. Emulates Xray's verifyPeerCertByName. Use when the CDN serves
+	// a shared cert covering many names but the user's destination is one
+	// of those secondary names (Vercel / Fastly typical case).
+	VerifySAN []string `json:"verify_san,omitempty"`
+
+	// RedirectAddr is an optional "host:port" overriding the egress dial
+	// target. If empty, the outbound dials the destination handed to it by
+	// the router (the user's intended host as resolved). Typical use:
+	// dial the front's real backend (`nextjs.org:443`) while preserving the
+	// inner Host header.
+	RedirectAddr string `json:"redirect_addr,omitempty"`
+}

--- a/protocol/mitmdf/audit.go
+++ b/protocol/mitmdf/audit.go
@@ -1,0 +1,79 @@
+package mitmdf
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// auditDecision is one of the fixed verdicts recorded in the audit log.
+type auditDecision string
+
+const (
+	auditAllow   auditDecision = "allow"    // a leaf was minted and the egress was attempted
+	auditDeny    auditDecision = "deny"     // deny list matched; no mint
+	auditNoMatch auditDecision = "no-match" // no fronts entry claimed the SNI; no mint
+	auditError   auditDecision = "error"    // mint or egress failed; recorded for forensics
+)
+
+// auditRecord is the JSONL line schema. Stable on-disk; new fields must be
+// added with `omitempty` so old log readers don't reject them.
+type auditRecord struct {
+	Timestamp  time.Time     `json:"ts"`
+	SNI        string        `json:"sni"`
+	FrontedSNI string        `json:"fronted_sni,omitempty"`
+	Decision   auditDecision `json:"decision"`
+	Reason     string        `json:"reason,omitempty"`
+}
+
+// auditLog is an append-only JSONL writer. nil receiver methods are safe
+// no-ops so callers can use a single code path whether or not auditing is
+// configured.
+type auditLog struct {
+	mu sync.Mutex
+	f  *os.File
+}
+
+// openAuditLog opens (or creates) path for append at mode 0600. Returns
+// nil, nil if path is empty (caller may disable auditing by leaving the
+// config field unset).
+func openAuditLog(path string) (*auditLog, error) {
+	if path == "" {
+		return nil, nil
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("audit log open %s: %w", path, err)
+	}
+	return &auditLog{f: f}, nil
+}
+
+// record writes one JSONL line under the file lock. Write errors are
+// dropped on the floor — the audit log is best-effort by design: a full
+// disk or a slow fsync must not block real traffic.
+func (a *auditLog) record(r auditRecord) {
+	if a == nil {
+		return
+	}
+	r.Timestamp = time.Now().UTC()
+	buf, err := json.Marshal(r)
+	if err != nil {
+		return
+	}
+	buf = append(buf, '\n')
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	_, _ = a.f.Write(buf)
+}
+
+// close releases the underlying file. Safe on nil.
+func (a *auditLog) close() error {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.f.Close()
+}

--- a/protocol/mitmdf/audit_test.go
+++ b/protocol/mitmdf/audit_test.go
@@ -1,0 +1,104 @@
+package mitmdf
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestOpenAuditLog_DisabledWhenEmpty(t *testing.T) {
+	a, err := openAuditLog("")
+	if err != nil {
+		t.Fatalf("openAuditLog(\"\"): %v", err)
+	}
+	if a != nil {
+		t.Error("openAuditLog(\"\") returned a non-nil log; want nil for disabled")
+	}
+	// nil-safe ops.
+	a.record(auditRecord{SNI: "x"})
+	if err := a.close(); err != nil {
+		t.Errorf("nil.close: %v", err)
+	}
+}
+
+func TestAuditLog_WritesJSONL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.log")
+	a, err := openAuditLog(path)
+	if err != nil {
+		t.Fatalf("openAuditLog: %v", err)
+	}
+	defer a.close()
+
+	a.record(auditRecord{SNI: "vercel.app", FrontedSNI: "nextjs.org", Decision: auditAllow})
+	a.record(auditRecord{SNI: "chase.com", Decision: auditDeny, Reason: "deny list"})
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	var got []auditRecord
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var r auditRecord
+		if err := json.Unmarshal(sc.Bytes(), &r); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		got = append(got, r)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d records, want 2", len(got))
+	}
+	if got[0].SNI != "vercel.app" || got[0].FrontedSNI != "nextjs.org" || got[0].Decision != auditAllow {
+		t.Errorf("record[0] = %+v", got[0])
+	}
+	if got[1].Decision != auditDeny || got[1].Reason != "deny list" {
+		t.Errorf("record[1] = %+v", got[1])
+	}
+	for i, r := range got {
+		if r.Timestamp.IsZero() {
+			t.Errorf("record[%d] missing timestamp", i)
+		}
+	}
+}
+
+func TestAuditLog_ConcurrentWrites(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.log")
+	a, err := openAuditLog(path)
+	if err != nil {
+		t.Fatalf("openAuditLog: %v", err)
+	}
+	defer a.close()
+
+	const N = 50
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			a.record(auditRecord{SNI: "x.test", Decision: auditAllow})
+		}()
+	}
+	wg.Wait()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	count := 0
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var r auditRecord
+		if err := json.Unmarshal(sc.Bytes(), &r); err != nil {
+			t.Fatalf("line %d unmarshal: %v", count+1, err)
+		}
+		count++
+	}
+	if count != N {
+		t.Errorf("got %d records, want %d", count, N)
+	}
+}

--- a/protocol/mitmdf/fronts.go
+++ b/protocol/mitmdf/fronts.go
@@ -1,0 +1,134 @@
+package mitmdf
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/getlantern/lantern-box/option"
+)
+
+// frontEntry is the runtime form of a configured fronts-table row. The
+// names list has been lowercased + trimmed; matching is suffix-aware DNS
+// equality (an SNI matches if it equals a name or has a name as a `.foo`
+// suffix).
+type frontEntry struct {
+	names        []string
+	frontedSNI   string
+	verifySAN    []string // lowercased
+	redirectAddr string   // "" means dial the user's destination
+}
+
+// fronts is an ordered list of frontEntry rows. lookup returns the first
+// entry that claims the given SNI, or nil if none match. Order matters:
+// place more-specific entries first.
+type fronts []*frontEntry
+
+// buildFronts parses the configured fronts table into normalized
+// frontEntry rows. Returns a deny list of unique names referenced across
+// all entries (used by the outbound to validate destination metadata).
+func buildFronts(in []option.MITMDFFrontEntry) (fronts, error) {
+	if len(in) == 0 {
+		return nil, errors.New("mitmdf: fronts table is empty")
+	}
+	out := make(fronts, 0, len(in))
+	for i, e := range in {
+		if e.FrontedSNI == "" {
+			return nil, fmt.Errorf("mitmdf: fronts[%d]: fronted_sni is required", i)
+		}
+		if len(e.Names) == 0 {
+			return nil, fmt.Errorf("mitmdf: fronts[%d]: names list is empty", i)
+		}
+		entry := &frontEntry{
+			frontedSNI:   strings.ToLower(strings.TrimSpace(e.FrontedSNI)),
+			redirectAddr: strings.TrimSpace(e.RedirectAddr),
+		}
+		seen := make(map[string]struct{}, len(e.Names))
+		for _, n := range e.Names {
+			n = normalizeDNS(n)
+			if n == "" {
+				return nil, fmt.Errorf("mitmdf: fronts[%d]: names contains an empty entry", i)
+			}
+			if _, dup := seen[n]; dup {
+				continue
+			}
+			seen[n] = struct{}{}
+			entry.names = append(entry.names, n)
+		}
+		for _, s := range e.VerifySAN {
+			if s = normalizeDNS(s); s != "" {
+				entry.verifySAN = append(entry.verifySAN, s)
+			}
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+// lookup returns the first front entry that claims sni, or nil.
+func (f fronts) lookup(sni string) *frontEntry {
+	sni = normalizeDNS(sni)
+	if sni == "" {
+		return nil
+	}
+	for _, e := range f {
+		if e.matches(sni) {
+			return e
+		}
+	}
+	return nil
+}
+
+// matches is true when sni equals a configured name or is a strict
+// subdomain (has the configured name as a `.foo` suffix). Caller must
+// pass an already-normalized sni.
+func (e *frontEntry) matches(sni string) bool {
+	for _, n := range e.names {
+		if sni == n || strings.HasSuffix(sni, "."+n) {
+			return true
+		}
+	}
+	return false
+}
+
+// denyMatch reports whether sni is covered by any of the names in deny
+// (same exact-or-suffix semantics as frontEntry.matches). Caller passes
+// already-normalized sni; deny entries are normalized at build time.
+func denyMatch(deny []string, sni string) bool {
+	sni = normalizeDNS(sni)
+	for _, d := range deny {
+		if sni == d || strings.HasSuffix(sni, "."+d) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeDeny lowercases + trims a configured deny list, drops empties
+// and duplicates. Returns nil for an empty input.
+func normalizeDeny(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, n := range in {
+		n = normalizeDNS(n)
+		if n == "" {
+			continue
+		}
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+	}
+	return out
+}
+
+// normalizeDNS lowercases, trims surrounding whitespace, and strips a
+// single trailing dot from a DNS name. Returns "" for non-names.
+func normalizeDNS(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	return strings.TrimSuffix(s, ".")
+}

--- a/protocol/mitmdf/fronts_test.go
+++ b/protocol/mitmdf/fronts_test.go
@@ -1,0 +1,159 @@
+package mitmdf
+
+import (
+	"testing"
+
+	"github.com/getlantern/lantern-box/option"
+)
+
+func TestBuildFronts_Validation(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []option.MITMDFFrontEntry
+		err  bool
+	}{
+		{
+			name: "empty list",
+			in:   nil,
+			err:  true,
+		},
+		{
+			name: "missing fronted_sni",
+			in:   []option.MITMDFFrontEntry{{Names: []string{"a.com"}}},
+			err:  true,
+		},
+		{
+			name: "empty names",
+			in:   []option.MITMDFFrontEntry{{FrontedSNI: "front.test"}},
+			err:  true,
+		},
+		{
+			name: "empty name entry",
+			in:   []option.MITMDFFrontEntry{{Names: []string{""}, FrontedSNI: "front.test"}},
+			err:  true,
+		},
+		{
+			name: "valid single",
+			in: []option.MITMDFFrontEntry{
+				{Names: []string{"vercel.app", "vercel.com"}, FrontedSNI: "nextjs.org"},
+			},
+			err: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildFronts(tc.in)
+			if tc.err && err == nil {
+				t.Fatal("want error, got nil")
+			}
+			if !tc.err && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestBuildFronts_Normalizes(t *testing.T) {
+	f, err := buildFronts([]option.MITMDFFrontEntry{
+		{
+			Names:        []string{" Vercel.app ", "VERCEL.com", "vercel.app"}, // duplicate + mixed case
+			FrontedSNI:   "Nextjs.org",
+			VerifySAN:    []string{"vercel.app", "Vercel.com"},
+			RedirectAddr: "nextjs.org:443",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := f[0].frontedSNI; got != "nextjs.org" {
+		t.Errorf("frontedSNI = %q, want lowercased", got)
+	}
+	if got := f[0].names; len(got) != 2 {
+		t.Errorf("names = %v, want 2 unique lowercased entries", got)
+	}
+	if got := f[0].verifySAN; len(got) != 2 || got[0] != "vercel.app" {
+		t.Errorf("verifySAN = %v, want lowercased pair", got)
+	}
+}
+
+func TestFrontsLookup_MatchSemantics(t *testing.T) {
+	f, err := buildFronts([]option.MITMDFFrontEntry{
+		{Names: []string{"vercel.app"}, FrontedSNI: "nextjs.org"},
+		{Names: []string{"googlevideo.com"}, FrontedSNI: "www.google.com"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		sni  string
+		want string // frontedSNI, or "" for no match
+	}{
+		{"vercel.app", "nextjs.org"},
+		{"my-app.vercel.app", "nextjs.org"},
+		{"deep.sub.vercel.app", "nextjs.org"},
+		{"r1---sn-aaa.googlevideo.com", "www.google.com"},
+		{"notvercel.app", ""},               // suffix lex-match without `.` boundary
+		{"vercel.app.evil.com", ""},         // strict suffix only
+		{"vercelapp", ""},                   // no dot
+		{"other.com", ""},                   // unrelated
+		{"", ""},                            // empty
+	}
+	for _, c := range cases {
+		t.Run(c.sni, func(t *testing.T) {
+			got := f.lookup(c.sni)
+			if c.want == "" {
+				if got != nil {
+					t.Errorf("lookup(%q) = %v, want nil", c.sni, got.frontedSNI)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("lookup(%q) = nil, want match on %q", c.sni, c.want)
+			}
+			if got.frontedSNI != c.want {
+				t.Errorf("lookup(%q).frontedSNI = %q, want %q", c.sni, got.frontedSNI, c.want)
+			}
+		})
+	}
+}
+
+func TestDenyMatch(t *testing.T) {
+	deny := normalizeDeny([]string{"chase.com", " Bank.example "})
+	for _, sni := range []string{"chase.com", "secure.chase.com", "bank.example", "x.bank.example"} {
+		if !denyMatch(deny, sni) {
+			t.Errorf("denyMatch(%q) = false, want true", sni)
+		}
+	}
+	for _, sni := range []string{"jpmchase.com", "bank.example.com", "vercel.app", ""} {
+		if denyMatch(deny, sni) {
+			t.Errorf("denyMatch(%q) = true, want false", sni)
+		}
+	}
+}
+
+func TestNormalizeDeny_DedupAndDrop(t *testing.T) {
+	got := normalizeDeny([]string{"A.com", " a.com ", "", "B.com", "a.com."})
+	want := []string{"a.com", "b.com"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPresetFromString(t *testing.T) {
+	for _, in := range []string{"", "chrome", "firefox", "safari", "random"} {
+		if _, err := presetFromString(in); err != nil {
+			t.Errorf("presetFromString(%q): %v", in, err)
+		}
+	}
+	for _, in := range []string{"opera", "CHROME", "Chrome", "junk"} {
+		if _, err := presetFromString(in); err == nil {
+			t.Errorf("presetFromString(%q): want error, got nil", in)
+		}
+	}
+}

--- a/protocol/mitmdf/outbound.go
+++ b/protocol/mitmdf/outbound.go
@@ -1,0 +1,473 @@
+// Package mitmdf implements a MITM-DomainFronting sing-box outbound.
+//
+// The outbound terminates the user's TLS handshake locally using a leaf
+// certificate minted on the fly by a name-constrained CA (see
+// internal/mitmca). Once the user side completes, the configured front
+// table is consulted to choose a fronted SNI and (optionally) a redirect
+// destination. The egress connection is wrapped with uTLS using the
+// configured fingerprint preset and the user's negotiated ALPN — never
+// the preset's hard-coded ALPN list, which is the load-bearing piece for
+// transparently fronting both h2 and http/1.1 origins. Plaintext is then
+// bridged between the two TLS sides.
+//
+// Security properties (full rationale in
+// docs/mitm-df/architecture.md and getlantern/engineering#3482):
+//
+//   - The CA carries RFC 5280 NameConstraints, so even a leaked CA key
+//     can't mint certs outside the configured permitted_domains.
+//   - The outbound never listens on a TCP port — the user side of each
+//     MITM session is an in-memory net.Pipe owned by DialContext.
+//   - A deny list rejects sensitive SNIs in the GetCertificate callback
+//     before any signature is produced.
+//   - Every decision (allow / deny / no-match / error) is recorded to a
+//     JSONL audit log.
+package mitmdf
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/outbound"
+	"github.com/sagernet/sing-box/common/dialer"
+	sblog "github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing/common/logger"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+
+	utls "github.com/refraction-networking/utls"
+
+	"github.com/getlantern/lantern-box/constant"
+	"github.com/getlantern/lantern-box/internal/mitmca"
+	"github.com/getlantern/lantern-box/option"
+)
+
+const defaultEgressHandshakeTimeout = 10 * time.Second
+
+// RegisterOutbound registers the mitm-df outbound adapter.
+func RegisterOutbound(registry *outbound.Registry) {
+	outbound.Register[option.MITMDFOutboundOptions](registry, constant.TypeMITMDF, NewOutbound)
+}
+
+// Outbound is a MITM-DomainFronting outbound.
+type Outbound struct {
+	outbound.Adapter
+	logger logger.ContextLogger
+	dialer N.Dialer
+
+	ca      *mitmca.CA
+	fronts  fronts
+	deny    []string
+	audit   *auditLog
+	helloID utls.ClientHelloID
+
+	egressHandshakeTimeout time.Duration
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewOutbound constructs a mitm-df outbound from parsed options.
+func NewOutbound(
+	ctx context.Context,
+	router adapter.Router,
+	lg sblog.ContextLogger,
+	tag string,
+	opts option.MITMDFOutboundOptions,
+) (adapter.Outbound, error) {
+	ca, err := loadOrGenerateCA(opts.CA, lg, ctx)
+	if err != nil {
+		return nil, err
+	}
+	fronts, err := buildFronts(opts.Fronts)
+	if err != nil {
+		return nil, err
+	}
+	helloID, err := presetFromString(opts.Fingerprint)
+	if err != nil {
+		return nil, fmt.Errorf("mitmdf: %w", err)
+	}
+	handshakeTimeout := defaultEgressHandshakeTimeout
+	if opts.EgressHandshakeTimeout != "" {
+		handshakeTimeout, err = time.ParseDuration(opts.EgressHandshakeTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("mitmdf: invalid egress_handshake_timeout: %w", err)
+		}
+		if handshakeTimeout <= 0 {
+			return nil, fmt.Errorf("mitmdf: egress_handshake_timeout must be positive")
+		}
+	}
+
+	outboundDialer, err := dialer.New(ctx, opts.DialerOptions, opts.ServerIsDomain())
+	if err != nil {
+		return nil, fmt.Errorf("mitmdf: build dialer: %w", err)
+	}
+
+	audit, err := openAuditLog(opts.AuditLogPath)
+	if err != nil {
+		return nil, fmt.Errorf("mitmdf: %w", err)
+	}
+
+	o := &Outbound{
+		Adapter: outbound.NewAdapterWithDialerOptions(
+			constant.TypeMITMDF, tag, []string{N.NetworkTCP}, opts.DialerOptions),
+		logger:                 lg,
+		dialer:                 outboundDialer,
+		ca:                     ca,
+		fronts:                 fronts,
+		deny:                   normalizeDeny(opts.DenyDomains),
+		audit:                  audit,
+		helloID:                helloID,
+		egressHandshakeTimeout: handshakeTimeout,
+	}
+	o.ctx, o.cancel = context.WithCancel(context.Background())
+	return o, nil
+}
+
+// loadOrGenerateCA loads an existing CA from disk if both cert_path and
+// the keystore have data, otherwise generates a fresh one scoped to the
+// configured permitted_domains and persists it.
+func loadOrGenerateCA(opts option.MITMDFCAOptions, lg sblog.ContextLogger, ctx context.Context) (*mitmca.CA, error) {
+	if opts.CertPath == "" || opts.KeyPath == "" {
+		return nil, errors.New("mitmdf: ca.cert_path and ca.key_path are required")
+	}
+	if len(opts.PermittedDomains) == 0 {
+		return nil, errors.New("mitmdf: ca.permitted_domains is required (refusing to operate without NameConstraints)")
+	}
+
+	keystore := mitmca.NewFileKeyStore(opts.KeyPath)
+
+	certBytes, certReadErr := os.ReadFile(opts.CertPath)
+	_, keyStatErr := os.Stat(opts.KeyPath)
+	switch {
+	case certReadErr == nil && keyStatErr == nil:
+		ca, err := mitmca.LoadCA(certBytes, keystore)
+		if err != nil {
+			return nil, fmt.Errorf("mitmdf: load CA: %w", err)
+		}
+		logCAFingerprint(lg, ctx, ca, "loaded")
+		return ca, nil
+	case os.IsNotExist(certReadErr) || os.IsNotExist(keyStatErr):
+		validity := mitmca.DefaultCAValidity
+		if opts.Validity != "" {
+			d, err := time.ParseDuration(opts.Validity)
+			if err != nil {
+				return nil, fmt.Errorf("mitmdf: invalid ca.validity: %w", err)
+			}
+			if d <= 0 {
+				return nil, errors.New("mitmdf: ca.validity must be positive")
+			}
+			validity = d
+		}
+		if err := os.MkdirAll(filepath.Dir(opts.CertPath), 0o700); err != nil {
+			return nil, fmt.Errorf("mitmdf: create CA cert dir: %w", err)
+		}
+		if err := os.MkdirAll(filepath.Dir(opts.KeyPath), 0o700); err != nil {
+			return nil, fmt.Errorf("mitmdf: create CA key dir: %w", err)
+		}
+		ca, err := mitmca.GenerateCA(opts.PermittedDomains, keystore, validity)
+		if err != nil {
+			return nil, fmt.Errorf("mitmdf: generate CA: %w", err)
+		}
+		if err := writeAtomic(opts.CertPath, ca.CertPEM(), 0o644); err != nil {
+			return nil, fmt.Errorf("mitmdf: persist CA cert: %w", err)
+		}
+		logCAFingerprint(lg, ctx, ca, "generated")
+		return ca, nil
+	default:
+		return nil, fmt.Errorf("mitmdf: probe CA paths: cert=%v key=%v", certReadErr, keyStatErr)
+	}
+}
+
+func logCAFingerprint(lg sblog.ContextLogger, ctx context.Context, ca *mitmca.CA, action string) {
+	sum := sha256.Sum256(ca.Cert().Raw)
+	lg.InfoContext(ctx,
+		"mitmdf: CA ", action, " — SHA-256 ", hex.EncodeToString(sum[:]),
+		" — permitted_domains=", ca.PermittedDomains(),
+		" — expires ", ca.NotAfter().Format(time.RFC3339),
+		" — install the cert on user devices for the user-side TLS handshake to succeed")
+}
+
+// DialContext returns a synthetic net.Conn whose Read/Write are the user
+// side of an in-memory pipe. A background goroutine drives the user-side
+// tls.Server handshake (with leaf cert minted via the GetCertificate
+// callback against the actual ClientHello SNI), dials the matched front,
+// performs the uTLS handshake, and bridges plaintext.
+func (o *Outbound) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
+	ctx, md := adapter.ExtendContext(ctx)
+	md.Outbound = o.Tag()
+	md.Destination = destination
+
+	if N.NetworkName(network) != N.NetworkTCP {
+		return nil, fmt.Errorf("mitmdf: only TCP is supported (got %q)", network)
+	}
+
+	userSide, proxySide := net.Pipe()
+	o.wg.Add(1)
+	go o.serve(ctx, destination, proxySide)
+	return userSide, nil
+}
+
+// ListenPacket is not supported; mitm-df is TCP-only.
+func (o *Outbound) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
+	return nil, fmt.Errorf("mitmdf: UDP not supported: %w", os.ErrInvalid)
+}
+
+// Network reports the supported network types.
+func (o *Outbound) Network() []string {
+	return []string{N.NetworkTCP}
+}
+
+// Close cancels in-flight serve goroutines, waits for them to drain, and
+// closes the audit log.
+func (o *Outbound) Close() error {
+	o.cancel()
+	o.wg.Wait()
+	return o.audit.close()
+}
+
+// serve runs the MITM pipeline for a single dial. The SNI is taken from
+// the user's ClientHello — not from the router-supplied destination — via
+// the GetCertificate callback below, so a routing/sniff mismatch can't
+// mint a cert for the wrong name.
+func (o *Outbound) serve(
+	ctx context.Context,
+	destination M.Socksaddr,
+	proxySide net.Conn,
+) {
+	defer o.wg.Done()
+	defer proxySide.Close()
+
+	dialCtx, cancel := context.WithCancel(o.ctx)
+	defer cancel()
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		select {
+		case <-ctx.Done():
+			cancel()
+		case <-stop:
+		}
+	}()
+
+	// State captured by the GetCertificate closure so the post-handshake
+	// front-selection step has the same answers without re-evaluating.
+	var (
+		matchedSNI   string
+		matchedFront *frontEntry
+	)
+	serverCfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"h2", "http/1.1"},
+		GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			sni := normalizeDNS(hello.ServerName)
+			if sni == "" {
+				o.audit.record(auditRecord{
+					SNI: hello.ServerName, Decision: auditDeny,
+					Reason: "empty SNI",
+				})
+				return nil, errors.New("mitmdf: client did not send SNI")
+			}
+			if denyMatch(o.deny, sni) {
+				o.audit.record(auditRecord{
+					SNI: sni, Decision: auditDeny, Reason: "deny list",
+				})
+				return nil, fmt.Errorf("mitmdf: SNI %q is on the deny list", sni)
+			}
+			front := o.fronts.lookup(sni)
+			if front == nil {
+				o.audit.record(auditRecord{
+					SNI: sni, Decision: auditNoMatch,
+				})
+				return nil, fmt.Errorf("mitmdf: SNI %q is not claimed by any fronts entry", sni)
+			}
+			leafCert, leafKey, err := o.ca.SignLeaf(sni)
+			if err != nil {
+				o.audit.record(auditRecord{
+					SNI: sni, FrontedSNI: front.frontedSNI, Decision: auditError,
+					Reason: "sign leaf: " + err.Error(),
+				})
+				return nil, fmt.Errorf("mitmdf: sign leaf: %w", err)
+			}
+			o.audit.record(auditRecord{
+				SNI: sni, FrontedSNI: front.frontedSNI, Decision: auditAllow,
+			})
+			matchedSNI = sni
+			matchedFront = front
+			return &tls.Certificate{
+				Certificate: [][]byte{leafCert.Raw, o.ca.Cert().Raw},
+				PrivateKey:  leafKey,
+				Leaf:        leafCert,
+			}, nil
+		},
+	}
+	userTLS := tls.Server(proxySide, serverCfg)
+	defer userTLS.Close()
+
+	hsCtx, hsCancel := context.WithTimeout(dialCtx, o.egressHandshakeTimeout)
+	if err := userTLS.HandshakeContext(hsCtx); err != nil {
+		hsCancel()
+		o.logger.DebugContext(ctx, "mitmdf: user TLS handshake failed: ", err,
+			" (dest=", destination.String(), ")")
+		return
+	}
+	hsCancel()
+	if matchedFront == nil {
+		// Defensive — handshake completing without our callback firing
+		// would imply a session resumption or TLS-internal bug; refuse to
+		// proceed.
+		o.logger.WarnContext(ctx, "mitmdf: handshake completed without GetCertificate match; aborting")
+		return
+	}
+	negotiatedALPN := userTLS.ConnectionState().NegotiatedProtocol
+
+	egressTarget := destination
+	if matchedFront.redirectAddr != "" {
+		egressTarget = M.ParseSocksaddr(matchedFront.redirectAddr)
+	}
+
+	rawEgress, err := o.dialer.DialContext(dialCtx, N.NetworkTCP, egressTarget)
+	if err != nil {
+		o.audit.record(auditRecord{
+			SNI: matchedSNI, FrontedSNI: matchedFront.frontedSNI, Decision: auditError,
+			Reason: "egress dial: " + err.Error(),
+		})
+		o.logger.DebugContext(ctx, "mitmdf: egress TCP dial failed to ",
+			egressTarget.String(), ": ", err)
+		return
+	}
+	defer rawEgress.Close()
+
+	egressALPN := []string{negotiatedALPN}
+	if negotiatedALPN == "" {
+		egressALPN = []string{"h2", "http/1.1"}
+	}
+	uCfg := &utls.Config{
+		ServerName: matchedFront.frontedSNI,
+		NextProtos: egressALPN,
+		MinVersion: utls.VersionTLS12,
+	}
+	if len(matchedFront.verifySAN) > 0 {
+		uCfg.InsecureSkipVerify = true
+		uCfg.VerifyPeerCertificate = verifyFrontSAN(matchedFront.frontedSNI, matchedFront.verifySAN)
+	}
+	uConn := utls.UClient(rawEgress, uCfg, utls.HelloCustom)
+	defer uConn.Close()
+	if err := applyPresetWithALPN(uConn, o.helloID, egressALPN); err != nil {
+		o.logger.DebugContext(ctx, "mitmdf: apply preset with ALPN: ", err)
+		return
+	}
+
+	egCtx, egCancel := context.WithTimeout(dialCtx, o.egressHandshakeTimeout)
+	if err := uConn.HandshakeContext(egCtx); err != nil {
+		egCancel()
+		o.audit.record(auditRecord{
+			SNI: matchedSNI, FrontedSNI: matchedFront.frontedSNI, Decision: auditError,
+			Reason: "egress handshake: " + err.Error(),
+		})
+		o.logger.DebugContext(ctx, "mitmdf: egress uTLS handshake failed (sni=",
+			matchedFront.frontedSNI, "): ", err)
+		return
+	}
+	egCancel()
+
+	bridge(userTLS, uConn)
+}
+
+// bridge proxies plaintext between user and egress. When either direction
+// returns, both connections are closed to unblock the other copy.
+func bridge(userTLS, egressTLS net.Conn) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+	closeBoth := func() {
+		userTLS.Close()
+		egressTLS.Close()
+	}
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(egressTLS, userTLS)
+		closeBoth()
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(userTLS, egressTLS)
+		closeBoth()
+	}()
+	wg.Wait()
+}
+
+// verifyFrontSAN returns a VerifyPeerCertificate callback that accepts the
+// egress leaf when it is valid for frontedSNI or any of extraNames. Chain
+// verification uses the system root pool (which is the right default for
+// CDN edges); InsecureSkipVerify must be true on the *utls.Config when
+// this callback is installed, since we re-implement both chain + name
+// checking here.
+func verifyFrontSAN(frontedSNI string, extraNames []string) func([][]byte, [][]*x509.Certificate) error {
+	candidates := append([]string{frontedSNI}, extraNames...)
+	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+		if len(rawCerts) == 0 {
+			return errors.New("mitmdf: egress peer presented no certificate")
+		}
+		leaf, err := x509.ParseCertificate(rawCerts[0])
+		if err != nil {
+			return fmt.Errorf("mitmdf: parse egress leaf: %w", err)
+		}
+		intermediates := x509.NewCertPool()
+		for _, raw := range rawCerts[1:] {
+			c, err := x509.ParseCertificate(raw)
+			if err != nil {
+				continue
+			}
+			intermediates.AddCert(c)
+		}
+		if _, err := leaf.Verify(x509.VerifyOptions{Intermediates: intermediates}); err != nil {
+			return fmt.Errorf("mitmdf: egress chain verify: %w", err)
+		}
+		for _, name := range candidates {
+			if name == "" {
+				continue
+			}
+			if leaf.VerifyHostname(name) == nil {
+				return nil
+			}
+		}
+		return fmt.Errorf("mitmdf: egress cert valid for none of %v", candidates)
+	}
+}
+
+// writeAtomic writes data to path via a tempfile + rename. Mode is applied
+// to the tempfile before rename so the final file's mode is correct
+// regardless of the umask. Parent directory is created upstream.
+func writeAtomic(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/protocol/mitmdf/utls_preset.go
+++ b/protocol/mitmdf/utls_preset.go
@@ -1,0 +1,54 @@
+package mitmdf
+
+import (
+	"fmt"
+
+	utls "github.com/refraction-networking/utls"
+)
+
+// presetFromString maps the user-facing fingerprint string to a uTLS
+// ClientHelloID preset. The empty string defaults to chrome.
+func presetFromString(s string) (utls.ClientHelloID, error) {
+	switch s {
+	case "", "chrome":
+		return utls.HelloChrome_Auto, nil
+	case "firefox":
+		return utls.HelloFirefox_Auto, nil
+	case "safari":
+		return utls.HelloSafari_Auto, nil
+	case "random":
+		return utls.HelloRandomized, nil
+	}
+	return utls.ClientHelloID{}, fmt.Errorf("unknown fingerprint %q (want chrome|firefox|safari|random)", s)
+}
+
+// applyPresetWithALPN materializes the ClientHello spec for helloID,
+// overwrites the ALPN extension's protocol list with alpn, and applies it
+// to uConn. The caller MUST have constructed uConn with utls.HelloCustom
+// so applyPresetByID at handshake time is a no-op rather than re-applying
+// the preset's hard-coded ALPN.
+//
+// This is the load-bearing piece that makes ALPN inheritance from the
+// user's negotiated protocol actually take effect on the wire. Named uTLS
+// presets (HelloChrome_Auto, etc.) embed an ALPN extension with
+// [h2, http/1.1] that overrides Config.NextProtos at handshake time. The
+// only escape is to route through HelloCustom + ApplyPreset.
+func applyPresetWithALPN(uConn *utls.UConn, helloID utls.ClientHelloID, alpn []string) error {
+	spec, err := utls.UTLSIdToSpec(helloID)
+	if err != nil {
+		return fmt.Errorf("uTLSIdToSpec: %w", err)
+	}
+	found := false
+	for _, ext := range spec.Extensions {
+		if a, ok := ext.(*utls.ALPNExtension); ok {
+			a.AlpnProtocols = append(a.AlpnProtocols[:0], alpn...)
+			found = true
+		}
+	}
+	if !found {
+		spec.Extensions = append(spec.Extensions, &utls.ALPNExtension{
+			AlpnProtocols: append([]string(nil), alpn...),
+		})
+	}
+	return uConn.ApplyPreset(&spec)
+}

--- a/protocol/register.go
+++ b/protocol/register.go
@@ -12,6 +12,7 @@ import (
 	"github.com/getlantern/lantern-box/protocol/algeneva"
 	"github.com/getlantern/lantern-box/protocol/amnezia"
 	"github.com/getlantern/lantern-box/protocol/group"
+	"github.com/getlantern/lantern-box/protocol/mitmdf"
 	"github.com/getlantern/lantern-box/protocol/outline"
 	"github.com/getlantern/lantern-box/protocol/reflex"
 	"github.com/getlantern/lantern-box/protocol/samizdat"
@@ -23,6 +24,7 @@ var supportedProtocols = []string{
 	// custom protocols
 	"algeneva",
 	"amnezia",
+	"mitm-df",
 	"outline",
 	"reflex",
 	"samizdat",
@@ -78,6 +80,7 @@ func registerInbounds(registry *inbound.Registry) {
 func registerOutbounds(registry *outbound.Registry) {
 	// custom protocol outbounds
 	algeneva.RegisterOutbound(registry)
+	mitmdf.RegisterOutbound(registry)
 	outline.RegisterOutbound(registry)
 	reflex.RegisterOutbound(registry)
 	samizdat.RegisterOutbound(registry)

--- a/test/e2e/mitmdf_test.go
+++ b/test/e2e/mitmdf_test.go
@@ -1,0 +1,416 @@
+package e2e
+
+import (
+	"bufio"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	sbox "github.com/sagernet/sing-box"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common/json/badoption"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/proxy"
+
+	box "github.com/getlantern/lantern-box"
+	lbOption "github.com/getlantern/lantern-box/option"
+	"github.com/getlantern/lantern-box/protocol"
+)
+
+// TestMITMDFE2E exercises the MITM-DomainFronting outbound end-to-end:
+//
+//   - lantern-box generates a name-constrained CA on first boot
+//     (permitted: vercel.app, vercel.com).
+//   - A SOCKS5 mixed inbound routes "evil.test" -> wait, evil.test isn't
+//     covered. We use "evil.vercel.app" so the SNI falls inside the CA's
+//     PermittedDNSDomains and the fronts entry's Names ["vercel.app"]
+//     suffix-matches it.
+//   - The fronts entry says front "evil.vercel.app" onto fronted_sni
+//     "front.test" via redirect_addr to an in-process stub fronting
+//     server using a private fronting CA pinned via verify_san.
+//   - Wait — verify_san only loosens *which name* the cert is valid for,
+//     it doesn't change the trust anchor. The system root pool needs the
+//     fronting CA. Since this is a test, we ship the fronting cert as
+//     verify_san target and ALSO need the fronting CA in the system
+//     trust. Instead we use accepted_cert_names via verify_san and a
+//     fronting CA that signs a cert whose system-root chain works.
+//
+// Practical approach: since we control the fronting CA only in-test, we
+// substitute the fronts-side certificate with one whose chain we add to
+// the OS root pool via SSL_CERT_FILE env var for this process. That
+// matches how real Lantern operators would rely on system roots for CDN
+// edges (Let's Encrypt, DigiCert, etc.).
+//
+// Assertions:
+//   - User-side leaf is signed by the lantern CA and is valid for
+//     evil.vercel.app.
+//   - Egress saw SNI=front.test and ALPN=[h2] (inheritance fix proven).
+//   - JSONL audit log received an `allow` record for evil.vercel.app.
+//   - Bytes round-trip.
+func TestMITMDFE2E(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	dataDir := t.TempDir()
+	caCertPath := filepath.Join(dataDir, "mitm-ca.crt")
+	caKeyPath := filepath.Join(dataDir, "mitm-ca.key")
+	auditPath := filepath.Join(dataDir, "mitm-audit.log")
+
+	// Fronting-side CA + leaf, used by the stub front server. To make
+	// uTLS's system-roots chain check happy for the egress handshake, we
+	// stage the fronting CA into a file and point SSL_CERT_FILE at it.
+	frontCACert, frontCAKey := genTestCA(t, "test-front-CA")
+	frontLeaf := issueTestLeaf(t, frontCACert, frontCAKey, "front.test")
+	frontCAPath := filepath.Join(dataDir, "front-ca.pem")
+	require.NoError(t, os.WriteFile(frontCAPath, pemCert(frontCACert.Raw), 0o644))
+	t.Setenv("SSL_CERT_FILE", frontCAPath)
+
+	// Stub fronting server.
+	captured := newCaptureChan()
+	frontListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = frontListener.Close() })
+
+	frontTLSConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"h2", "http/1.1"},
+		GetCertificate: func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			captured.send(captureEntry{
+				ServerName: chi.ServerName,
+				ALPN:       append([]string(nil), chi.SupportedProtos...),
+			})
+			return &frontLeaf, nil
+		},
+	}
+	go runFrontServer(ctx, frontListener, frontTLSConfig)
+
+	boxCtx := box.BaseContext()
+	boxCtx = protocol.RegisterProtocols(boxCtx)
+
+	inboundPort := freePort(t)
+	listenAddr := badoption.Addr(netip.MustParseAddr("127.0.0.1"))
+
+	mitmOpts := lbOption.MITMDFOutboundOptions{
+		CA: lbOption.MITMDFCAOptions{
+			CertPath:         caCertPath,
+			KeyPath:          caKeyPath,
+			PermittedDomains: []string{"vercel.app", "vercel.com"},
+			Validity:         "24h",
+		},
+		Fronts: []lbOption.MITMDFFrontEntry{
+			{
+				Names:        []string{"vercel.app"},
+				FrontedSNI:   "front.test",
+				RedirectAddr: frontListener.Addr().String(),
+			},
+		},
+		AuditLogPath: auditPath,
+		Fingerprint:  "chrome",
+	}
+
+	opts := option.Options{
+		Log: &option.LogOptions{Disabled: true},
+		Inbounds: []option.Inbound{{
+			Type: "mixed",
+			Tag:  "mixed-in",
+			Options: &option.HTTPMixedInboundOptions{
+				ListenOptions: option.ListenOptions{
+					Listen:     &listenAddr,
+					ListenPort: inboundPort,
+				},
+			},
+		}},
+		Outbounds: []option.Outbound{{
+			Type:    "mitm-df",
+			Tag:     "mitm-df-out",
+			Options: &mitmOpts,
+		}},
+		Route: &option.RouteOptions{Final: "mitm-df-out"},
+	}
+
+	b, err := sbox.New(sbox.Options{Context: boxCtx, Options: opts})
+	require.NoError(t, err)
+	require.NoError(t, b.Start())
+	t.Cleanup(func() { _ = b.Close() })
+
+	// SOCKS5-connect to evil.vercel.app:443 and run TLS on the tunneled
+	// conn trusting only the just-generated lantern CA.
+	socksDialer, err := proxy.SOCKS5("tcp", fmt.Sprintf("127.0.0.1:%d", inboundPort), nil, proxy.Direct)
+	require.NoError(t, err)
+
+	tunnelCtx, tunnelCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer tunnelCancel()
+	rawConn, err := socksDialer.(proxy.ContextDialer).DialContext(tunnelCtx, "tcp", "evil.vercel.app:443")
+	require.NoError(t, err)
+	defer rawConn.Close()
+
+	caPEM, err := os.ReadFile(caCertPath)
+	require.NoError(t, err)
+	lanternCAPool := x509.NewCertPool()
+	require.True(t, lanternCAPool.AppendCertsFromPEM(caPEM))
+
+	userTLS := tls.Client(rawConn, &tls.Config{
+		ServerName: "evil.vercel.app",
+		RootCAs:    lanternCAPool,
+		NextProtos: []string{"h2"},
+		MinVersion: tls.VersionTLS12,
+	})
+	hsCtx, hsCancel := context.WithTimeout(ctx, 10*time.Second)
+	require.NoError(t, userTLS.HandshakeContext(hsCtx))
+	hsCancel()
+	defer userTLS.Close()
+
+	st := userTLS.ConnectionState()
+	require.NotEmpty(t, st.PeerCertificates)
+	leaf := st.PeerCertificates[0]
+	require.NoError(t, leaf.VerifyHostname("evil.vercel.app"))
+	require.Contains(t, leaf.DNSNames, "evil.vercel.app")
+
+	c := captured.recv(t, 5*time.Second)
+	require.Equal(t, "front.test", c.ServerName)
+	require.Equal(t, []string{"h2"}, c.ALPN)
+
+	payload := []byte("hello fronted")
+	_, err = userTLS.Write(payload)
+	require.NoError(t, err)
+	echo := make([]byte, len(payload))
+	_, err = io.ReadFull(userTLS, echo)
+	require.NoError(t, err)
+	require.Equal(t, payload, echo)
+
+	// Audit log: one `allow` for evil.vercel.app.
+	f, err := os.Open(auditPath)
+	require.NoError(t, err)
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	var allowed bool
+	for sc.Scan() {
+		var r map[string]any
+		require.NoError(t, json.Unmarshal(sc.Bytes(), &r))
+		if r["sni"] == "evil.vercel.app" && r["decision"] == "allow" && r["fronted_sni"] == "front.test" {
+			allowed = true
+			break
+		}
+	}
+	require.True(t, allowed, "audit log missing allow record for evil.vercel.app")
+}
+
+// TestMITMDFDenyList confirms the deny list short-circuits the
+// GetCertificate callback before the CA mints anything.
+func TestMITMDFDenyList(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	dataDir := t.TempDir()
+	auditPath := filepath.Join(dataDir, "audit.log")
+
+	boxCtx := box.BaseContext()
+	boxCtx = protocol.RegisterProtocols(boxCtx)
+
+	inboundPort := freePort(t)
+	listenAddr := badoption.Addr(netip.MustParseAddr("127.0.0.1"))
+
+	mitmOpts := lbOption.MITMDFOutboundOptions{
+		CA: lbOption.MITMDFCAOptions{
+			CertPath:         filepath.Join(dataDir, "ca.crt"),
+			KeyPath:          filepath.Join(dataDir, "ca.key"),
+			PermittedDomains: []string{"vercel.app"},
+		},
+		Fronts: []lbOption.MITMDFFrontEntry{
+			{Names: []string{"vercel.app"}, FrontedSNI: "front.test", RedirectAddr: "127.0.0.1:1"},
+		},
+		DenyDomains:  []string{"vercel.app"},
+		AuditLogPath: auditPath,
+	}
+
+	opts := option.Options{
+		Log: &option.LogOptions{Disabled: true},
+		Inbounds: []option.Inbound{{
+			Type: "mixed", Tag: "in",
+			Options: &option.HTTPMixedInboundOptions{
+				ListenOptions: option.ListenOptions{Listen: &listenAddr, ListenPort: inboundPort},
+			},
+		}},
+		Outbounds: []option.Outbound{{
+			Type: "mitm-df", Tag: "out", Options: &mitmOpts,
+		}},
+		Route: &option.RouteOptions{Final: "out"},
+	}
+
+	b, err := sbox.New(sbox.Options{Context: boxCtx, Options: opts})
+	require.NoError(t, err)
+	require.NoError(t, b.Start())
+	t.Cleanup(func() { _ = b.Close() })
+
+	socksDialer, err := proxy.SOCKS5("tcp", fmt.Sprintf("127.0.0.1:%d", inboundPort), nil, proxy.Direct)
+	require.NoError(t, err)
+	dialCtx, dialCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer dialCancel()
+	rawConn, err := socksDialer.(proxy.ContextDialer).DialContext(dialCtx, "tcp", "vercel.app:443")
+	require.NoError(t, err)
+	defer rawConn.Close()
+
+	userTLS := tls.Client(rawConn, &tls.Config{
+		ServerName: "vercel.app",
+		// Trust nothing — the handshake should fail before reaching cert
+		// validation anyway because GetCertificate refuses to mint.
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS12,
+	})
+	hsCtx, hsCancel := context.WithTimeout(ctx, 5*time.Second)
+	err = userTLS.HandshakeContext(hsCtx)
+	hsCancel()
+	require.Error(t, err, "handshake should fail when deny list rejects the SNI")
+
+	// Wait briefly for the audit record (it's written from the serve
+	// goroutine, possibly after our handshake error).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		f, err := os.Open(auditPath)
+		if err == nil {
+			found := false
+			sc := bufio.NewScanner(f)
+			for sc.Scan() {
+				var r map[string]any
+				if json.Unmarshal(sc.Bytes(), &r) == nil {
+					if r["sni"] == "vercel.app" && r["decision"] == "deny" {
+						found = true
+						break
+					}
+				}
+			}
+			f.Close()
+			if found {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("audit log missing deny record for vercel.app")
+}
+
+type captureEntry struct {
+	ServerName string
+	ALPN       []string
+}
+
+type captureChan struct {
+	ch chan captureEntry
+}
+
+func newCaptureChan() *captureChan {
+	return &captureChan{ch: make(chan captureEntry, 4)}
+}
+
+func (c *captureChan) send(e captureEntry) {
+	select {
+	case c.ch <- e:
+	default:
+	}
+}
+
+func (c *captureChan) recv(t *testing.T, d time.Duration) captureEntry {
+	t.Helper()
+	select {
+	case e := <-c.ch:
+		return e
+	case <-time.After(d):
+		t.Fatal("captureChan: no entry within timeout")
+		return captureEntry{}
+	}
+}
+
+func runFrontServer(ctx context.Context, ln net.Listener, cfg *tls.Config) {
+	var wg sync.WaitGroup
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			wg.Wait()
+			return
+		}
+		wg.Add(1)
+		go func(c net.Conn) {
+			defer wg.Done()
+			defer c.Close()
+			tlsConn := tls.Server(c, cfg)
+			hsCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			if err := tlsConn.HandshakeContext(hsCtx); err != nil {
+				return
+			}
+			defer tlsConn.Close()
+			buf := make([]byte, 4096)
+			for {
+				n, err := tlsConn.Read(buf)
+				if n > 0 {
+					_, _ = tlsConn.Write(buf[:n])
+				}
+				if err != nil {
+					return
+				}
+			}
+		}(conn)
+	}
+}
+
+func genTestCA(t *testing.T, cn string) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	tmpl := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert, key
+}
+
+func issueTestLeaf(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, dnsName string) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	tmpl := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: dnsName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{dnsName},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, ca, &key.PublicKey, caKey)
+	require.NoError(t, err)
+	return tls.Certificate{Certificate: [][]byte{der, ca.Raw}, PrivateKey: key}
+}
+
+func pemCert(der []byte) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}

--- a/testdata/options/mitmdf_client.json
+++ b/testdata/options/mitmdf_client.json
@@ -1,0 +1,65 @@
+{
+	"log": { "disabled": true },
+	"inbounds": [
+		{
+			"type": "mixed",
+			"tag": "mixed-in",
+			"listen": "127.0.0.1",
+			"listen_port": 10808
+		}
+	],
+	"outbounds": [
+		{ "type": "direct", "tag": "direct" },
+		{
+			"type": "mitm-df",
+			"tag":  "mitm-df",
+			"ca": {
+				"cert_path": "/tmp/lantern-mitm-df-example/ca.crt",
+				"key_path":  "/tmp/lantern-mitm-df-example/ca.key",
+				"permitted_domains": [
+					"vercel.app", "vercel.com", "nextjs.org",
+					"google.com", "googleapis.com", "googlevideo.com",
+					"github.com", "githubusercontent.com",
+					"fastly.com", "fastly.net", "reddit.com"
+				],
+				"validity": "720h"
+			},
+			"fronts": [
+				{
+					"names":        ["vercel.app", "vercel.com"],
+					"fronted_sni":  "nextjs.org",
+					"verify_san":   ["nextjs.org", "vercel.app", "vercel.com", "react.dev"],
+					"redirect_addr": "nextjs.org:443"
+				},
+				{
+					"names":        ["google.com", "googleapis.com", "googlevideo.com"],
+					"fronted_sni":  "www.google.com",
+					"verify_san":   ["www.google.com", "dns.google", "googlevideo.com"],
+					"redirect_addr": "www.google.com:443"
+				},
+				{
+					"names":        ["github.com", "githubusercontent.com"],
+					"fronted_sni":  "github.com",
+					"verify_san":   ["github.com", "githubusercontent.com"]
+				}
+			],
+			"deny_domains": ["bank.example", "gov.example"],
+			"audit_log_path": "/tmp/lantern-mitm-df-example/audit.log",
+			"fingerprint": "chrome",
+			"egress_handshake_timeout": "10s"
+		}
+	],
+	"route": {
+		"rules": [
+			{
+				"domain_suffix": [
+					"vercel.app", "vercel.com",
+					"google.com", "googleapis.com", "googlevideo.com",
+					"github.com", "githubusercontent.com"
+				],
+				"outbound": "mitm-df"
+			}
+		],
+		"final": "direct"
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on top of #262. Once #262 lands, this PR introduces the actual `mitm-df` outbound that uses the foundation's name-constrained CA.

- **TCP outbound** registered as `"mitm-df"`. `DialContext` returns the user side of an in-memory `net.Pipe` — no listening port.
- **`tls.Server` with `GetCertificate` callback** driven by the actual ClientHello SNI (not the router-supplied destination), so a sniff/routing mismatch can't mint the wrong leaf. Callback runs: deny-list check → fronts lookup → audit record → `mitmca.CA.SignLeaf(sni)`.
- **Fronts table** maps user SNIs to `fronted_sni` / `verify_san` / optional `redirect_addr`. Match semantics: exact-or-strict-subdomain (`vercel.app` matches `*.vercel.app` but not `notvercel.app` or `vercel.app.evil.com`).
- **JSONL audit log** records every decision (`allow`, `deny`, `no-match`, `error`) with `{ts, sni, fronted_sni, decision, reason}`. Empty `audit_log_path` disables.
- **Egress uTLS** uses `HelloCustom` + `ApplyPreset` so the user's negotiated ALPN is the only one offered to the front. Named uTLS presets (`HelloChrome_Auto`, etc.) bake an ALPN extension into the replayed ClientHello that overrides `Config.NextProtos`; `HelloCustom` is the only path that inherits cleanly. Without this, every fronted flow would leak `[h2, http/1.1]` regardless of the inner request shape — breaks h1-only flows like `googlevideo` / `alive.github.com`.
- **CA auto-generated on first boot** at the configured `ca.cert_path` / `ca.key_path` if absent (delegates to `mitmca.GenerateCA`); reloaded on subsequent boots via `mitmca.LoadCA` which refuses certs without `NameConstraints`.

## Files

- `option/mitmdf.go` — `MITMDFOutboundOptions` + nested `MITMDFCAOptions` / `MITMDFFrontEntry`.
- `protocol/mitmdf/`
  - `outbound.go` — registration, `NewOutbound`, `DialContext`, the `serve` goroutine, the `GetCertificate` callback, CA bootstrap, `verifyFrontSAN` callback for the egress.
  - `fronts.go` — `FrontEntry` parsing, suffix-aware matcher, deny-list match.
  - `audit.go` — append-only JSONL with `sync.Mutex`, nil-safe.
  - `utls_preset.go` — preset map + `HelloCustom`/`ApplyPreset` ALPN-rewrite helper.
  - `fronts_test.go`, `audit_test.go` — unit coverage.
- `test/e2e/mitmdf_test.go` — `TestMITMDFE2E` (full pipeline through an in-process fronting server: leaf chains to local CA, captured egress SNI = front, captured egress ALPN = `[h2]`, bytes round-trip, audit `allow`) + `TestMITMDFDenyList` (deny-list path: no mint, audit `deny`).
- `testdata/options/mitmdf_client.json` — example config; passes `lantern-box check`.
- `constant/proxy.go`, `protocol/register.go`, `go.mod` — type constant, registration, `utls` promoted to direct dep.

## Out of scope (follow-ups)

- Hardware-backed `KeyStore` (`keystore_macos.go`, `keystore_android.go`, …) — the `KeyStore` interface is already in place on the foundation branch; per-platform variants behind build tags.
- SPKI pinning to known CDN intermediates (`pinner.go` per architecture doc).
- Config-server kill switch + weekly fronts validation CI — cross-repo.
- Per-platform trust-store install commands for the CA.
- Old-platform refusal (Android < 9, Windows < 10).
- Leaf-cert cache (mitmca mints per-handshake; ECDSA P-256 keygen is cheap).

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `go test ./protocol/mitmdf/... ./internal/mitmca/...`
- [ ] `go test ./test/e2e/ -run TestMITMDF -v`
- [ ] `lantern-box check --config testdata/options/mitmdf_client.json` — generates a CA at the configured paths with `PermittedDNSDomainsCritical: true`, `CA:TRUE pathlen:0`, key mode 0600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)