### PR TITLE
group: add MutableAutoSelect outbound

### DIFF
--- a/adapter/autoselect_history.go
+++ b/adapter/autoselect_history.go
@@ -40,11 +40,11 @@ type TagHistory struct {
 	UpdatedAt    time.Time `json:"updated_at"`
 }
 
-// AutoSelectHistoryStorage is the in-memory store the
-// MutableAutoSelect group writes to whenever a member's history
-// changes. A host that wants durability registers a hook via SetHook
-// and periodically reads All() to flush to disk; on next startup it
-// seeds entries back into a fresh storage via Store.
+// AutoSelectHistoryStorage is the store the MutableAutoSelect group
+// writes to whenever a member's history changes. A host that wants
+// durability registers a hook via SetHook and periodically reads All()
+// to flush to disk; on next startup it seeds entries back into a fresh
+// storage via Store.
 //
 // Implementations must be safe for concurrent use. Store and Delete
 // must be non-blocking and fast: the group calls them while holding
@@ -148,8 +148,6 @@ func (s *memoryAutoSelectHistoryStorage) Close() error {
 
 // LatestSuccessDelay returns the DelayMs of the most recent
 // OutcomeSuccess in h.Outcomes, or 0 when no success is recorded.
-// Used by UIs that want a single "last known good latency" number
-// without re-implementing the ring walk.
 func (h *TagHistory) LatestSuccessDelay() uint32 {
 	if h == nil {
 		return 0

--- a/adapter/autoselect_history.go
+++ b/adapter/autoselect_history.go
@@ -41,20 +41,15 @@ type TagHistory struct {
 }
 
 // AutoSelectHistoryStorage is the store the MutableAutoSelect group
-// writes to whenever a member's history changes. A host that wants
-// durability registers a hook via SetHook and periodically reads All()
-// to flush to disk; on next startup it seeds entries back into a fresh
-// storage via Store.
+// writes to whenever a member's history changes.
 //
 // Implementations must be safe for concurrent use. Store and Delete
 // must be non-blocking and fast: the group calls them while holding
-// internal locks (s.access), so blocking work — disk I/O,
-// network calls, slow serialization — must happen out-of-band via the
-// hook, not inline. When a state change actually occurs, the hook
-// fires after the change is visible to subsequent Load callers so a
-// hook-driven flusher that calls Load observes what fired its hook.
-// A Store of nil is equivalent to Delete. Calls that arrive after
-// Close are dropped without panic.
+// internal locks, so blocking work — disk I/O, network calls, slow
+// serialization — must happen out-of-band via the hook, not inline.
+// When a state change actually occurs, the hook fires after the change
+// is visible to subsequent Load callers. A Store of nil is equivalent
+// to Delete. Calls that arrive after Close are dropped without panic.
 type AutoSelectHistoryStorage interface {
 	Load(tag string) *TagHistory
 	Store(tag string, h *TagHistory)
@@ -177,8 +172,6 @@ func (h *TagHistory) LatestSuccessTime() time.Time {
 	return h.UpdatedAt
 }
 
-// cloneTagHistory returns a deep copy so callers can mutate the
-// returned struct (or the storage's internal copy) without racing.
 func cloneTagHistory(h *TagHistory) *TagHistory {
 	if h == nil {
 		return nil

--- a/adapter/autoselect_history.go
+++ b/adapter/autoselect_history.go
@@ -1,0 +1,194 @@
+package adapter
+
+import (
+	"sync"
+	"time"
+)
+
+// Outcome classifies the result of a probe or user dial attempt. The
+// enum value is what gets persisted, so additions must append rather
+// than reorder.
+type Outcome uint8
+
+const (
+	OutcomeSuccess Outcome = iota
+	OutcomeTimeout
+	OutcomeHandshakeFailure
+)
+
+// TimestampedOutcome is one entry in a member's recent-outcome ring.
+type TimestampedOutcome struct {
+	Outcome   Outcome   `json:"outcome"`
+	DelayMs   uint32    `json:"delay_ms,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// TagHistory is a point-in-time snapshot of one member's selection
+// state, mirroring the in-memory history kept by the MutableAutoSelect
+// group.
+type TagHistory struct {
+	Outcomes []TimestampedOutcome `json:"outcomes,omitempty"`
+	// ConsecutiveFailures resets to zero on the next probe success.
+	ConsecutiveFailures uint32 `json:"consecutive_failures,omitempty"`
+	// UserFailures counts real user-traffic failures (dial errors +
+	// data-plane stalls). Persisting it means a server that was about
+	// to be demoted on user traffic doesn't come back innocent after
+	// a tunnel close/open inside the current poll window. Laundering-
+	// resistant: probe successes do not decrement it; only a
+	// successful read on a wrapped data-plane conn resets it.
+	UserFailures uint32    `json:"user_failures,omitempty"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+// AutoSelectHistoryStorage is the in-memory store the
+// MutableAutoSelect group writes to whenever a member's history
+// changes. A host that wants durability registers a hook via SetHook
+// and periodically reads All() to flush to disk; on next startup it
+// seeds entries back into a fresh storage via Store.
+//
+// Implementations must be safe for concurrent use. Store and Delete
+// must be non-blocking and fast: the group calls them while holding
+// internal locks (s.access), so blocking work — disk I/O,
+// network calls, slow serialization — must happen out-of-band via the
+// hook, not inline. When a state change actually occurs, the hook
+// fires after the change is visible to subsequent Load callers so a
+// hook-driven flusher that calls Load observes what fired its hook.
+// A Store of nil is equivalent to Delete. Calls that arrive after
+// Close are dropped without panic.
+type AutoSelectHistoryStorage interface {
+	Load(tag string) *TagHistory
+	Store(tag string, h *TagHistory)
+	Delete(tag string)
+	All() map[string]*TagHistory
+	SetHook(hook func(tag string))
+	Close() error
+}
+
+// NewAutoSelectHistoryStorage returns an in-memory
+// AutoSelectHistoryStorage. The returned storage is empty; hosts seed
+// it by calling Store for each entry restored from disk before
+// registering it in the service context.
+func NewAutoSelectHistoryStorage() AutoSelectHistoryStorage {
+	return &memoryAutoSelectHistoryStorage{entries: make(map[string]*TagHistory)}
+}
+
+type memoryAutoSelectHistoryStorage struct {
+	mu      sync.RWMutex
+	entries map[string]*TagHistory
+	hook    func(tag string)
+}
+
+func (s *memoryAutoSelectHistoryStorage) Load(tag string) *TagHistory {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return cloneTagHistory(s.entries[tag])
+}
+
+func (s *memoryAutoSelectHistoryStorage) Store(tag string, h *TagHistory) {
+	if h == nil {
+		s.Delete(tag)
+		return
+	}
+	s.mu.Lock()
+	if s.entries == nil {
+		// Closed. Probe / dataplane goroutines can outlive the
+		// storage on tunnel shutdown (group.Close cancels its
+		// context but does not block on in-flight callbacks); a
+		// nil-map assignment here would panic the writer's
+		// goroutine. Dropping the late write is the safe choice.
+		s.mu.Unlock()
+		return
+	}
+	s.entries[tag] = cloneTagHistory(h)
+	hook := s.hook
+	s.mu.Unlock()
+	if hook != nil {
+		hook(tag)
+	}
+}
+
+func (s *memoryAutoSelectHistoryStorage) Delete(tag string) {
+	s.mu.Lock()
+	if s.entries == nil {
+		s.mu.Unlock()
+		return
+	}
+	_, existed := s.entries[tag]
+	delete(s.entries, tag)
+	hook := s.hook
+	s.mu.Unlock()
+	if existed && hook != nil {
+		hook(tag)
+	}
+}
+
+func (s *memoryAutoSelectHistoryStorage) All() map[string]*TagHistory {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]*TagHistory, len(s.entries))
+	for tag, h := range s.entries {
+		out[tag] = cloneTagHistory(h)
+	}
+	return out
+}
+
+func (s *memoryAutoSelectHistoryStorage) SetHook(hook func(tag string)) {
+	s.mu.Lock()
+	s.hook = hook
+	s.mu.Unlock()
+}
+
+func (s *memoryAutoSelectHistoryStorage) Close() error {
+	s.mu.Lock()
+	s.hook = nil
+	s.entries = nil
+	s.mu.Unlock()
+	return nil
+}
+
+// LatestSuccessDelay returns the DelayMs of the most recent
+// OutcomeSuccess in h.Outcomes, or 0 when no success is recorded.
+// Used by UIs that want a single "last known good latency" number
+// without re-implementing the ring walk.
+func (h *TagHistory) LatestSuccessDelay() uint32 {
+	if h == nil {
+		return 0
+	}
+	for i := len(h.Outcomes) - 1; i >= 0; i-- {
+		if h.Outcomes[i].Outcome == OutcomeSuccess {
+			return h.Outcomes[i].DelayMs
+		}
+	}
+	return 0
+}
+
+// LatestSuccessTime returns the Timestamp of the most recent
+// OutcomeSuccess in h.Outcomes, or UpdatedAt when no success exists.
+// Falls back to UpdatedAt rather than the zero time so callers that
+// render "tested N seconds ago" still have a usable reference point
+// after a string of failures.
+func (h *TagHistory) LatestSuccessTime() time.Time {
+	if h == nil {
+		return time.Time{}
+	}
+	for i := len(h.Outcomes) - 1; i >= 0; i-- {
+		if h.Outcomes[i].Outcome == OutcomeSuccess {
+			return h.Outcomes[i].Timestamp
+		}
+	}
+	return h.UpdatedAt
+}
+
+// cloneTagHistory returns a deep copy so callers can mutate the
+// returned struct (or the storage's internal copy) without racing.
+func cloneTagHistory(h *TagHistory) *TagHistory {
+	if h == nil {
+		return nil
+	}
+	out := *h
+	if len(h.Outcomes) > 0 {
+		out.Outcomes = make([]TimestampedOutcome, len(h.Outcomes))
+		copy(out.Outcomes, h.Outcomes)
+	}
+	return &out
+}

--- a/adapter/autoselect_history.go
+++ b/adapter/autoselect_history.go
@@ -5,39 +5,31 @@ import (
 	"time"
 )
 
-// Outcome classifies the result of a probe or user dial attempt. The
-// enum value is what gets persisted, so additions must append rather
-// than reorder.
-type Outcome uint8
-
-const (
-	OutcomeSuccess Outcome = iota
-	OutcomeTimeout
-	OutcomeHandshakeFailure
-)
-
-// TimestampedOutcome is one entry in a member's recent-outcome ring.
-type TimestampedOutcome struct {
-	Outcome   Outcome   `json:"outcome"`
-	DelayMs   uint32    `json:"delay_ms,omitempty"`
-	Timestamp time.Time `json:"timestamp"`
-}
-
 // TagHistory is a point-in-time snapshot of one member's selection
 // state, mirroring the in-memory history kept by the MutableAutoSelect
-// group.
+// group. Probe outcomes feed the scalar fields; real user-traffic
+// outcomes (dial errors, data-plane stalls) feed the UserFailures
+// sliding window. The two tracks are kept separate so a censor that
+// lets the probe URL through while dropping user traffic shows up as
+// elevated UserFailures with healthy probe scalars simultaneously.
 type TagHistory struct {
-	Outcomes []TimestampedOutcome `json:"outcomes,omitempty"`
-	// ConsecutiveFailures resets to zero on the next probe success.
+	// LastSuccessDelayMs is the most recent successful probe RTT
+	// (clamped to ≥1 ms). 0 means "no successful probe yet" — rank
+	// uses it as a sentinel to deprioritize against measured peers.
+	LastSuccessDelayMs uint32 `json:"last_success_delay_ms,omitempty"`
+	// LastOutcomeAt is the timestamp of the most recent probe outcome
+	// (success or failure). Used by the probe-cycle freshSince gate to
+	// distinguish "probed this cycle" from "stale outcome."
+	LastOutcomeAt time.Time `json:"last_outcome_at,omitempty"`
+	// ConsecutiveFailures counts probe failures since the last probe
+	// success. Resets to zero on probe success.
 	ConsecutiveFailures uint32 `json:"consecutive_failures,omitempty"`
-	// UserFailures counts real user-traffic failures (dial errors +
-	// data-plane stalls). Persisting it means a server that was about
-	// to be demoted on user traffic doesn't come back innocent after
-	// a tunnel close/open inside the current poll window. Laundering-
-	// resistant: probe successes do not decrement it; only a
-	// successful read on a wrapped data-plane conn resets it.
-	UserFailures uint32    `json:"user_failures,omitempty"`
-	UpdatedAt    time.Time `json:"updated_at"`
+	// UserFailures is the sliding window of user-traffic failure
+	// timestamps (dial errors and data-plane stalls). Probe successes
+	// never enter this window; entries age out naturally on the next
+	// mutation older than the group's userFailureWindow.
+	UserFailures []time.Time `json:"user_failures,omitempty"`
+	UpdatedAt    time.Time   `json:"updated_at"`
 }
 
 // AutoSelectHistoryStorage is the store the MutableAutoSelect group
@@ -141,33 +133,24 @@ func (s *memoryAutoSelectHistoryStorage) Close() error {
 	return nil
 }
 
-// LatestSuccessDelay returns the DelayMs of the most recent
-// OutcomeSuccess in h.Outcomes, or 0 when no success is recorded.
+// LatestSuccessDelay returns LastSuccessDelayMs, or 0 when h is nil.
+// Kept as a method for symmetry with LatestSuccessTime and to let
+// callers handle nil snapshots without an extra branch.
 func (h *TagHistory) LatestSuccessDelay() uint32 {
 	if h == nil {
 		return 0
 	}
-	for i := len(h.Outcomes) - 1; i >= 0; i-- {
-		if h.Outcomes[i].Outcome == OutcomeSuccess {
-			return h.Outcomes[i].DelayMs
-		}
-	}
-	return 0
+	return h.LastSuccessDelayMs
 }
 
-// LatestSuccessTime returns the Timestamp of the most recent
-// OutcomeSuccess in h.Outcomes, or UpdatedAt when no success exists.
-// Falls back to UpdatedAt rather than the zero time so callers that
-// render "tested N seconds ago" still have a usable reference point
-// after a string of failures.
+// LatestSuccessTime is best-effort: the spec only persists the most
+// recent outcome timestamp (success or failure), so callers asking
+// "tested N seconds ago" get UpdatedAt as a usable reference even when
+// the most recent outcome was a failure. Returns the zero time when h
+// is nil.
 func (h *TagHistory) LatestSuccessTime() time.Time {
 	if h == nil {
 		return time.Time{}
-	}
-	for i := len(h.Outcomes) - 1; i >= 0; i-- {
-		if h.Outcomes[i].Outcome == OutcomeSuccess {
-			return h.Outcomes[i].Timestamp
-		}
 	}
 	return h.UpdatedAt
 }
@@ -177,9 +160,9 @@ func cloneTagHistory(h *TagHistory) *TagHistory {
 		return nil
 	}
 	out := *h
-	if len(h.Outcomes) > 0 {
-		out.Outcomes = make([]TimestampedOutcome, len(h.Outcomes))
-		copy(out.Outcomes, h.Outcomes)
+	if len(h.UserFailures) > 0 {
+		out.UserFailures = make([]time.Time, len(h.UserFailures))
+		copy(out.UserFailures, h.UserFailures)
 	}
 	return &out
 }

--- a/adapter/group.go
+++ b/adapter/group.go
@@ -22,6 +22,14 @@ type OutboundChecker interface {
 	CheckOutbounds()
 }
 
+// ExhaustionSignaler exposes a channel the host can select on to learn that
+// the group's reconnection ladder finished without finding a working
+// candidate. At most one value is sent per ladder run; the host decides
+// what to do (typically a rate-limited config refetch).
+type ExhaustionSignaler interface {
+	ExhaustionSignal() <-chan struct{}
+}
+
 // TaggedConn is a net.Conn tagged with the outbound tag used to create it.
 type TaggedConn struct {
 	net.Conn

--- a/constant/proxy.go
+++ b/constant/proxy.go
@@ -14,4 +14,5 @@ const (
 	TypeFallback        = "fallback"
 	TypeMutableSelector = "mutableselector"
 	TypeMutableURLTest  = "mutableurltest"
+	TypeMutableAutoSelect  = "mutableautoselect"
 )

--- a/constant/proxy.go
+++ b/constant/proxy.go
@@ -11,8 +11,8 @@ const (
 )
 
 const (
-	TypeFallback        = "fallback"
-	TypeMutableSelector = "mutableselector"
-	TypeMutableURLTest  = "mutableurltest"
-	TypeMutableAutoSelect  = "mutableautoselect"
+	TypeFallback          = "fallback"
+	TypeMutableSelector   = "mutableselector"
+	TypeMutableURLTest    = "mutableurltest"
+	TypeMutableAutoSelect = "mutableautoselect"
 )

--- a/option/group.go
+++ b/option/group.go
@@ -21,12 +21,12 @@ type MutableURLTestOutboundOptions struct {
 	IdleTimeout  badoption.Duration `json:"idle_timeout,omitempty"`
 }
 
-// MutableAutoSelectOutboundOptions configures the client-side server-selection
-// group described in client-server-selection-spec.md. The group probes its
-// members in parallel, selects the lowest-delay healthy candidate (with a
-// switch tolerance to dampen churn), maintains a per-server outcome ring
-// to demote chronically-bad servers, and emits an exhaustion signal when
-// its reconnection ladder fails. Zero values fall back to documented
+// MutableAutoSelectOutboundOptions configures the client-side
+// server-selection group. The group probes its members in parallel,
+// selects the lowest-delay healthy candidate (with a switch tolerance to
+// dampen churn), maintains a per-server outcome ring to demote
+// chronically-bad servers, and emits an exhaustion signal when its
+// reconnection ladder fails. Zero values fall back to documented
 // defaults.
 type MutableAutoSelectOutboundOptions struct {
 	Outbounds    []string          `json:"outbounds"`
@@ -54,8 +54,9 @@ type MutableAutoSelectOutboundOptions struct {
 	// Default 5.
 	DemoteMinOutcomes uint32 `json:"demote_min_outcomes,omitempty"`
 
-	// ConsecutiveFailureLimit is the consecutive-failure count at which a
-	// server is unconditionally demoted. Default 3.
+	// ConsecutiveFailureLimit bounds both the consecutive probe-failure
+	// count and the user-failure count; reaching it on either counter
+	// unconditionally demotes the server. Default 3.
 	ConsecutiveFailureLimit uint32 `json:"consecutive_failure_limit,omitempty"`
 
 	// BackgroundIntervalSeconds is the active cadence for the low-priority

--- a/option/group.go
+++ b/option/group.go
@@ -20,3 +20,69 @@ type MutableURLTestOutboundOptions struct {
 	Tolerance    uint16             `json:"tolerance,omitempty"`
 	IdleTimeout  badoption.Duration `json:"idle_timeout,omitempty"`
 }
+
+// MutableAutoSelectOutboundOptions configures the client-side server-selection
+// group described in client-server-selection-spec.md. The group probes its
+// members in parallel, selects the lowest-delay healthy candidate (with a
+// switch tolerance to dampen churn), maintains a per-server outcome ring
+// to demote chronically-bad servers, and emits an exhaustion signal when
+// its reconnection ladder fails. Zero values fall back to documented
+// defaults.
+type MutableAutoSelectOutboundOptions struct {
+	Outbounds    []string          `json:"outbounds"`
+	URL          string            `json:"url,omitempty"`
+	URLOverrides map[string]string `json:"url_overrides,omitempty"`
+
+	// SwitchToleranceMs is the delay improvement (in ms) a candidate must
+	// beat the current selection by before the group switches. Default 50.
+	SwitchToleranceMs uint32 `json:"switch_tolerance_ms,omitempty"`
+
+	// HistoryRingSize caps the per-server outcome ring. Default 20.
+	HistoryRingSize uint32 `json:"history_ring_size,omitempty"`
+
+	// SuccessRateWindowMinutes is the look-back window used to compute
+	// recent_success_rate for the demotion filter. Default 60.
+	SuccessRateWindowMinutes uint32 `json:"success_rate_window_minutes,omitempty"`
+
+	// DemoteSuccessRateBelow is the success-rate threshold under which a
+	// server is demoted, provided it also has at least DemoteMinOutcomes
+	// outcomes in the window. Default 0.3.
+	DemoteSuccessRateBelow float64 `json:"demote_success_rate_below,omitempty"`
+
+	// DemoteMinOutcomes is the minimum number of outcomes within the
+	// success-rate window required to consider the rate signal at all.
+	// Default 5.
+	DemoteMinOutcomes uint32 `json:"demote_min_outcomes,omitempty"`
+
+	// ConsecutiveFailureLimit is the consecutive-failure count at which a
+	// server is unconditionally demoted. Default 3.
+	ConsecutiveFailureLimit uint32 `json:"consecutive_failure_limit,omitempty"`
+
+	// BackgroundIntervalSeconds is the active cadence for the low-priority
+	// probe cycle (when data has flowed recently — see
+	// IdleThresholdSeconds). Default 180.
+	BackgroundIntervalSeconds uint32 `json:"background_interval_seconds,omitempty"`
+
+	// IdleIntervalSeconds is the cadence used when no data has flowed
+	// through a wrapped data-plane conn for IdleThresholdSeconds. The
+	// slower cadence trims background traffic on tunnels left idle.
+	// Default 900.
+	IdleIntervalSeconds uint32 `json:"idle_interval_seconds,omitempty"`
+
+	// IdleThresholdSeconds is the no-data-plane-activity window after
+	// which the background probe cadence backs off from
+	// BackgroundIntervalSeconds to IdleIntervalSeconds. Default 600.
+	IdleThresholdSeconds uint32 `json:"idle_threshold_seconds,omitempty"`
+
+	// LadderFastRetryMs is the budget for the first step of the
+	// reconnection ladder (re-probe the current member). Default 1000.
+	LadderFastRetryMs uint32 `json:"ladder_fast_retry_ms,omitempty"`
+
+	// LadderTotalBudgetSeconds is the total budget the reconnection ladder
+	// has before emitting the exhaustion signal. Default 10.
+	LadderTotalBudgetSeconds uint32 `json:"ladder_total_budget_seconds,omitempty"`
+
+	// DataPlaneIdleSeconds is the no-traffic threshold after which an
+	// established tunnel is treated as a data-plane failure. Default 30.
+	DataPlaneIdleSeconds uint32 `json:"data_plane_idle_seconds,omitempty"`
+}

--- a/option/group.go
+++ b/option/group.go
@@ -21,13 +21,8 @@ type MutableURLTestOutboundOptions struct {
 	IdleTimeout  badoption.Duration `json:"idle_timeout,omitempty"`
 }
 
-// MutableAutoSelectOutboundOptions configures the client-side
-// server-selection group. The group probes its members in parallel,
-// selects the lowest-delay healthy candidate (with a switch tolerance to
-// dampen churn), maintains a per-server outcome ring to demote
-// chronically-bad servers, and emits an exhaustion signal when its
-// reconnection ladder fails. Zero values fall back to documented
-// defaults.
+// MutableAutoSelectOutboundOptions configures the MutableAutoSelect
+// group. Zero values fall back to documented defaults.
 type MutableAutoSelectOutboundOptions struct {
 	Outbounds    []string          `json:"outbounds"`
 	URL          string            `json:"url,omitempty"`

--- a/option/group.go
+++ b/option/group.go
@@ -29,7 +29,7 @@ type MutableAutoSelectOutboundOptions struct {
 	URLOverrides map[string]string `json:"url_overrides,omitempty"`
 
 	// SwitchToleranceMs is the delay improvement (in ms) a candidate must
-	// beat the current selection by before the group switches. Default 50.
+	// beat the current selection by before the group switches. Default 200.
 	SwitchToleranceMs uint32 `json:"switch_tolerance_ms,omitempty"`
 
 	// ConsecutiveFailureLimit hard-demotes a member once probe failures
@@ -78,6 +78,12 @@ type MutableAutoSelectOutboundOptions struct {
 	// LadderTotalBudgetSeconds is the total budget the reconnection ladder
 	// has before emitting the exhaustion signal. Default 10.
 	LadderTotalBudgetSeconds uint32 `json:"ladder_total_budget_seconds,omitempty"`
+
+	// LadderCooldownSeconds is the minimum time after a ladder run before
+	// another ladder run can fire. Suppresses repeated full-fleet
+	// re-probes when stalls or dial errors arrive in quick succession on
+	// the same already-shuffled pool. Default 60.
+	LadderCooldownSeconds uint32 `json:"ladder_cooldown_seconds,omitempty"`
 
 	// DataPlaneIdleSeconds is the no-traffic threshold after which an
 	// established and proven tunnel is treated as a data-plane stall.

--- a/option/group.go
+++ b/option/group.go
@@ -32,27 +32,32 @@ type MutableAutoSelectOutboundOptions struct {
 	// beat the current selection by before the group switches. Default 50.
 	SwitchToleranceMs uint32 `json:"switch_tolerance_ms,omitempty"`
 
-	// HistoryRingSize caps the per-server outcome ring. Default 20.
-	HistoryRingSize uint32 `json:"history_ring_size,omitempty"`
-
-	// SuccessRateWindowMinutes is the look-back window used to compute
-	// recent_success_rate for the demotion filter. Default 60.
-	SuccessRateWindowMinutes uint32 `json:"success_rate_window_minutes,omitempty"`
-
-	// DemoteSuccessRateBelow is the success-rate threshold under which a
-	// server is demoted, provided it also has at least DemoteMinOutcomes
-	// outcomes in the window. Default 0.3.
-	DemoteSuccessRateBelow float64 `json:"demote_success_rate_below,omitempty"`
-
-	// DemoteMinOutcomes is the minimum number of outcomes within the
-	// success-rate window required to consider the rate signal at all.
-	// Default 5.
-	DemoteMinOutcomes uint32 `json:"demote_min_outcomes,omitempty"`
-
-	// ConsecutiveFailureLimit bounds both the consecutive probe-failure
-	// count and the user-failure count; reaching it on either counter
-	// unconditionally demotes the server. Default 3.
+	// ConsecutiveFailureLimit hard-demotes a member once probe failures
+	// reach this count, or once user-traffic failures within
+	// UserFailureWindowSeconds reach this count. Default 3.
 	ConsecutiveFailureLimit uint32 `json:"consecutive_failure_limit,omitempty"`
+
+	// SoftDemoteLimit soft-demotes a member once user-traffic failures
+	// within UserFailureWindowSeconds reach this count. A soft-demoted
+	// member loses to every clean peer but still beats hard-demoted
+	// peers. Set lower for a fleet with few alternatives; higher for a
+	// large pool where one transient stall shouldn't be enough to push
+	// the active member behind every clean alternative. Default 2.
+	SoftDemoteLimit uint32 `json:"soft_demote_limit,omitempty"`
+
+	// UserFailureWindowSeconds is the sliding-window length used to
+	// count user-traffic failures (dial errors and data-plane stalls)
+	// for the demote rule. Failures older than this age out of the
+	// window so a transient failure self-recovers without depending on
+	// traffic being routed through the member. Default 300 (5 min).
+	UserFailureWindowSeconds uint32 `json:"user_failure_window_seconds,omitempty"`
+
+	// MaxPersistedAgeSeconds caps the age of persisted TagHistory
+	// entries on hydrate. Entries with UpdatedAt older than this are
+	// dropped — bandit-driven candidate sets typically rotate every
+	// 60 s – 15 min, so a stale snapshot from a prior session would
+	// describe a member that may no longer exist. Default 3600 (1 h).
+	MaxPersistedAgeSeconds uint32 `json:"max_persisted_age_seconds,omitempty"`
 
 	// BackgroundIntervalSeconds is the active cadence for the low-priority
 	// probe cycle (when data has flowed recently — see
@@ -60,25 +65,31 @@ type MutableAutoSelectOutboundOptions struct {
 	BackgroundIntervalSeconds uint32 `json:"background_interval_seconds,omitempty"`
 
 	// IdleIntervalSeconds is the cadence used when no data has flowed
-	// through a wrapped data-plane conn for IdleThresholdSeconds. The
-	// slower cadence trims background traffic on tunnels left idle.
-	// Default 900.
+	// through a wrapped data-plane conn for IdleThresholdSeconds.
+	// Default 900 (15 min).
 	IdleIntervalSeconds uint32 `json:"idle_interval_seconds,omitempty"`
 
 	// IdleThresholdSeconds is the no-data-plane-activity window after
 	// which the background probe cadence backs off from
-	// BackgroundIntervalSeconds to IdleIntervalSeconds. Default 600.
+	// BackgroundIntervalSeconds to IdleIntervalSeconds. Default 600
+	// (10 min).
 	IdleThresholdSeconds uint32 `json:"idle_threshold_seconds,omitempty"`
-
-	// LadderFastRetryMs is the budget for the first step of the
-	// reconnection ladder (re-probe the current member). Default 1000.
-	LadderFastRetryMs uint32 `json:"ladder_fast_retry_ms,omitempty"`
 
 	// LadderTotalBudgetSeconds is the total budget the reconnection ladder
 	// has before emitting the exhaustion signal. Default 10.
 	LadderTotalBudgetSeconds uint32 `json:"ladder_total_budget_seconds,omitempty"`
 
 	// DataPlaneIdleSeconds is the no-traffic threshold after which an
-	// established tunnel is treated as a data-plane failure. Default 30.
+	// established and proven tunnel is treated as a data-plane stall.
+	// Default 60.
 	DataPlaneIdleSeconds uint32 `json:"data_plane_idle_seconds,omitempty"`
+
+	// DataPlaneProvedReadBytes is the cumulative Read-bytes threshold a
+	// single wrapped conn must cross before the data-plane stall timer
+	// is allowed to fire. Before a conn is proven, it is treated as
+	// "established but inactive" — a brand-new conn, a handshake-only
+	// conn, or a keepalive-only conn isn't evidence of stalling and
+	// other failure paths (dial errors, probe failures) catch the
+	// actually-broken cases. Default 4096.
+	DataPlaneProvedReadBytes uint32 `json:"data_plane_proved_read_bytes,omitempty"`
 }

--- a/protocol/group/fallback_test.go
+++ b/protocol/group/fallback_test.go
@@ -15,7 +15,9 @@ import (
 type mockOutbound struct {
 	mock.Mock
 	adapter.Outbound
-	tag string
+	tag      string
+	typeName string
+	networks []string
 }
 
 func (m *mockOutbound) DialContext(ctx context.Context, network string, destination metadata.Socksaddr) (net.Conn, error) {

--- a/protocol/group/mutableautoselect.go
+++ b/protocol/group/mutableautoselect.go
@@ -49,11 +49,7 @@ var (
 
 const probeConcurrency = 6
 
-// MutableAutoSelect is the client-side server-selection group. It probes
-// its members in parallel, picks the lowest-delay healthy candidate with
-// switch-tolerance hysteresis, demotes servers whose probes pass but whose
-// user traffic fails, watches connections for data-plane stalls, and
-// emits an exhaustion signal when every candidate is blocked.
+// MutableAutoSelect is the client-side server-selection group.
 type MutableAutoSelect struct {
 	outbound.Adapter
 	ctx         context.Context
@@ -216,9 +212,7 @@ func (s *MutableAutoSelect) Start() error {
 	return nil
 }
 
-// hydrateHistoryLocked seeds the in-memory localHistory from the persisted
-// snapshot. No-op when an in-memory entry already exists. Caller must hold
-// s.access.
+// Caller must hold s.access. No-op when an in-memory entry already exists.
 func (s *MutableAutoSelect) hydrateHistoryLocked(tag string) {
 	if _, ok := s.histories[tag]; ok {
 		return
@@ -369,8 +363,7 @@ func (s *MutableAutoSelect) SetURLOverrides(overrides map[string]string) {
 	}
 }
 
-// invalidateHistoryLocked drops both the in-memory ring and the persisted
-// snapshot for tag. Caller must hold s.access.
+// Caller must hold s.access.
 func (s *MutableAutoSelect) invalidateHistoryLocked(tag string) {
 	delete(s.histories, tag)
 	if s.history != nil {
@@ -497,9 +490,6 @@ func (s *MutableAutoSelect) NewPacketConnectionEx(ctx context.Context, conn N.Pa
 	s.connMgr.NewPacketConnection(ctx, s, conn, metadata, onClose)
 }
 
-// selectFor ranks every viable member, applies the three-tier demote
-// fallback per network, and picks the winner with switch-tolerance
-// hysteresis against the previous sticky tag.
 func (s *MutableAutoSelect) selectFor(network string) (A.Outbound, error) {
 	var slot *atomic.Value
 	switch network {
@@ -600,9 +590,7 @@ func (s *MutableAutoSelect) peekHistoryLocked(tag string) (*localHistory, bool) 
 	return h, ok
 }
 
-// collectProbeJobsLocked snapshots the current member set into a slice of
-// probe jobs. Excluded protocols (tor, unbounded) are skipped. Caller must
-// hold s.access.
+// Caller must hold s.access. Skips excludeFromPool members.
 func (s *MutableAutoSelect) collectProbeJobsLocked() []probeJob {
 	jobs := make([]probeJob, 0, len(s.tags))
 	for _, tag := range s.tags {
@@ -830,15 +818,6 @@ func (s *MutableAutoSelect) recordOutcome(tag string, o localOutcome, delayMs ui
 	})
 }
 
-// runLadder runs the two-step reconnection ladder (fast retry of target,
-// then a full parallel re-probe) and emits the exhaustion signal if
-// neither step produced a working candidate. Concurrent invocations
-// collapse via the laddering CAS guard. An empty target falls back to
-// the most recent sticky tag (TCP preferred, UDP secondary).
-//
-// Step 1 is skipped when target has any user-failure evidence: probe
-// URLs can still pass while real traffic doesn't (a common censorship
-// shape), and step 1 would just launder those failures.
 func (s *MutableAutoSelect) runLadder(target string) {
 	if s.isClosed() {
 		return
@@ -870,6 +849,9 @@ func (s *MutableAutoSelect) runLadder(target string) {
 			}
 		}
 	}
+	// Skip step 1 when the target has any user-failure evidence: probes
+	// can pass while real traffic doesn't, and step 1 would just launder
+	// that.
 	skipStep1 := false
 	if current != nil {
 		s.access.Lock()
@@ -958,10 +940,6 @@ func (s *MutableAutoSelect) nextProbeInterval() time.Duration {
 	return s.cfg.activeInterval
 }
 
-// runBackgroundLoop drives the low-priority probe cycle that keeps
-// alternative members warm. The ticker is registered with the pause
-// manager so probes are suppressed while the device is paused; the
-// adaptive cadence reasserts on every tick via nextProbeInterval.
 // TODO: skip on metered connections once lantern-box's platform interface
 // gains a network-cost API.
 func (s *MutableAutoSelect) runBackgroundLoop() {

--- a/protocol/group/mutableautoselect.go
+++ b/protocol/group/mutableautoselect.go
@@ -635,7 +635,9 @@ const (
 )
 
 // demoteLevel ranks how cautious selection should be about a candidate.
-// Ordering is load-bearing: see candidateKind.
+// Ordering is load-bearing: rank sorts on the integer value, so
+// demoteClean must compare < demoteSoft < demoteHard for the tiers to
+// land in the right order.
 type demoteLevel uint8
 
 const (
@@ -892,7 +894,7 @@ func (s *MutableAutoSelect) runLadder(target string) {
 		}
 	} else if skipStep1 {
 		s.logger.Info("ladder skipping step 1: ", current.Tag(),
-			" has crossed user-failure limit; jumping straight to step 2")
+			" has a non-zero user-failure count; jumping straight to step 2")
 	}
 
 	s.logger.Info("ladder step 2: full re-probe")

--- a/protocol/group/mutableautoselect.go
+++ b/protocol/group/mutableautoselect.go
@@ -1,0 +1,991 @@
+package group
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"net"
+	"slices"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	A "github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/outbound"
+	"github.com/sagernet/sing-box/log"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+	"github.com/sagernet/sing/service"
+	"github.com/sagernet/sing/service/pause"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/getlantern/lantern-box/adapter"
+	"github.com/getlantern/lantern-box/constant"
+	isync "github.com/getlantern/lantern-box/internal/sync"
+	lLog "github.com/getlantern/lantern-box/log"
+	"github.com/getlantern/lantern-box/option"
+)
+
+func RegisterMutableAutoSelect(registry *outbound.Registry) {
+	outbound.Register[option.MutableAutoSelectOutboundOptions](registry, constant.TypeMutableAutoSelect, NewMutableAutoSelect)
+}
+
+var (
+	_ adapter.MutableOutboundGroup = (*MutableAutoSelect)(nil)
+	_ A.OutboundGroup              = (*MutableAutoSelect)(nil)
+	_ A.URLTestGroup               = (*MutableAutoSelect)(nil)
+	_ A.InterfaceUpdateListener    = (*MutableAutoSelect)(nil)
+	_ A.ConnectionHandlerEx        = (*MutableAutoSelect)(nil)
+	_ A.PacketConnectionHandlerEx  = (*MutableAutoSelect)(nil)
+	_ adapter.URLOverrideSetter    = (*MutableAutoSelect)(nil)
+	_ adapter.OutboundChecker      = (*MutableAutoSelect)(nil)
+	_ adapter.ExhaustionSignaler   = (*MutableAutoSelect)(nil)
+)
+
+const probeConcurrency = 6
+
+// MutableAutoSelect is the client-side server-selection group. It probes
+// its members in parallel, picks the lowest-delay healthy candidate with
+// switch-tolerance hysteresis, demotes servers whose probes pass but whose
+// user traffic fails, watches connections for data-plane stalls, and
+// emits an exhaustion signal when every candidate is blocked.
+type MutableAutoSelect struct {
+	outbound.Adapter
+	ctx         context.Context
+	cancel      context.CancelFunc
+	outboundMgr A.OutboundManager
+	connMgr     A.ConnectionManager
+	logger      log.ContextLogger
+
+	access       sync.Mutex
+	tags         []string
+	members      isync.TypedMap[string, A.Outbound]
+	urlOverrides map[string]string
+	defaultURL   string
+	histories    map[string]*localHistory
+	cfg          mutableAutoSelectConfig
+	hist         historyParams
+	history      adapter.AutoSelectHistoryStorage
+
+	// Last dial-time tag per network, for switch-tolerance hysteresis.
+	// atomic.Value (not access-guarded) so Now() can read without taking
+	// the access lock. A stale tag is harmless: the in-pool check in
+	// applyStickiness drops it.
+	stickyTag struct {
+		tcp atomic.Value // string; "" when unset
+		udp atomic.Value // string; "" when unset
+	}
+
+	// probeMu serializes probe cycles. Fire-and-forget callers
+	// (runProbeCycle) TryLock; callers that need a deterministic outcome
+	// (URLTest, runLadder) Lock so they observe the cycle they triggered.
+	probeMu           sync.Mutex
+	laddering         atomic.Bool
+	exhaustionEmitted atomic.Bool
+	exhaustionCh      chan struct{}
+
+	// Unix-nano of the most recent non-empty data-plane Read/Write; 0
+	// means no traffic observed yet. Drives the adaptive probe cadence.
+	lastActive atomic.Int64
+
+	started   bool
+	closeOnce sync.Once
+}
+
+type mutableAutoSelectConfig struct {
+	switchTolerance   time.Duration
+	activeInterval    time.Duration
+	idleInterval      time.Duration
+	idleThreshold     time.Duration
+	ladderFastRetry   time.Duration
+	ladderTotalBudget time.Duration
+	dataPlaneIdle     time.Duration
+}
+
+func resolveMutableAutoSelectOptions(o option.MutableAutoSelectOutboundOptions) (mutableAutoSelectConfig, historyParams) {
+	cfg := mutableAutoSelectConfig{
+		switchTolerance:   time.Duration(o.SwitchToleranceMs) * time.Millisecond,
+		activeInterval:    time.Duration(o.BackgroundIntervalSeconds) * time.Second,
+		idleInterval:      time.Duration(o.IdleIntervalSeconds) * time.Second,
+		idleThreshold:     time.Duration(o.IdleThresholdSeconds) * time.Second,
+		ladderFastRetry:   time.Duration(o.LadderFastRetryMs) * time.Millisecond,
+		ladderTotalBudget: time.Duration(o.LadderTotalBudgetSeconds) * time.Second,
+		dataPlaneIdle:     time.Duration(o.DataPlaneIdleSeconds) * time.Second,
+	}
+	if cfg.switchTolerance == 0 {
+		cfg.switchTolerance = 50 * time.Millisecond
+	}
+	if cfg.activeInterval == 0 {
+		cfg.activeInterval = 180 * time.Second
+	}
+	if cfg.idleInterval == 0 {
+		cfg.idleInterval = 900 * time.Second
+	}
+	if cfg.idleThreshold == 0 {
+		cfg.idleThreshold = 600 * time.Second
+	}
+	if cfg.ladderFastRetry == 0 {
+		cfg.ladderFastRetry = 1000 * time.Millisecond
+	}
+	if cfg.ladderTotalBudget == 0 {
+		cfg.ladderTotalBudget = 10 * time.Second
+	}
+	if cfg.dataPlaneIdle == 0 {
+		cfg.dataPlaneIdle = defaultDataPlaneIdle
+	}
+
+	hp := defaultHistoryParams()
+	if o.HistoryRingSize > 0 {
+		hp.ringMax = int(o.HistoryRingSize)
+	}
+	if o.SuccessRateWindowMinutes > 0 {
+		hp.successRateWindow = time.Duration(o.SuccessRateWindowMinutes) * time.Minute
+	}
+	if o.DemoteSuccessRateBelow > 0 {
+		hp.demoteSuccessRate = o.DemoteSuccessRateBelow
+	}
+	if o.DemoteMinOutcomes > 0 {
+		hp.demoteMinOutcomes = o.DemoteMinOutcomes
+	}
+	if o.ConsecutiveFailureLimit > 0 {
+		hp.consecutiveFailLimit = o.ConsecutiveFailureLimit
+	}
+	return cfg, hp
+}
+
+func NewMutableAutoSelect(ctx context.Context, _ A.Router, logger log.ContextLogger, tag string, options option.MutableAutoSelectOutboundOptions) (A.Outbound, error) {
+	cfg, hp := resolveMutableAutoSelectOptions(options)
+	ctx, cancel := context.WithCancel(ctx)
+	out := &MutableAutoSelect{
+		Adapter:      outbound.NewAdapter(constant.TypeMutableAutoSelect, tag, []string{"tcp", "udp"}, nil),
+		ctx:          ctx,
+		cancel:       cancel,
+		outboundMgr:  service.FromContext[A.OutboundManager](ctx),
+		connMgr:      service.FromContext[A.ConnectionManager](ctx),
+		logger:       logger,
+		tags:         append([]string(nil), options.Outbounds...),
+		urlOverrides: maps.Clone(options.URLOverrides),
+		defaultURL:   options.URL,
+		histories:    make(map[string]*localHistory),
+		cfg:          cfg,
+		hist:         hp,
+		history:      resolveHistoryStorage(ctx),
+		exhaustionCh: make(chan struct{}, 1),
+	}
+	if slogger, ok := logger.(lLog.SLogger); ok {
+		nfact := lLog.NewFactory(slogger.SlogHandler().WithAttrs([]slog.Attr{slog.String("mutableautoselect_group", tag)}))
+		out.logger = nfact.Logger()
+	}
+	return out, nil
+}
+
+func resolveHistoryStorage(ctx context.Context) adapter.AutoSelectHistoryStorage {
+	if h := service.FromContext[adapter.AutoSelectHistoryStorage](ctx); h != nil {
+		return h
+	}
+	return adapter.NewAutoSelectHistoryStorage()
+}
+
+// Start resolves every configured tag to an outbound atomically: a missing
+// tag aborts without partially populating s.members.
+func (s *MutableAutoSelect) Start() error {
+	s.access.Lock()
+	defer s.access.Unlock()
+
+	if len(s.tags) == 0 {
+		return nil
+	}
+
+	loaded := make(map[string]A.Outbound, len(s.tags))
+	for _, tag := range s.tags {
+		o, found := s.outboundMgr.Outbound(tag)
+		if !found {
+			return fmt.Errorf("outbound %s not found", tag)
+		}
+		loaded[tag] = o
+	}
+	for tag, o := range loaded {
+		s.members.Store(tag, o)
+		s.hydrateHistoryLocked(tag)
+	}
+	return nil
+}
+
+// hydrateHistoryLocked seeds the in-memory localHistory from the persisted
+// snapshot. No-op when an in-memory entry already exists. Caller must hold
+// s.access.
+func (s *MutableAutoSelect) hydrateHistoryLocked(tag string) {
+	if _, ok := s.histories[tag]; ok {
+		return
+	}
+	if s.history == nil {
+		return
+	}
+	snap := s.history.Load(tag)
+	if snap == nil {
+		return
+	}
+	s.histories[tag] = hydrateLocalHistory(snap, s.hist.ringMax)
+}
+
+// PostStart is idempotent: a second invocation is a no-op rather than a
+// duplicate background loop.
+func (s *MutableAutoSelect) PostStart() error {
+	s.access.Lock()
+	if s.started {
+		s.access.Unlock()
+		return nil
+	}
+	s.started = true
+	s.access.Unlock()
+	go s.runBackgroundLoop()
+	s.CheckOutbounds()
+	return nil
+}
+
+func (s *MutableAutoSelect) Close() error {
+	s.closeOnce.Do(func() {
+		s.cancel()
+		// Close under s.access so emitExhaustion (which holds the same
+		// lock around its send) can't race a send into a closed channel.
+		s.access.Lock()
+		close(s.exhaustionCh)
+		s.access.Unlock()
+	})
+	return nil
+}
+
+func (s *MutableAutoSelect) InterfaceUpdated() {
+	s.logger.Info("interface updated, re-probing mutableautoselect group")
+	go s.runProbeCycle(s.ctx)
+}
+
+// Now reports the most recent dial-time selection, TCP preferred, UDP
+// fallback. Single representative tag for telemetry; not a per-network
+// route — TCP and UDP select independently at dial time.
+func (s *MutableAutoSelect) Now() string {
+	if t := loadString(&s.stickyTag.tcp); t != "" {
+		return t
+	}
+	return loadString(&s.stickyTag.udp)
+}
+
+func (s *MutableAutoSelect) All() []string {
+	s.access.Lock()
+	defer s.access.Unlock()
+	out := make([]string, len(s.tags))
+	copy(out, s.tags)
+	return out
+}
+
+func (s *MutableAutoSelect) Add(tags ...string) (n int, err error) {
+	s.access.Lock()
+	defer s.access.Unlock()
+	if s.isClosed() {
+		return 0, errors.New("group is closed")
+	}
+	var missing []string
+	for _, tag := range tags {
+		if _, exists := s.members.Load(tag); exists {
+			continue
+		}
+		// A tag may be in s.tags without a members entry after a partial
+		// init failure. Don't re-append in that case.
+		alreadyListed := slices.Contains(s.tags, tag)
+		o, found := s.outboundMgr.Outbound(tag)
+		if !found {
+			missing = append(missing, tag)
+			continue
+		}
+		s.members.Store(tag, o)
+		s.hydrateHistoryLocked(tag)
+		if !alreadyListed {
+			s.tags = append(s.tags, tag)
+		}
+		n++
+	}
+	if len(missing) > 0 {
+		return n, fmt.Errorf("%d outbounds not found: %v", len(missing), missing)
+	}
+	return n, nil
+}
+
+func (s *MutableAutoSelect) Remove(tags ...string) (n int, err error) {
+	s.access.Lock()
+	defer s.access.Unlock()
+	if s.isClosed() {
+		return 0, errors.New("group is closed")
+	}
+	removed := make(map[string]struct{}, len(tags))
+	for _, tag := range tags {
+		if _, exists := s.members.Load(tag); !exists {
+			continue
+		}
+		s.members.Delete(tag)
+		delete(s.histories, tag)
+		if s.history != nil {
+			s.history.Delete(tag)
+		}
+		s.clearStickyTagLocked(tag)
+		removed[tag] = struct{}{}
+		n++
+	}
+	if n > 0 {
+		// Preserve registration order; rank() ties on first-seen in s.tags.
+		filtered := s.tags[:0]
+		for _, tag := range s.tags {
+			if _, gone := removed[tag]; gone {
+				continue
+			}
+			filtered = append(filtered, tag)
+		}
+		s.tags = filtered
+	}
+	return
+}
+
+// SetURLOverrides replaces the per-member callback URL map. Members whose
+// override changed (including removals) get their history dropped so the
+// next probe cycle re-tests against the new URL.
+func (s *MutableAutoSelect) SetURLOverrides(overrides map[string]string) {
+	s.access.Lock()
+	defer s.access.Unlock()
+	old := s.urlOverrides
+	s.urlOverrides = maps.Clone(overrides)
+	for tag, v := range s.urlOverrides {
+		if old[tag] != v {
+			s.invalidateHistoryLocked(tag)
+		}
+	}
+	for tag := range old {
+		if _, kept := s.urlOverrides[tag]; !kept {
+			s.invalidateHistoryLocked(tag)
+		}
+	}
+}
+
+// invalidateHistoryLocked drops both the in-memory ring and the persisted
+// snapshot for tag. Caller must hold s.access.
+func (s *MutableAutoSelect) invalidateHistoryLocked(tag string) {
+	delete(s.histories, tag)
+	if s.history != nil {
+		s.history.Delete(tag)
+	}
+}
+
+func (s *MutableAutoSelect) CheckOutbounds() {
+	go s.runProbeCycle(s.ctx)
+}
+
+// ExhaustionSignal returns a receive-only channel that emits when every
+// candidate fails within a ladder's budget. Buffers one pending signal;
+// an unread signal is replaced by the next ladder's emission. Closed on
+// group Close so range-loop consumers terminate cleanly.
+func (s *MutableAutoSelect) ExhaustionSignal() <-chan struct{} {
+	return s.exhaustionCh
+}
+
+// URLTest implements sing-box's URLTestGroup contract: probes every
+// member in parallel and returns delay_ms per success. Used by the
+// offline pre-warm path before Start, so members are resolved lazily
+// from the outbound manager when not already loaded.
+func (s *MutableAutoSelect) URLTest(ctx context.Context) (map[string]uint16, error) {
+	results := make(map[string]uint16)
+
+	s.probeMu.Lock()
+	defer s.probeMu.Unlock()
+
+	s.access.Lock()
+	if len(s.tags) == 0 {
+		s.access.Unlock()
+		return results, nil
+	}
+	for _, tag := range s.tags {
+		if _, ok := s.members.Load(tag); ok {
+			continue
+		}
+		o, found := s.outboundMgr.Outbound(tag)
+		if !found {
+			continue
+		}
+		s.members.Store(tag, o)
+		// Hydrate before the first recordOutcome lands so the persisted
+		// ring isn't clobbered by a one-entry write from an empty
+		// in-memory localHistory.
+		s.hydrateHistoryLocked(tag)
+	}
+	jobs := s.collectProbeJobsLocked()
+	s.access.Unlock()
+
+	s.probeAll(ctx, jobs, func(res probeResult) {
+		results[res.tag] = uint16(min(65535, res.delayMs))
+	})
+	return results, nil
+}
+
+func (s *MutableAutoSelect) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "MutableAutoSelect.DialContext", trace.WithAttributes(
+		attribute.String("network", network),
+		attribute.StringSlice("supported_network_options", s.Network()),
+		attribute.String("outbound", s.Now()),
+		attribute.String("tag", s.Tag()),
+		attribute.String("type", s.Type()),
+	))
+	defer span.End()
+
+	o, err := s.selectFor(network)
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+	outerTag := o.Tag()
+	conn, err := o.DialContext(ctx, network, destination)
+	if err != nil {
+		s.logger.ErrorContext(ctx, err)
+		// Attribute the failure to the outer (member) tag so rank and
+		// runLadder's skip-step-1 check both see the bump. For nested
+		// groups, the inner tag isn't a member of this group, so
+		// recordUserFailure would drop on the member gate.
+		s.recordUserFailure(outerTag)
+		go s.runLadder(outerTag)
+		span.RecordError(err)
+		return nil, err
+	}
+	onStall, onRead := s.makeHooks(outerTag)
+	wrapped := newDataPlaneStream(conn, s.cfg.dataPlaneIdle, onStall, s.bumpActive, onRead)
+	return adapter.NewTaggedConn(wrapped, realTag(o)), nil
+}
+
+func (s *MutableAutoSelect) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "MutableAutoSelect.ListenPacket", trace.WithAttributes(
+		attribute.StringSlice("supported_network_options", s.Network()),
+		attribute.String("outbound", s.Now()),
+		attribute.String("tag", s.Tag()),
+		attribute.String("type", s.Type()),
+	))
+	defer span.End()
+
+	o, err := s.selectFor("udp")
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+	outerTag := o.Tag()
+	conn, err := o.ListenPacket(ctx, destination)
+	if err != nil {
+		s.logger.ErrorContext(ctx, err)
+		s.recordUserFailure(outerTag)
+		go s.runLadder(outerTag)
+		span.RecordError(err)
+		return nil, err
+	}
+	onStall, onRead := s.makeHooks(outerTag)
+	wrapped := newDataPlanePacket(conn, s.cfg.dataPlaneIdle, onStall, s.bumpActive, onRead)
+	return adapter.NewTaggedPacketConn(wrapped, realTag(o)), nil
+}
+
+func (s *MutableAutoSelect) NewConnectionEx(ctx context.Context, conn net.Conn, metadata A.InboundContext, onClose N.CloseHandlerFunc) {
+	s.connMgr.NewConnection(ctx, s, conn, metadata, onClose)
+}
+
+func (s *MutableAutoSelect) NewPacketConnectionEx(ctx context.Context, conn N.PacketConn, metadata A.InboundContext, onClose N.CloseHandlerFunc) {
+	s.connMgr.NewPacketConnection(ctx, s, conn, metadata, onClose)
+}
+
+// selectFor ranks every viable member, applies the three-tier demote
+// fallback per network, and picks the winner with switch-tolerance
+// hysteresis against the previous sticky tag.
+func (s *MutableAutoSelect) selectFor(network string) (A.Outbound, error) {
+	var slot *atomic.Value
+	switch network {
+	case "tcp":
+		slot = &s.stickyTag.tcp
+	case "udp":
+		slot = &s.stickyTag.udp
+	default:
+		return nil, fmt.Errorf("network %s not supported", network)
+	}
+	s.access.Lock()
+	ranked := s.rank(time.Now(), time.Time{})
+	pool := splitHealthyFor(ranked, network)
+	if len(pool) == 0 {
+		s.access.Unlock()
+		s.CheckOutbounds()
+		return nil, errors.New("no outbound available, recovery in progress")
+	}
+	winner := s.applyStickiness(network, slot, pool)
+	prev := loadString(slot)
+	if prev != winner.tag {
+		slot.Store(winner.tag)
+		if prev == "" {
+			s.logger.Info(network, " select: ", winner.tag)
+		}
+	}
+	s.access.Unlock()
+	return winner.outbound, nil
+}
+
+// applyStickiness applies the spec's switch-tolerance hysteresis: keep
+// the sticky tag if it's in pool and the rank winner doesn't beat it by
+// at least switchTolerance. Caller must hold s.access.
+func (s *MutableAutoSelect) applyStickiness(network string, slot *atomic.Value, pool []rankedCandidate) rankedCandidate {
+	best := pool[0]
+	sticky := loadString(slot)
+	if sticky == "" || sticky == best.tag {
+		return best
+	}
+	for _, c := range pool {
+		if c.tag != sticky {
+			continue
+		}
+		tolMs := uint64(s.cfg.switchTolerance / time.Millisecond)
+		if uint64(best.delayMs)+tolMs <= uint64(c.delayMs) {
+			s.logger.Info(network, " switch: ", c.tag, "(", c.delayMs, "ms) -> ", best.tag, "(", best.delayMs, "ms)")
+			return best
+		}
+		return c
+	}
+	s.logger.Info(network, " switch: ", sticky, " -> ", best.tag, " (sticky not in pool)")
+	return best
+}
+
+// clearStickyTagLocked drops the sticky tag for any network where it
+// equals tag. Caller must hold s.access.
+func (s *MutableAutoSelect) clearStickyTagLocked(tag string) {
+	for _, slot := range [...]*atomic.Value{&s.stickyTag.tcp, &s.stickyTag.udp} {
+		if loadString(slot) == tag {
+			slot.Store("")
+		}
+	}
+}
+
+func loadString(v *atomic.Value) string {
+	s, _ := v.Load().(string)
+	return s
+}
+
+type probeJob struct {
+	outbound A.Outbound
+	probeURL string
+	beh      protocolBehavior
+}
+
+func (s *MutableAutoSelect) probeURLForLocked(tag string) string {
+	if u, ok := s.urlOverrides[tag]; ok && u != "" {
+		return u
+	}
+	return s.defaultURL
+}
+
+// historyForLocked returns the history for tag, creating an empty one if
+// none exists. Use only on the write path; read-only callers must use
+// peekHistoryLocked so ranking a never-probed tag doesn't litter the map.
+// Caller must hold s.access.
+func (s *MutableAutoSelect) historyForLocked(tag string) *localHistory {
+	h, ok := s.histories[tag]
+	if !ok {
+		h = newLocalHistory(s.hist.ringMax)
+		s.histories[tag] = h
+	}
+	return h
+}
+
+func (s *MutableAutoSelect) peekHistoryLocked(tag string) (*localHistory, bool) {
+	h, ok := s.histories[tag]
+	return h, ok
+}
+
+// collectProbeJobsLocked snapshots the current member set into a slice of
+// probe jobs. Excluded protocols (tor, unbounded) are skipped. Caller must
+// hold s.access.
+func (s *MutableAutoSelect) collectProbeJobsLocked() []probeJob {
+	jobs := make([]probeJob, 0, len(s.tags))
+	for _, tag := range s.tags {
+		o, ok := s.members.Load(tag)
+		if !ok {
+			continue
+		}
+		beh := behaviorFor(o.Type())
+		if beh.excludeFromPool {
+			continue
+		}
+		jobs = append(jobs, probeJob{
+			outbound: o,
+			probeURL: s.probeURLForLocked(tag),
+			beh:      beh,
+		})
+	}
+	return jobs
+}
+
+// candidateKind classifies confidence in a candidate's delay measurement.
+// Ordering is load-bearing: rank's sort treats the integer value as the
+// tie-break key, so real-seeded must come first and substituted last.
+type candidateKind uint8
+
+const (
+	kindRealSeeded  candidateKind = iota // measured delay from a real probe
+	kindUnknown                          // no in-memory data and no persisted seed
+	kindSubstituted                      // protocol carries a substituteDelay (samizdat)
+)
+
+// demoteLevel ranks how cautious selection should be about a candidate.
+// Ordering is load-bearing: see candidateKind.
+type demoteLevel uint8
+
+const (
+	demoteClean demoteLevel = iota
+	demoteSoft              // userFailures > 0 but demote() says no
+	demoteHard              // demote() returned true
+)
+
+type rankedCandidate struct {
+	outbound A.Outbound
+	tag      string
+	delayMs  uint32
+	demote   demoteLevel
+	kind     candidateKind
+}
+
+// splitHealthyFor restricts ranked to candidates supporting network,
+// then returns the cleanest non-empty subset: clean if any exist, else
+// soft-demoted, else the network-filtered slice (hard-demoted as last
+// resort). Per-network so a soft-only UDP candidate isn't drowned out
+// by a clean TCP-only peer.
+func splitHealthyFor(ranked []rankedCandidate, network string) []rankedCandidate {
+	var filtered, clean, soft []rankedCandidate
+	for _, c := range ranked {
+		if !slices.Contains(c.outbound.Network(), network) {
+			continue
+		}
+		filtered = append(filtered, c)
+		switch c.demote {
+		case demoteClean:
+			clean = append(clean, c)
+		case demoteSoft:
+			soft = append(soft, c)
+		}
+	}
+	if len(clean) > 0 {
+		return clean
+	}
+	if len(soft) > 0 {
+		return soft
+	}
+	return filtered
+}
+
+// rank builds the candidate set for selection. A non-zero freshSince
+// restricts to members with a recorded outcome at or after freshSince
+// and drops those without a fresh success (rawDelay==0); the
+// probe-cycle ranker uses this so the "is there a winner this cycle?"
+// check can't see stale outcomes. Caller must hold s.access.
+func (s *MutableAutoSelect) rank(now time.Time, freshSince time.Time) []rankedCandidate {
+	out := make([]rankedCandidate, 0, len(s.tags))
+	for _, tag := range s.tags {
+		o, ok := s.members.Load(tag)
+		if !ok {
+			continue
+		}
+		beh := behaviorFor(o.Type())
+		if beh.excludeFromPool {
+			continue
+		}
+		var (
+			rawDelay  uint32
+			hard      bool
+			userFails uint32
+			haveData  bool
+		)
+		if h, ok := s.peekHistoryLocked(tag); ok {
+			entries, consec, fails := h.snapshot()
+			if !freshSince.IsZero() && !hasOutcomeSince(entries, freshSince) {
+				continue
+			}
+			rawDelay = lastSuccessDelay(entries)
+			hard = demoted(entries, consec, fails, now, s.hist)
+			userFails = fails
+			haveData = true
+		} else if freshSince.IsZero() && s.history != nil {
+			// Cold member (added without going through hydrate). Fall back
+			// to the persisted snapshot so recompute-style callers see
+			// host-injected data. Probe-cycle callers (freshSince set) skip
+			// this branch — they only count outcomes from this cycle.
+			if seed := s.history.Load(tag); seed != nil {
+				entries := localizeOutcomes(seed.Outcomes)
+				rawDelay = lastSuccessDelay(entries)
+				hard = demoted(entries, seed.ConsecutiveFailures, seed.UserFailures, now, s.hist)
+				userFails = seed.UserFailures
+				haveData = true
+			}
+		}
+		if !freshSince.IsZero() && (!haveData || rawDelay == 0) {
+			continue
+		}
+		var (
+			delay uint32
+			kind  candidateKind
+		)
+		switch {
+		case beh.substituteDelay > 0:
+			delay, kind = uint32(beh.substituteDelay/time.Millisecond), kindSubstituted
+		case rawDelay == 0:
+			delay, kind = 0, kindUnknown
+		default:
+			delay, kind = rawDelay, kindRealSeeded
+		}
+		level := demoteClean
+		switch {
+		case hard:
+			level = demoteHard
+		case userFails > 0:
+			level = demoteSoft
+		}
+		out = append(out, rankedCandidate{outbound: o, tag: tag, delayMs: delay, kind: kind, demote: level})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		if a.demote != b.demote {
+			return a.demote < b.demote
+		}
+		if a.kind != b.kind {
+			return a.kind < b.kind
+		}
+		return a.delayMs < b.delayMs
+	})
+	return out
+}
+
+// runProbeCycle is the fire-and-forget entry point; it skips when another
+// cycle is in flight. Callers that need a deterministic outcome acquire
+// s.probeMu directly and call probeCycleInner.
+func (s *MutableAutoSelect) runProbeCycle(ctx context.Context) {
+	if !s.probeMu.TryLock() {
+		return
+	}
+	defer s.probeMu.Unlock()
+	s.probeCycleInner(ctx, time.Now())
+}
+
+// probeCycleInner probes every non-excluded member in parallel and
+// returns the lowest-delay candidate that succeeded at or after
+// cycleStart, or nil when no candidate succeeded. Caller must hold
+// s.probeMu so concurrent cycles can't interleave recordOutcome calls.
+func (s *MutableAutoSelect) probeCycleInner(ctx context.Context, cycleStart time.Time) A.Outbound {
+	s.access.Lock()
+	jobs := s.collectProbeJobsLocked()
+	s.access.Unlock()
+	if len(jobs) == 0 {
+		return nil
+	}
+	s.probeAll(ctx, jobs, nil)
+
+	s.access.Lock()
+	defer s.access.Unlock()
+	ranked := s.rank(time.Now(), cycleStart)
+	if len(ranked) == 0 {
+		return nil
+	}
+	return ranked[0].outbound
+}
+
+// mutateHistory applies fn to tag's history under s.access and persists
+// the result when fn returns true. Drops silently when tag is no longer a
+// member. Holds the lock through both the in-memory mutation and the
+// persistence write so a concurrent Remove can't be undone by a late
+// goroutine. fn is passed the timestamp used for both the entry and the
+// persisted snapshot.
+func (s *MutableAutoSelect) mutateHistory(tag string, fn func(*localHistory, time.Time) bool) {
+	s.access.Lock()
+	defer s.access.Unlock()
+	if _, member := s.members.Load(tag); !member {
+		return
+	}
+	h := s.historyForLocked(tag)
+	now := time.Now()
+	if !fn(h, now) || s.history == nil {
+		return
+	}
+	s.history.Store(tag, h.toTagHistory(now))
+}
+
+func (s *MutableAutoSelect) recordUserFailure(tag string) {
+	s.mutateHistory(tag, func(h *localHistory, _ time.Time) bool {
+		h.bumpUserFailures()
+		return true
+	})
+}
+
+func (s *MutableAutoSelect) recordOutcome(tag string, o localOutcome, delayMs uint32) {
+	s.mutateHistory(tag, func(h *localHistory, now time.Time) bool {
+		h.append(o, delayMs, now)
+		return true
+	})
+}
+
+// runLadder runs the two-step reconnection ladder (fast retry of target,
+// then a full parallel re-probe) and emits the exhaustion signal if
+// neither step produced a working candidate. Concurrent invocations
+// collapse via the laddering CAS guard. An empty target falls back to
+// the most recent sticky tag (TCP preferred, UDP secondary).
+//
+// Step 1 is skipped when target has any user-failure evidence: probe
+// URLs can still pass while real traffic doesn't (a common censorship
+// shape), and step 1 would just launder those failures.
+func (s *MutableAutoSelect) runLadder(target string) {
+	if s.isClosed() {
+		return
+	}
+	if !s.laddering.CompareAndSwap(false, true) {
+		return
+	}
+	defer s.laddering.Store(false)
+	s.exhaustionEmitted.Store(false)
+	deadline := time.Now().Add(s.cfg.ladderTotalBudget)
+
+	var current A.Outbound
+	if target != "" {
+		if o, ok := s.members.Load(target); ok {
+			current = o
+		}
+	}
+	if current == nil {
+		for _, t := range [2]string{
+			loadString(&s.stickyTag.tcp),
+			loadString(&s.stickyTag.udp),
+		} {
+			if t == "" {
+				continue
+			}
+			if o, ok := s.members.Load(t); ok {
+				current = o
+				break
+			}
+		}
+	}
+	skipStep1 := false
+	if current != nil {
+		s.access.Lock()
+		if h, ok := s.peekHistoryLocked(current.Tag()); ok && h.userFailureCount() > 0 {
+			skipStep1 = true
+		}
+		s.access.Unlock()
+	}
+	if current != nil && !skipStep1 {
+		s.logger.Info("ladder step 1: fast retry of ", current.Tag())
+		fastCtx, cancel := context.WithTimeout(s.ctx, s.cfg.ladderFastRetry)
+		defer cancel()
+		s.access.Lock()
+		probeURL := s.probeURLForLocked(current.Tag())
+		beh := behaviorFor(current.Type())
+		s.access.Unlock()
+		res := runProbe(fastCtx, current, probeURL, beh)
+		s.recordOutcome(res.tag, res.outcome, res.delayMs)
+		if res.outcome == outcomeSuccess {
+			s.logger.Info("ladder step 1 succeeded for ", current.Tag())
+			return
+		}
+	} else if skipStep1 {
+		s.logger.Info("ladder skipping step 1: ", current.Tag(),
+			" has crossed user-failure limit; jumping straight to step 2")
+	}
+
+	s.logger.Info("ladder step 2: full re-probe")
+	// Lock (not TryLock) so the exhaustion gate keys off this call's
+	// cycle, never a stale bg cycle. Compute the budget after the wait
+	// so serialization queueing doesn't eat probing time.
+	s.probeMu.Lock()
+	remaining := time.Until(deadline)
+	if minStep2 := s.cfg.ladderTotalBudget / 2; remaining < minStep2 {
+		remaining = minStep2
+	}
+	fullCtx, cancel := context.WithTimeout(s.ctx, remaining)
+	defer cancel()
+	winner := s.probeCycleInner(fullCtx, time.Now())
+	s.probeMu.Unlock()
+	if s.isClosed() {
+		return
+	}
+	if winner == nil {
+		s.logger.Warn("ladder exhausted: no candidate succeeded")
+		s.emitExhaustion()
+		return
+	}
+	s.logger.Info("ladder step 2 found winner: ", winner.Tag())
+}
+
+func (s *MutableAutoSelect) emitExhaustion() {
+	if !s.exhaustionEmitted.CompareAndSwap(false, true) {
+		return
+	}
+	// Hold s.access across drain+send so Close (which closes the channel
+	// under the same lock) can't turn the send into a panic-on-closed.
+	s.access.Lock()
+	defer s.access.Unlock()
+	if s.isClosed() {
+		return
+	}
+	// Drop any unread pending signal; the channel buffers exactly one.
+	select {
+	case <-s.exhaustionCh:
+	default:
+	}
+	select {
+	case s.exhaustionCh <- struct{}{}:
+	default:
+	}
+}
+
+func (s *MutableAutoSelect) bumpActive() {
+	s.lastActive.Store(time.Now().UnixNano())
+}
+
+// nextProbeInterval picks the cadence for the next background probe. A
+// brand-new group (lastActive == 0) is treated as idle so we don't burn
+// the fast cadence on a tunnel nobody is using yet.
+func (s *MutableAutoSelect) nextProbeInterval() time.Duration {
+	last := s.lastActive.Load()
+	if last == 0 || time.Since(time.Unix(0, last)) > s.cfg.idleThreshold {
+		return s.cfg.idleInterval
+	}
+	return s.cfg.activeInterval
+}
+
+// runBackgroundLoop drives the low-priority probe cycle that keeps
+// alternative members warm. The ticker is registered with the pause
+// manager so probes are suppressed while the device is paused; the
+// adaptive cadence reasserts on every tick via nextProbeInterval.
+// TODO: skip on metered connections once lantern-box's platform interface
+// gains a network-cost API.
+func (s *MutableAutoSelect) runBackgroundLoop() {
+	activeInterval := s.cfg.activeInterval
+	t := time.NewTicker(activeInterval)
+	defer t.Stop()
+	if pm := service.FromContext[pause.Manager](s.ctx); pm != nil {
+		cb := pause.RegisterTicker(pm, t, activeInterval, nil)
+		defer pm.UnregisterCallback(cb)
+	}
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-t.C:
+			t.Reset(s.nextProbeInterval())
+			go s.runProbeCycle(s.ctx)
+		}
+	}
+}
+
+func (s *MutableAutoSelect) isClosed() bool {
+	select {
+	case <-s.ctx.Done():
+		return true
+	default:
+		return false
+	}
+}

--- a/protocol/group/mutableautoselect.go
+++ b/protocol/group/mutableautoselect.go
@@ -80,8 +80,8 @@ type MutableAutoSelect struct {
 	// probeMu serializes probe cycles. Fire-and-forget callers
 	// (runProbeCycle) TryLock; callers that need a deterministic outcome
 	// (URLTest, runLadder) Lock so they observe the cycle they triggered.
-	probeMu      sync.Mutex
-	laddering    atomic.Bool
+	probeMu   sync.Mutex
+	laddering atomic.Bool
 	// Unix-nano of the most recent runLadder completion. Read by the
 	// cooldown gate to suppress back-to-back full-fleet re-probes when
 	// stalls or dial errors arrive in quick succession.

--- a/protocol/group/mutableautoselect.go
+++ b/protocol/group/mutableautoselect.go
@@ -80,10 +80,9 @@ type MutableAutoSelect struct {
 	// probeMu serializes probe cycles. Fire-and-forget callers
 	// (runProbeCycle) TryLock; callers that need a deterministic outcome
 	// (URLTest, runLadder) Lock so they observe the cycle they triggered.
-	probeMu           sync.Mutex
-	laddering         atomic.Bool
-	exhaustionEmitted atomic.Bool
-	exhaustionCh      chan struct{}
+	probeMu      sync.Mutex
+	laddering    atomic.Bool
+	exhaustionCh chan struct{}
 
 	// Unix-nano of the most recent non-empty data-plane Read/Write; 0
 	// means no traffic observed yet. Drives the adaptive probe cadence.
@@ -94,24 +93,26 @@ type MutableAutoSelect struct {
 }
 
 type mutableAutoSelectConfig struct {
-	switchTolerance   time.Duration
-	activeInterval    time.Duration
-	idleInterval      time.Duration
-	idleThreshold     time.Duration
-	ladderFastRetry   time.Duration
-	ladderTotalBudget time.Duration
-	dataPlaneIdle     time.Duration
+	switchTolerance     time.Duration
+	activeInterval      time.Duration
+	idleInterval        time.Duration
+	idleThreshold       time.Duration
+	ladderTotalBudget   time.Duration
+	dataPlaneIdle       time.Duration
+	dataPlaneProvedRead uint64
+	maxPersistedAge     time.Duration
 }
 
 func resolveMutableAutoSelectOptions(o option.MutableAutoSelectOutboundOptions) (mutableAutoSelectConfig, historyParams) {
 	cfg := mutableAutoSelectConfig{
-		switchTolerance:   time.Duration(o.SwitchToleranceMs) * time.Millisecond,
-		activeInterval:    time.Duration(o.BackgroundIntervalSeconds) * time.Second,
-		idleInterval:      time.Duration(o.IdleIntervalSeconds) * time.Second,
-		idleThreshold:     time.Duration(o.IdleThresholdSeconds) * time.Second,
-		ladderFastRetry:   time.Duration(o.LadderFastRetryMs) * time.Millisecond,
-		ladderTotalBudget: time.Duration(o.LadderTotalBudgetSeconds) * time.Second,
-		dataPlaneIdle:     time.Duration(o.DataPlaneIdleSeconds) * time.Second,
+		switchTolerance:     time.Duration(o.SwitchToleranceMs) * time.Millisecond,
+		activeInterval:      time.Duration(o.BackgroundIntervalSeconds) * time.Second,
+		idleInterval:        time.Duration(o.IdleIntervalSeconds) * time.Second,
+		idleThreshold:       time.Duration(o.IdleThresholdSeconds) * time.Second,
+		ladderTotalBudget:   time.Duration(o.LadderTotalBudgetSeconds) * time.Second,
+		dataPlaneIdle:       time.Duration(o.DataPlaneIdleSeconds) * time.Second,
+		dataPlaneProvedRead: uint64(o.DataPlaneProvedReadBytes),
+		maxPersistedAge:     time.Duration(o.MaxPersistedAgeSeconds) * time.Second,
 	}
 	if cfg.switchTolerance == 0 {
 		cfg.switchTolerance = 50 * time.Millisecond
@@ -125,31 +126,28 @@ func resolveMutableAutoSelectOptions(o option.MutableAutoSelectOutboundOptions) 
 	if cfg.idleThreshold == 0 {
 		cfg.idleThreshold = 600 * time.Second
 	}
-	if cfg.ladderFastRetry == 0 {
-		cfg.ladderFastRetry = 1000 * time.Millisecond
-	}
 	if cfg.ladderTotalBudget == 0 {
 		cfg.ladderTotalBudget = 10 * time.Second
 	}
 	if cfg.dataPlaneIdle == 0 {
 		cfg.dataPlaneIdle = defaultDataPlaneIdle
 	}
+	if cfg.dataPlaneProvedRead == 0 {
+		cfg.dataPlaneProvedRead = defaultDataPlaneProvedReadBytes
+	}
+	if cfg.maxPersistedAge == 0 {
+		cfg.maxPersistedAge = defaultMaxPersistedAge
+	}
 
 	hp := defaultHistoryParams()
-	if o.HistoryRingSize > 0 {
-		hp.ringMax = int(o.HistoryRingSize)
-	}
-	if o.SuccessRateWindowMinutes > 0 {
-		hp.successRateWindow = time.Duration(o.SuccessRateWindowMinutes) * time.Minute
-	}
-	if o.DemoteSuccessRateBelow > 0 {
-		hp.demoteSuccessRate = o.DemoteSuccessRateBelow
-	}
-	if o.DemoteMinOutcomes > 0 {
-		hp.demoteMinOutcomes = o.DemoteMinOutcomes
-	}
 	if o.ConsecutiveFailureLimit > 0 {
 		hp.consecutiveFailLimit = o.ConsecutiveFailureLimit
+	}
+	if o.SoftDemoteLimit > 0 {
+		hp.softFailLimit = o.SoftDemoteLimit
+	}
+	if o.UserFailureWindowSeconds > 0 {
+		hp.userFailureWindow = time.Duration(o.UserFailureWindowSeconds) * time.Second
 	}
 	return cfg, hp
 }
@@ -212,7 +210,8 @@ func (s *MutableAutoSelect) Start() error {
 	return nil
 }
 
-// Caller must hold s.access. No-op when an in-memory entry already exists.
+// Caller must hold s.access. No-op when an in-memory entry already exists
+// or when the persisted snapshot is older than cfg.maxPersistedAge.
 func (s *MutableAutoSelect) hydrateHistoryLocked(tag string) {
 	if _, ok := s.histories[tag]; ok {
 		return
@@ -224,7 +223,15 @@ func (s *MutableAutoSelect) hydrateHistoryLocked(tag string) {
 	if snap == nil {
 		return
 	}
-	s.histories[tag] = hydrateLocalHistory(snap, s.hist.ringMax)
+	now := time.Now()
+	if !snap.UpdatedAt.IsZero() && now.Sub(snap.UpdatedAt) > s.cfg.maxPersistedAge {
+		// Stale snapshot from a prior session — typically describes a
+		// candidate the bandit has rotated away from. Drop it from the
+		// store too so a later All() doesn't surface it.
+		s.history.Delete(tag)
+		return
+	}
+	s.histories[tag] = hydrateLocalHistory(snap, now, s.hist.userFailureWindow)
 }
 
 // PostStart is idempotent: a second invocation is a no-op rather than a
@@ -407,9 +414,9 @@ func (s *MutableAutoSelect) URLTest(ctx context.Context) (map[string]uint16, err
 			continue
 		}
 		s.members.Store(tag, o)
-		// Hydrate before the first recordOutcome lands so the persisted
-		// ring isn't clobbered by a one-entry write from an empty
-		// in-memory localHistory.
+		// Hydrate before the first recordProbeOutcome lands so the
+		// persisted scalars aren't clobbered by a one-entry write from
+		// an empty in-memory localHistory.
 		s.hydrateHistoryLocked(tag)
 	}
 	jobs := s.collectProbeJobsLocked()
@@ -438,20 +445,35 @@ func (s *MutableAutoSelect) DialContext(ctx context.Context, network string, des
 	}
 	outerTag := o.Tag()
 	conn, err := o.DialContext(ctx, network, destination)
-	if err != nil {
-		s.logger.ErrorContext(ctx, err)
-		// Attribute the failure to the outer (member) tag so rank and
-		// runLadder's skip-step-1 check both see the bump. For nested
-		// groups, the inner tag isn't a member of this group, so
-		// recordUserFailure would drop on the member gate.
-		s.recordUserFailure(outerTag)
-		go s.runLadder(outerTag)
-		span.RecordError(err)
-		return nil, err
+	if err == nil {
+		return s.wrapStream(conn, o), nil
 	}
-	onStall, onRead := s.makeHooks(outerTag)
-	wrapped := newDataPlaneStream(conn, s.cfg.dataPlaneIdle, onStall, s.bumpActive, onRead)
-	return adapter.NewTaggedConn(wrapped, realTag(o)), nil
+	s.logger.ErrorContext(ctx, err)
+	// Attribute the failure to the outer (member) tag so rank and
+	// runLadder's gating both see it. For nested groups, the inner tag
+	// isn't a member of this group, so recordUserFailure would drop on
+	// the member gate.
+	s.recordUserFailure(outerTag)
+
+	// Fast failover: try one alternate from the current rank before
+	// kicking the ladder. The active 3-min cadence keeps the probe
+	// history fresh enough to pick a working peer without re-probing.
+	alt, altErr := s.selectForExcluding(network, outerTag)
+	if altErr == nil {
+		altTag := alt.Tag()
+		conn, err = alt.DialContext(ctx, network, destination)
+		if err == nil {
+			go s.runLadder(outerTag)
+			return s.wrapStream(conn, alt), nil
+		}
+		s.logger.ErrorContext(ctx, err)
+		s.recordUserFailure(altTag)
+		outerTag = altTag
+	}
+
+	go s.runLadder(outerTag)
+	span.RecordError(err)
+	return nil, err
 }
 
 func (s *MutableAutoSelect) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
@@ -470,16 +492,40 @@ func (s *MutableAutoSelect) ListenPacket(ctx context.Context, destination M.Sock
 	}
 	outerTag := o.Tag()
 	conn, err := o.ListenPacket(ctx, destination)
-	if err != nil {
-		s.logger.ErrorContext(ctx, err)
-		s.recordUserFailure(outerTag)
-		go s.runLadder(outerTag)
-		span.RecordError(err)
-		return nil, err
+	if err == nil {
+		return s.wrapPacket(conn, o), nil
 	}
-	onStall, onRead := s.makeHooks(outerTag)
-	wrapped := newDataPlanePacket(conn, s.cfg.dataPlaneIdle, onStall, s.bumpActive, onRead)
-	return adapter.NewTaggedPacketConn(wrapped, realTag(o)), nil
+	s.logger.ErrorContext(ctx, err)
+	s.recordUserFailure(outerTag)
+
+	alt, altErr := s.selectForExcluding("udp", outerTag)
+	if altErr == nil {
+		altTag := alt.Tag()
+		conn, err = alt.ListenPacket(ctx, destination)
+		if err == nil {
+			go s.runLadder(outerTag)
+			return s.wrapPacket(conn, alt), nil
+		}
+		s.logger.ErrorContext(ctx, err)
+		s.recordUserFailure(altTag)
+		outerTag = altTag
+	}
+
+	go s.runLadder(outerTag)
+	span.RecordError(err)
+	return nil, err
+}
+
+func (s *MutableAutoSelect) wrapStream(conn net.Conn, o A.Outbound) net.Conn {
+	onStall, onActivity := s.makeHooks(o.Tag())
+	wrapped := newDataPlaneStream(conn, s.cfg.dataPlaneIdle, s.cfg.dataPlaneProvedRead, onStall, onActivity)
+	return adapter.NewTaggedConn(wrapped, realTag(o))
+}
+
+func (s *MutableAutoSelect) wrapPacket(conn net.PacketConn, o A.Outbound) net.PacketConn {
+	onStall, onActivity := s.makeHooks(o.Tag())
+	wrapped := newDataPlanePacket(conn, s.cfg.dataPlaneIdle, s.cfg.dataPlaneProvedRead, onStall, onActivity)
+	return adapter.NewTaggedPacketConn(wrapped, realTag(o))
 }
 
 func (s *MutableAutoSelect) NewConnectionEx(ctx context.Context, conn net.Conn, metadata A.InboundContext, onClose N.CloseHandlerFunc) {
@@ -491,6 +537,18 @@ func (s *MutableAutoSelect) NewPacketConnectionEx(ctx context.Context, conn N.Pa
 }
 
 func (s *MutableAutoSelect) selectFor(network string) (A.Outbound, error) {
+	return s.selectForExcluding(network, "")
+}
+
+// selectForExcluding ranks the current members for the requested network
+// and returns the winner. excludeTag is dropped from the pool before
+// ranking — used by the dial-site fast-failover path to skip the tag
+// that just failed. An empty excludeTag is equivalent to plain selectFor.
+//
+// The sticky tag is only updated on the non-excluding path: a fast-
+// failover pick shouldn't poison the next dial's hysteresis with a tag
+// that was a fallback choice, not a steady-state winner.
+func (s *MutableAutoSelect) selectForExcluding(network, excludeTag string) (A.Outbound, error) {
 	var slot *atomic.Value
 	switch network {
 	case "tcp":
@@ -502,19 +560,33 @@ func (s *MutableAutoSelect) selectFor(network string) (A.Outbound, error) {
 	}
 	s.access.Lock()
 	ranked := s.rank(time.Now(), time.Time{})
+	if excludeTag != "" {
+		ranked = slices.DeleteFunc(ranked, func(c rankedCandidate) bool {
+			return c.tag == excludeTag
+		})
+	}
 	pool := splitHealthyFor(ranked, network)
 	if len(pool) == 0 {
 		s.access.Unlock()
-		s.CheckOutbounds()
+		if excludeTag == "" {
+			// No-pool on the primary path: kick a fresh probe cycle so
+			// the next attempt has data.
+			s.CheckOutbounds()
+		}
 		return nil, errors.New("no outbound available, recovery in progress")
 	}
-	winner := s.applyStickiness(network, slot, pool)
-	prev := loadString(slot)
-	if prev != winner.tag {
-		slot.Store(winner.tag)
-		if prev == "" {
-			s.logger.Info(network, " select: ", winner.tag)
+	var winner rankedCandidate
+	if excludeTag == "" {
+		winner = s.applyStickiness(network, slot, pool)
+		prev := loadString(slot)
+		if prev != winner.tag {
+			slot.Store(winner.tag)
+			if prev == "" {
+				s.logger.Info(network, " select: ", winner.tag)
+			}
 		}
+	} else {
+		winner = pool[0]
 	}
 	s.access.Unlock()
 	return winner.outbound, nil
@@ -579,7 +651,7 @@ func (s *MutableAutoSelect) probeURLForLocked(tag string) string {
 func (s *MutableAutoSelect) historyForLocked(tag string) *localHistory {
 	h, ok := s.histories[tag]
 	if !ok {
-		h = newLocalHistory(s.hist.ringMax)
+		h = newLocalHistory()
 		s.histories[tag] = h
 	}
 	return h
@@ -630,8 +702,8 @@ type demoteLevel uint8
 
 const (
 	demoteClean demoteLevel = iota
-	demoteSoft              // userFailures > 0 but demote() says no
-	demoteHard              // demote() returned true
+	demoteSoft              // window_count(userFailures) >= 1, hard threshold not reached
+	demoteHard              // consecutive_failures or windowed user-failures at limit
 )
 
 type rankedCandidate struct {
@@ -672,11 +744,19 @@ func splitHealthyFor(ranked []rankedCandidate, network string) []rankedCandidate
 
 // rank builds the candidate set for selection. A non-zero freshSince
 // restricts to members with a recorded outcome at or after freshSince
-// and drops those without a fresh success (rawDelay==0); the
+// and drops those without a fresh success (lastSuccessDelayMs==0); the
 // probe-cycle ranker uses this so the "is there a winner this cycle?"
 // check can't see stale outcomes. Caller must hold s.access.
 func (s *MutableAutoSelect) rank(now time.Time, freshSince time.Time) []rankedCandidate {
-	out := make([]rankedCandidate, 0, len(s.tags))
+	type pre struct {
+		o         A.Outbound
+		tag       string
+		delayMs   uint32
+		kind      candidateKind
+		consec    uint32
+		userFails uint32
+	}
+	pres := make([]pre, 0, len(s.tags))
 	for _, tag := range s.tags {
 		o, ok := s.members.Load(tag)
 		if !ok {
@@ -688,30 +768,31 @@ func (s *MutableAutoSelect) rank(now time.Time, freshSince time.Time) []rankedCa
 		}
 		var (
 			rawDelay  uint32
-			hard      bool
+			consec    uint32
 			userFails uint32
 			haveData  bool
 		)
 		if h, ok := s.peekHistoryLocked(tag); ok {
-			entries, consec, fails := h.snapshot()
-			if !freshSince.IsZero() && !hasOutcomeSince(entries, freshSince) {
+			lastDelay, lastAt, c, uf := h.snapshot(now, s.hist.userFailureWindow)
+			if !freshSince.IsZero() && lastAt.Before(freshSince) {
 				continue
 			}
-			rawDelay = lastSuccessDelay(entries)
-			hard = demoted(entries, consec, fails, now, s.hist)
-			userFails = fails
+			rawDelay = lastDelay
+			consec = c
+			userFails = uint32(len(uf))
 			haveData = true
 		} else if freshSince.IsZero() && s.history != nil {
 			// Cold member (added without going through hydrate). Fall back
 			// to the persisted snapshot so recompute-style callers see
-			// host-injected data. Probe-cycle callers (freshSince set) skip
-			// this branch — they only count outcomes from this cycle.
+			// host-injected data. Probe-cycle callers (freshSince set)
+			// skip this branch — they only count outcomes from this cycle.
 			if seed := s.history.Load(tag); seed != nil {
-				entries := localizeOutcomes(seed.Outcomes)
-				rawDelay = lastSuccessDelay(entries)
-				hard = demoted(entries, seed.ConsecutiveFailures, seed.UserFailures, now, s.hist)
-				userFails = seed.UserFailures
-				haveData = true
+				if seed.UpdatedAt.IsZero() || now.Sub(seed.UpdatedAt) <= s.cfg.maxPersistedAge {
+					rawDelay = seed.LastSuccessDelayMs
+					consec = seed.ConsecutiveFailures
+					userFails = countUserFailuresInWindow(seed.UserFailures, now, s.hist.userFailureWindow)
+					haveData = true
+				}
 			}
 		}
 		if !freshSince.IsZero() && (!haveData || rawDelay == 0) {
@@ -729,14 +810,51 @@ func (s *MutableAutoSelect) rank(now time.Time, freshSince time.Time) []rankedCa
 		default:
 			delay, kind = rawDelay, kindRealSeeded
 		}
+		pres = append(pres, pre{o: o, tag: tag, delayMs: delay, kind: kind, consec: consec, userFails: userFails})
+	}
+
+	// Switch-penalty awareness: when deciding whether to hard-demote a
+	// candidate, demoted() needs to see the best alternative's delay so
+	// the rule can soften when the only fallback is much slower. Only
+	// kindRealSeeded delays participate — substituted/unknown values are
+	// synthetic, so basing a "switching is costly" decision on them
+	// would be meaningless.
+	var min1, min2 uint32
+	for _, p := range pres {
+		if p.kind != kindRealSeeded || p.delayMs == 0 {
+			continue
+		}
+		switch {
+		case min1 == 0 || p.delayMs < min1:
+			min2 = min1
+			min1 = p.delayMs
+		case min2 == 0 || p.delayMs < min2:
+			min2 = p.delayMs
+		}
+	}
+
+	out := make([]rankedCandidate, 0, len(pres))
+	for _, p := range pres {
+		// Pass selfMs=0 for non-real-seeded candidates so the boost
+		// can't trigger off a synthetic delay. bestAlt for those is
+		// irrelevant — demoted gates the boost on selfMs>0.
+		var selfMs, bestAlt uint32
+		if p.kind == kindRealSeeded {
+			selfMs = p.delayMs
+			bestAlt = min1
+			if p.delayMs == min1 {
+				bestAlt = min2
+			}
+		}
+		hard, soft, _ := demoted(p.consec, p.userFails, selfMs, bestAlt, s.hist)
 		level := demoteClean
 		switch {
 		case hard:
 			level = demoteHard
-		case userFails > 0:
+		case soft:
 			level = demoteSoft
 		}
-		out = append(out, rankedCandidate{outbound: o, tag: tag, delayMs: delay, kind: kind, demote: level})
+		out = append(out, rankedCandidate{outbound: p.o, tag: p.tag, delayMs: p.delayMs, kind: p.kind, demote: level})
 	}
 	sort.SliceStable(out, func(i, j int) bool {
 		a, b := out[i], out[j]
@@ -765,7 +883,8 @@ func (s *MutableAutoSelect) runProbeCycle(ctx context.Context) {
 // probeCycleInner probes every non-excluded member in parallel and
 // returns the lowest-delay candidate that succeeded at or after
 // cycleStart, or nil when no candidate succeeded. Caller must hold
-// s.probeMu so concurrent cycles can't interleave recordOutcome calls.
+// s.probeMu so concurrent cycles can't interleave recordProbeOutcome
+// calls.
 func (s *MutableAutoSelect) probeCycleInner(ctx context.Context, cycleStart time.Time) A.Outbound {
 	s.access.Lock()
 	jobs := s.collectProbeJobsLocked()
@@ -789,35 +908,60 @@ func (s *MutableAutoSelect) probeCycleInner(ctx context.Context, cycleStart time
 // member. Holds the lock through both the in-memory mutation and the
 // persistence write so a concurrent Remove can't be undone by a late
 // goroutine. fn is passed the timestamp used for both the entry and the
-// persisted snapshot.
-func (s *MutableAutoSelect) mutateHistory(tag string, fn func(*localHistory, time.Time) bool) {
+// persisted snapshot. Returns true only if fn ran and reported a change.
+func (s *MutableAutoSelect) mutateHistory(tag string, fn func(*localHistory, time.Time) bool) bool {
 	s.access.Lock()
 	defer s.access.Unlock()
 	if _, member := s.members.Load(tag); !member {
-		return
+		return false
 	}
 	h := s.historyForLocked(tag)
 	now := time.Now()
-	if !fn(h, now) || s.history == nil {
-		return
+	if !fn(h, now) {
+		return false
 	}
-	s.history.Store(tag, h.toTagHistory(now))
+	if s.history != nil {
+		s.history.Store(tag, h.toTagHistory(now, s.hist.userFailureWindow))
+	}
+	return true
 }
 
-func (s *MutableAutoSelect) recordUserFailure(tag string) {
-	s.mutateHistory(tag, func(h *localHistory, _ time.Time) bool {
-		h.bumpUserFailures()
-		return true
+// recordUserFailure appends a single user-traffic failure timestamp to
+// the member's sliding window and persists the snapshot. Dial errors
+// and confirmed data-plane stalls both pass through here; each counts
+// as one failure, with softFailLimit tripping the soft tier and
+// consecutiveFailLimit tripping the hard tier. Returns true if the
+// failure was persisted; false on dedup or non-member tag, so callers
+// can suppress downstream side effects (e.g. ladder kicks) on collapsed
+// events.
+func (s *MutableAutoSelect) recordUserFailure(tag string) bool {
+	return s.mutateHistory(tag, func(h *localHistory, now time.Time) bool {
+		return h.addUserFailure(now, s.hist.userFailureWindow, s.hist.userFailureDedupeWindow)
 	})
 }
 
-func (s *MutableAutoSelect) recordOutcome(tag string, o localOutcome, delayMs uint32) {
+func (s *MutableAutoSelect) recordProbeOutcome(tag string, success bool, delayMs uint32) {
 	s.mutateHistory(tag, func(h *localHistory, now time.Time) bool {
-		h.append(o, delayMs, now)
+		if success {
+			h.recordProbeSuccess(delayMs, now)
+		} else {
+			h.recordProbeFailure(now)
+		}
 		return true
 	})
 }
 
+// runLadder is invoked on any dial/listen error (after the dial-site
+// fast-failover step has already had its shot) and on data-plane stall
+// callbacks. It does not retry the failing member: the dial caller
+// already retries on its own schedule, and the fast-failover path has
+// already exercised the next-best alternate. The ladder's job is to
+// reshape the candidate pool: full parallel re-probe; if nothing
+// succeeds inside ladderTotalBudget, emit the exhaustion signal so
+// radiance can refetch /config-new.
+//
+// target is for diagnostic logging only and to gate concurrent
+// invocations through laddering's CAS.
 func (s *MutableAutoSelect) runLadder(target string) {
 	if s.isClosed() {
 		return
@@ -826,69 +970,13 @@ func (s *MutableAutoSelect) runLadder(target string) {
 		return
 	}
 	defer s.laddering.Store(false)
-	s.exhaustionEmitted.Store(false)
-	deadline := time.Now().Add(s.cfg.ladderTotalBudget)
 
-	var current A.Outbound
-	if target != "" {
-		if o, ok := s.members.Load(target); ok {
-			current = o
-		}
-	}
-	if current == nil {
-		for _, t := range [2]string{
-			loadString(&s.stickyTag.tcp),
-			loadString(&s.stickyTag.udp),
-		} {
-			if t == "" {
-				continue
-			}
-			if o, ok := s.members.Load(t); ok {
-				current = o
-				break
-			}
-		}
-	}
-	// Skip step 1 when the target has any user-failure evidence: probes
-	// can pass while real traffic doesn't, and step 1 would just launder
-	// that.
-	skipStep1 := false
-	if current != nil {
-		s.access.Lock()
-		if h, ok := s.peekHistoryLocked(current.Tag()); ok && h.userFailureCount() > 0 {
-			skipStep1 = true
-		}
-		s.access.Unlock()
-	}
-	if current != nil && !skipStep1 {
-		s.logger.Info("ladder step 1: fast retry of ", current.Tag())
-		fastCtx, cancel := context.WithTimeout(s.ctx, s.cfg.ladderFastRetry)
-		defer cancel()
-		s.access.Lock()
-		probeURL := s.probeURLForLocked(current.Tag())
-		beh := behaviorFor(current.Type())
-		s.access.Unlock()
-		res := runProbe(fastCtx, current, probeURL, beh)
-		s.recordOutcome(res.tag, res.outcome, res.delayMs)
-		if res.outcome == outcomeSuccess {
-			s.logger.Info("ladder step 1 succeeded for ", current.Tag())
-			return
-		}
-	} else if skipStep1 {
-		s.logger.Info("ladder skipping step 1: ", current.Tag(),
-			" has a non-zero user-failure count; jumping straight to step 2")
-	}
-
-	s.logger.Info("ladder step 2: full re-probe")
-	// Lock (not TryLock) so the exhaustion gate keys off this call's
-	// cycle, never a stale bg cycle. Compute the budget after the wait
-	// so serialization queueing doesn't eat probing time.
+	s.logger.Info("ladder: full re-probe (target=", target, ")")
+	// Acquire probeMu before computing the budget so a slow background
+	// cycle holding the mutex doesn't eat into the ladder's actual
+	// probing time.
 	s.probeMu.Lock()
-	remaining := time.Until(deadline)
-	if minStep2 := s.cfg.ladderTotalBudget / 2; remaining < minStep2 {
-		remaining = minStep2
-	}
-	fullCtx, cancel := context.WithTimeout(s.ctx, remaining)
+	fullCtx, cancel := context.WithTimeout(s.ctx, s.cfg.ladderTotalBudget)
 	defer cancel()
 	winner := s.probeCycleInner(fullCtx, time.Now())
 	s.probeMu.Unlock()
@@ -900,13 +988,10 @@ func (s *MutableAutoSelect) runLadder(target string) {
 		s.emitExhaustion()
 		return
 	}
-	s.logger.Info("ladder step 2 found winner: ", winner.Tag())
+	s.logger.Info("ladder found winner: ", winner.Tag())
 }
 
 func (s *MutableAutoSelect) emitExhaustion() {
-	if !s.exhaustionEmitted.CompareAndSwap(false, true) {
-		return
-	}
 	// Hold s.access across drain+send so Close (which closes the channel
 	// under the same lock) can't turn the send into a panic-on-closed.
 	s.access.Lock()

--- a/protocol/group/mutableautoselect.go
+++ b/protocol/group/mutableautoselect.go
@@ -82,6 +82,10 @@ type MutableAutoSelect struct {
 	// (URLTest, runLadder) Lock so they observe the cycle they triggered.
 	probeMu      sync.Mutex
 	laddering    atomic.Bool
+	// Unix-nano of the most recent runLadder completion. Read by the
+	// cooldown gate to suppress back-to-back full-fleet re-probes when
+	// stalls or dial errors arrive in quick succession.
+	lastLadderAt atomic.Int64
 	exhaustionCh chan struct{}
 
 	// Unix-nano of the most recent non-empty data-plane Read/Write; 0
@@ -98,6 +102,7 @@ type mutableAutoSelectConfig struct {
 	idleInterval        time.Duration
 	idleThreshold       time.Duration
 	ladderTotalBudget   time.Duration
+	ladderCooldown      time.Duration
 	dataPlaneIdle       time.Duration
 	dataPlaneProvedRead uint64
 	maxPersistedAge     time.Duration
@@ -110,12 +115,13 @@ func resolveMutableAutoSelectOptions(o option.MutableAutoSelectOutboundOptions) 
 		idleInterval:        time.Duration(o.IdleIntervalSeconds) * time.Second,
 		idleThreshold:       time.Duration(o.IdleThresholdSeconds) * time.Second,
 		ladderTotalBudget:   time.Duration(o.LadderTotalBudgetSeconds) * time.Second,
+		ladderCooldown:      time.Duration(o.LadderCooldownSeconds) * time.Second,
 		dataPlaneIdle:       time.Duration(o.DataPlaneIdleSeconds) * time.Second,
 		dataPlaneProvedRead: uint64(o.DataPlaneProvedReadBytes),
 		maxPersistedAge:     time.Duration(o.MaxPersistedAgeSeconds) * time.Second,
 	}
 	if cfg.switchTolerance == 0 {
-		cfg.switchTolerance = 50 * time.Millisecond
+		cfg.switchTolerance = 200 * time.Millisecond
 	}
 	if cfg.activeInterval == 0 {
 		cfg.activeInterval = 180 * time.Second
@@ -128,6 +134,9 @@ func resolveMutableAutoSelectOptions(o option.MutableAutoSelectOutboundOptions) 
 	}
 	if cfg.ladderTotalBudget == 0 {
 		cfg.ladderTotalBudget = 10 * time.Second
+	}
+	if cfg.ladderCooldown == 0 {
+		cfg.ladderCooldown = 60 * time.Second
 	}
 	if cfg.dataPlaneIdle == 0 {
 		cfg.dataPlaneIdle = defaultDataPlaneIdle
@@ -960,11 +969,21 @@ func (s *MutableAutoSelect) recordProbeOutcome(tag string, success bool, delayMs
 // succeeds inside ladderTotalBudget, emit the exhaustion signal so
 // radiance can refetch /config-new.
 //
+// A ladderCooldown window after the previous run suppresses repeat
+// kicks: probe data is still fresh, and rank demotion via
+// recordUserFailure already moves traffic off bad peers without
+// needing the ladder to re-shape the pool.
+//
 // target is for diagnostic logging only and to gate concurrent
 // invocations through laddering's CAS.
 func (s *MutableAutoSelect) runLadder(target string) {
 	if s.isClosed() {
 		return
+	}
+	if last := s.lastLadderAt.Load(); last != 0 {
+		if time.Since(time.Unix(0, last)) < s.cfg.ladderCooldown {
+			return
+		}
 	}
 	if !s.laddering.CompareAndSwap(false, true) {
 		return
@@ -980,6 +999,9 @@ func (s *MutableAutoSelect) runLadder(target string) {
 	defer cancel()
 	winner := s.probeCycleInner(fullCtx, time.Now())
 	s.probeMu.Unlock()
+	// Stamp on completion, not entry, so a slow ladder's runtime counts
+	// toward the cooldown.
+	s.lastLadderAt.Store(time.Now().UnixNano())
 	if s.isClosed() {
 		return
 	}

--- a/protocol/group/mutableautoselect_dataplane.go
+++ b/protocol/group/mutableautoselect_dataplane.go
@@ -1,0 +1,169 @@
+package group
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// makeHooks returns the (onStall, onRead) callback pair wired into the
+// data-plane wrappers. Callbacks re-look-up the member's history at fire
+// time so a Remove+Add cycle can't strand writes on a stale entry.
+func (s *MutableAutoSelect) makeHooks(outerTag string) (onStall, onRead func()) {
+	onStall = func() {
+		s.recordUserFailure(outerTag)
+		go s.runLadder(outerTag)
+	}
+	onRead = func() {
+		// Peek (not historyForLocked): a tag whose first event is a
+		// successful Read has no user_failures to reset, and creating
+		// an empty entry just litters the map.
+		s.access.Lock()
+		defer s.access.Unlock()
+		if _, member := s.members.Load(outerTag); !member {
+			return
+		}
+		h, ok := s.peekHistoryLocked(outerTag)
+		if !ok || !h.resetUserFailures() || s.history == nil {
+			return
+		}
+		s.history.Store(outerTag, h.toTagHistory(time.Now()))
+	}
+	return onStall, onRead
+}
+
+// dataPlaneWatchdog drives the no-traffic stall timer and the three
+// optional activity callbacks shared by the stream and packet wrappers.
+//
+//   - onStall fires once if the idle threshold elapses with no I/O.
+//   - onActivity fires on every non-empty Read or Write (Write-as-liveness
+//     is good enough for the adaptive probe-cadence signal).
+//   - onRead fires only on non-empty Read; the user-failure reset needs
+//     unambiguous bidirectional evidence because a QUIC/HTTP2 Write only
+//     proves the local stack accepted the bytes, not that the peer did.
+type dataPlaneWatchdog struct {
+	idle       time.Duration
+	onStall    func()
+	onActivity func()
+	onRead     func()
+	stalled    atomic.Bool
+	timer      *time.Timer
+	closeOnce  sync.Once
+}
+
+func (w *dataPlaneWatchdog) init(idle time.Duration, onStall, onActivity, onRead func()) {
+	w.idle = idle
+	w.onStall = onStall
+	w.onActivity = onActivity
+	w.onRead = onRead
+	w.timer = time.AfterFunc(idle, w.fireStall)
+}
+
+func (w *dataPlaneWatchdog) noteIO(n int, err error, isRead bool) {
+	if n <= 0 || err != nil {
+		return
+	}
+	w.timer.Reset(w.idle)
+	if w.onActivity != nil {
+		w.onActivity()
+	}
+	if isRead && w.onRead != nil {
+		w.onRead()
+	}
+}
+
+// closeWatchdog stops the timer and sets stalled=true so a Read/Write
+// that races Close — returning n>0 just before Stop and then re-arming
+// via Reset — can't deliver a phantom onStall after the conn is gone.
+func (w *dataPlaneWatchdog) closeWatchdog() (firstClose bool) {
+	w.closeOnce.Do(func() {
+		w.stalled.Store(true)
+		w.timer.Stop()
+		firstClose = true
+	})
+	return firstClose
+}
+
+func (w *dataPlaneWatchdog) fireStall() {
+	if w.stalled.CompareAndSwap(false, true) {
+		w.onStall()
+	}
+}
+
+// dataPlaneStream wraps a net.Conn with the stall watchdog and activity
+// hooks. Detects tunnels that handshake successfully but never carry data.
+type dataPlaneStream struct {
+	net.Conn
+	dataPlaneWatchdog
+}
+
+func newDataPlaneStream(c net.Conn, idle time.Duration, onStall, onActivity, onRead func()) *dataPlaneStream {
+	d := &dataPlaneStream{Conn: c}
+	d.init(idle, onStall, onActivity, onRead)
+	return d
+}
+
+func (d *dataPlaneStream) Read(p []byte) (int, error) {
+	n, err := d.Conn.Read(p)
+	d.noteIO(n, err, true)
+	return n, err
+}
+
+func (d *dataPlaneStream) Write(p []byte) (int, error) {
+	n, err := d.Conn.Write(p)
+	d.noteIO(n, err, false)
+	return n, err
+}
+
+// Close is idempotent: sing-box's connection lifecycle frequently
+// double-closes, so the underlying Close runs at most once.
+func (d *dataPlaneStream) Close() error {
+	if !d.closeWatchdog() {
+		return nil
+	}
+	return d.Conn.Close()
+}
+
+// Upstream lets common.Cast descend through the wrapper to find feature
+// interfaces (EarlyConn, VectorisedConn, ReadWaiter, ...) on the inner
+// outbound; without this, fast paths downstream silently disable.
+func (d *dataPlaneStream) Upstream() any { return d.Conn }
+
+// dataPlanePacket wraps a net.PacketConn; same contract as dataPlaneStream.
+type dataPlanePacket struct {
+	net.PacketConn
+	dataPlaneWatchdog
+}
+
+func newDataPlanePacket(c net.PacketConn, idle time.Duration, onStall, onActivity, onRead func()) *dataPlanePacket {
+	d := &dataPlanePacket{PacketConn: c}
+	d.init(idle, onStall, onActivity, onRead)
+	return d
+}
+
+func (d *dataPlanePacket) ReadFrom(p []byte) (int, net.Addr, error) {
+	n, addr, err := d.PacketConn.ReadFrom(p)
+	d.noteIO(n, err, true)
+	return n, addr, err
+}
+
+func (d *dataPlanePacket) WriteTo(p []byte, addr net.Addr) (int, error) {
+	n, err := d.PacketConn.WriteTo(p, addr)
+	d.noteIO(n, err, false)
+	return n, err
+}
+
+func (d *dataPlanePacket) Close() error {
+	if !d.closeWatchdog() {
+		return nil
+	}
+	return d.PacketConn.Close()
+}
+
+func (d *dataPlanePacket) Upstream() any { return d.PacketConn }
+
+var (
+	_ net.Conn       = (*dataPlaneStream)(nil)
+	_ net.PacketConn = (*dataPlanePacket)(nil)
+)

--- a/protocol/group/mutableautoselect_dataplane.go
+++ b/protocol/group/mutableautoselect_dataplane.go
@@ -33,23 +33,19 @@ func (s *MutableAutoSelect) makeHooks(outerTag string) (onStall, onRead func()) 
 	return onStall, onRead
 }
 
-// dataPlaneWatchdog drives the no-traffic stall timer and the three
-// optional activity callbacks shared by the stream and packet wrappers.
-//
-//   - onStall fires once if the idle threshold elapses with no I/O.
-//   - onActivity fires on every non-empty Read or Write (Write-as-liveness
-//     is good enough for the adaptive probe-cadence signal).
-//   - onRead fires only on non-empty Read; the user-failure reset needs
-//     unambiguous bidirectional evidence because a QUIC/HTTP2 Write only
-//     proves the local stack accepted the bytes, not that the peer did.
+// dataPlaneWatchdog is the no-traffic stall timer shared by the stream
+// and packet wrappers.
 type dataPlaneWatchdog struct {
 	idle       time.Duration
 	onStall    func()
 	onActivity func()
-	onRead     func()
-	stalled    atomic.Bool
-	timer      *time.Timer
-	closeOnce  sync.Once
+	// onRead fires only on non-empty Read: the user-failure reset needs
+	// bidirectional evidence, since a QUIC/HTTP2 Write only proves the
+	// local stack accepted the bytes, not that the peer did.
+	onRead    func()
+	stalled   atomic.Bool
+	timer     *time.Timer
+	closeOnce sync.Once
 }
 
 func (w *dataPlaneWatchdog) init(idle time.Duration, onStall, onActivity, onRead func()) {
@@ -64,6 +60,11 @@ func (w *dataPlaneWatchdog) noteIO(n int, err error, isRead bool) {
 	if n <= 0 || err != nil {
 		return
 	}
+	// Short-circuit once stalled: a late onRead would reset the
+	// userFailure the stall just recorded.
+	if w.stalled.Load() {
+		return
+	}
 	w.timer.Reset(w.idle)
 	if w.onActivity != nil {
 		w.onActivity()
@@ -73,9 +74,9 @@ func (w *dataPlaneWatchdog) noteIO(n int, err error, isRead bool) {
 	}
 }
 
-// closeWatchdog stops the timer and sets stalled=true so a Read/Write
-// that races Close — returning n>0 just before Stop and then re-arming
-// via Reset — can't deliver a phantom onStall after the conn is gone.
+// closeWatchdog sets stalled=true before Stop so any concurrent noteIO
+// short-circuits and any concurrent fireStall CAS-fails — late I/O can't
+// deliver a phantom onStall after Close.
 func (w *dataPlaneWatchdog) closeWatchdog() (firstClose bool) {
 	w.closeOnce.Do(func() {
 		w.stalled.Store(true)
@@ -91,8 +92,8 @@ func (w *dataPlaneWatchdog) fireStall() {
 	}
 }
 
-// dataPlaneStream wraps a net.Conn with the stall watchdog and activity
-// hooks. Detects tunnels that handshake successfully but never carry data.
+// dataPlaneStream detects tunnels that handshake successfully but never
+// carry data.
 type dataPlaneStream struct {
 	net.Conn
 	dataPlaneWatchdog

--- a/protocol/group/mutableautoselect_dataplane.go
+++ b/protocol/group/mutableautoselect_dataplane.go
@@ -7,52 +7,58 @@ import (
 	"time"
 )
 
-// makeHooks returns the (onStall, onRead) callback pair wired into the
-// data-plane wrappers. Callbacks re-look-up the member's history at fire
-// time so a Remove+Add cycle can't strand writes on a stale entry.
-func (s *MutableAutoSelect) makeHooks(outerTag string) (onStall, onRead func()) {
+// makeHooks returns the (onStall, onActivity) callback pair wired into
+// the data-plane wrappers. Callbacks re-look-up the member's history
+// at fire time so a Remove+Add cycle can't strand writes on a stale
+// entry. The stall callback short-circuits when recordUserFailure
+// reports a dedup/non-member, so a single broken outbound with N
+// orphan idle conns doesn't trigger N redundant full-fleet probe
+// sweeps.
+func (s *MutableAutoSelect) makeHooks(outerTag string) (onStall, onActivity func()) {
 	onStall = func() {
-		s.recordUserFailure(outerTag)
+		if !s.recordUserFailure(outerTag) {
+			return
+		}
 		go s.runLadder(outerTag)
 	}
-	onRead = func() {
-		// Peek (not historyForLocked): a tag whose first event is a
-		// successful Read has no user_failures to reset, and creating
-		// an empty entry just litters the map.
-		s.access.Lock()
-		defer s.access.Unlock()
-		if _, member := s.members.Load(outerTag); !member {
-			return
-		}
-		h, ok := s.peekHistoryLocked(outerTag)
-		if !ok || !h.resetUserFailures() || s.history == nil {
-			return
-		}
-		s.history.Store(outerTag, h.toTagHistory(time.Now()))
-	}
-	return onStall, onRead
+	return onStall, s.bumpActive
 }
 
 // dataPlaneWatchdog is the no-traffic stall timer shared by the stream
 // and packet wrappers.
+//
+// provedReadBytes gates whether the stall is real: until the wrapped conn
+// has delivered that many cumulative non-empty Read bytes, an
+// idle-window expiry is treated as "established but never carried real
+// traffic" (e.g. a handshake-only or keepalive-only conn) and the
+// stall handler is suppressed.
+//
+// lastWasWrite separately distinguishes "tunnel is broken" from "user
+// stopped sending traffic" on an already-proven conn. The stall fires
+// only when the most recent non-empty IO was a Write — i.e. we sent
+// bytes and got nothing back for the idle window. A proven conn whose
+// last activity was a Read (response arrived, then silence) is treated
+// as user-idle, not broken: a healthy keep-alive going unused looks
+// identical to a broken tunnel without this gate.
 type dataPlaneWatchdog struct {
-	idle       time.Duration
-	onStall    func()
-	onActivity func()
-	// onRead fires only on non-empty Read: the user-failure reset needs
-	// bidirectional evidence, since a QUIC/HTTP2 Write only proves the
-	// local stack accepted the bytes, not that the peer did.
-	onRead    func()
-	stalled   atomic.Bool
-	timer     *time.Timer
-	closeOnce sync.Once
+	idle            time.Duration
+	onStall         func()
+	onActivity      func()
+	provedReadBytes uint64
+	readBytes       atomic.Uint64
+	proven          atomic.Bool
+	lastWasWrite    atomic.Bool
+	stalled         atomic.Bool
+	fired           atomic.Bool
+	timer           *time.Timer
+	closeOnce       sync.Once
 }
 
-func (w *dataPlaneWatchdog) init(idle time.Duration, onStall, onActivity, onRead func()) {
+func (w *dataPlaneWatchdog) init(idle time.Duration, provedReadBytes uint64, onStall, onActivity func()) {
 	w.idle = idle
+	w.provedReadBytes = provedReadBytes
 	w.onStall = onStall
 	w.onActivity = onActivity
-	w.onRead = onRead
 	w.timer = time.AfterFunc(idle, w.fireStall)
 }
 
@@ -60,17 +66,34 @@ func (w *dataPlaneWatchdog) noteIO(n int, err error, isRead bool) {
 	if n <= 0 || err != nil {
 		return
 	}
-	// Short-circuit once stalled: a late onRead would reset the
-	// userFailure the stall just recorded.
+	// Short-circuit once stalled: a late noteIO must not re-arm the
+	// timer or fire onActivity after the conn is logically gone.
 	if w.stalled.Load() {
 		return
 	}
+	// Publish the gate value before re-arming the timer so a fireStall
+	// racing the Reset reads the fresh classification, not the previous
+	// IO's value. Otherwise a Read landing just as the timer fires
+	// could leave lastWasWrite=true from an earlier Write and trip
+	// the gate it's supposed to suppress.
+	w.lastWasWrite.Store(!isRead)
 	w.timer.Reset(w.idle)
 	if w.onActivity != nil {
 		w.onActivity()
 	}
-	if isRead && w.onRead != nil {
-		w.onRead()
+	if !isRead {
+		return
+	}
+	// Mark the conn proven once cumulative Read bytes cross the
+	// threshold. provedReadBytes==0 keeps the legacy "any non-empty Read
+	// proves" behavior for tests that don't care about the threshold;
+	// production callers always pass a non-zero default.
+	if w.proven.Load() {
+		return
+	}
+	total := w.readBytes.Add(uint64(n))
+	if total >= w.provedReadBytes {
+		w.proven.Store(true)
 	}
 }
 
@@ -86,22 +109,43 @@ func (w *dataPlaneWatchdog) closeWatchdog() (firstClose bool) {
 	return firstClose
 }
 
+// fireStall is the AfterFunc callback. The stall counts only if the
+// conn has delivered enough Read payload to be proven AND the most
+// recent non-empty IO was a Write — i.e. we sent bytes and heard
+// nothing back. A proven conn whose last activity was a Read is
+// treated as user-idle and suppressed: an unused HTTPS keep-alive
+// looks identical to a broken tunnel without this gate. Other failure
+// paths (dial errors, probe failures) still catch the cases this gate
+// suppresses. fired is the once-per-conn CAS so a re-armed timer
+// can't double-deliver onStall.
 func (w *dataPlaneWatchdog) fireStall() {
-	if w.stalled.CompareAndSwap(false, true) {
+	if !w.proven.Load() {
+		return
+	}
+	if !w.lastWasWrite.Load() {
+		return
+	}
+	if !w.stalled.CompareAndSwap(false, true) {
+		return
+	}
+	if !w.fired.CompareAndSwap(false, true) {
+		return
+	}
+	if w.onStall != nil {
 		w.onStall()
 	}
 }
 
-// dataPlaneStream detects tunnels that handshake successfully but never
-// carry data.
+// dataPlaneStream detects tunnels that handshake successfully but
+// stop carrying data after they have started carrying it.
 type dataPlaneStream struct {
 	net.Conn
 	dataPlaneWatchdog
 }
 
-func newDataPlaneStream(c net.Conn, idle time.Duration, onStall, onActivity, onRead func()) *dataPlaneStream {
+func newDataPlaneStream(c net.Conn, idle time.Duration, provedReadBytes uint64, onStall, onActivity func()) *dataPlaneStream {
 	d := &dataPlaneStream{Conn: c}
-	d.init(idle, onStall, onActivity, onRead)
+	d.init(idle, provedReadBytes, onStall, onActivity)
 	return d
 }
 
@@ -137,9 +181,9 @@ type dataPlanePacket struct {
 	dataPlaneWatchdog
 }
 
-func newDataPlanePacket(c net.PacketConn, idle time.Duration, onStall, onActivity, onRead func()) *dataPlanePacket {
+func newDataPlanePacket(c net.PacketConn, idle time.Duration, provedReadBytes uint64, onStall, onActivity func()) *dataPlanePacket {
 	d := &dataPlanePacket{PacketConn: c}
-	d.init(idle, onStall, onActivity, onRead)
+	d.init(idle, provedReadBytes, onStall, onActivity)
 	return d
 }
 

--- a/protocol/group/mutableautoselect_history.go
+++ b/protocol/group/mutableautoselect_history.go
@@ -1,0 +1,247 @@
+package group
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/getlantern/lantern-box/adapter"
+)
+
+// localOutcome mirrors adapter.Outcome with the same numeric values so
+// hydrate/snapshot convert by direct cast. Additions must append in both
+// enums to keep the cast valid.
+type localOutcome uint8
+
+const (
+	outcomeSuccess localOutcome = iota
+	outcomeTimeout
+	outcomeHandshakeFailure
+)
+
+func (o localOutcome) isSuccess() bool { return o == outcomeSuccess }
+
+type timestampedOutcome struct {
+	outcome   localOutcome
+	delayMs   uint32
+	timestamp time.Time
+}
+
+const (
+	defaultHistoryRingMax       = 20
+	defaultSuccessRateWindow    = time.Hour
+	defaultDemoteMinOutcomes    = 5
+	defaultDemoteSuccessRate    = 0.3
+	defaultConsecutiveFailLimit = 3
+	defaultDataPlaneIdle        = 30 * time.Second
+)
+
+type historyParams struct {
+	ringMax              int
+	successRateWindow    time.Duration
+	demoteSuccessRate    float64
+	demoteMinOutcomes    uint32
+	consecutiveFailLimit uint32
+}
+
+func defaultHistoryParams() historyParams {
+	return historyParams{
+		ringMax:              defaultHistoryRingMax,
+		successRateWindow:    defaultSuccessRateWindow,
+		demoteSuccessRate:    defaultDemoteSuccessRate,
+		demoteMinOutcomes:    defaultDemoteMinOutcomes,
+		consecutiveFailLimit: defaultConsecutiveFailLimit,
+	}
+}
+
+// localHistory is the in-memory probe history for one server tag. The
+// outcomes ring and consecutiveFailures track probe outcomes only.
+// userFailures is the laundering-resistant user-traffic counter: a passing
+// probe never decrements it; only a successful non-empty Read through a
+// wrapped data-plane conn does.
+type localHistory struct {
+	mu                  sync.Mutex
+	ringMax             int
+	outcomes            []timestampedOutcome
+	consecutiveFailures uint32
+	userFailures        atomic.Uint32
+}
+
+func newLocalHistory(ringMax int) *localHistory {
+	if ringMax <= 0 {
+		ringMax = defaultHistoryRingMax
+	}
+	return &localHistory{ringMax: ringMax}
+}
+
+// append records one outcome, evicting the oldest entry when the ring is
+// full. now is a parameter so tests can drive a fake clock.
+func (h *localHistory) append(o localOutcome, delayMs uint32, now time.Time) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	entry := timestampedOutcome{outcome: o, delayMs: delayMs, timestamp: now}
+	if o != outcomeSuccess {
+		entry.delayMs = 0
+	}
+	if len(h.outcomes) < h.ringMax {
+		h.outcomes = append(h.outcomes, entry)
+	} else {
+		copy(h.outcomes, h.outcomes[1:])
+		h.outcomes[len(h.outcomes)-1] = entry
+	}
+	if o.isSuccess() {
+		h.consecutiveFailures = 0
+	} else {
+		h.consecutiveFailures++
+	}
+}
+
+func (h *localHistory) bumpUserFailures() { h.userFailures.Add(1) }
+
+// resetUserFailures zeroes the user-traffic-failure counter and reports
+// whether it was previously non-zero, so the hot path can skip a storage
+// write when nothing changed.
+func (h *localHistory) resetUserFailures() bool {
+	return h.userFailures.Swap(0) != 0
+}
+
+func (h *localHistory) userFailureCount() uint32 { return h.userFailures.Load() }
+
+// snapshot returns a copy of the outcomes ring along with the running
+// consecutive-failure and user-failure counters.
+func (h *localHistory) snapshot() ([]timestampedOutcome, uint32, uint32) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]timestampedOutcome, len(h.outcomes))
+	copy(out, h.outcomes)
+	return out, h.consecutiveFailures, h.userFailures.Load()
+}
+
+// toTagHistory snapshots the localHistory into adapter.TagHistory form.
+// updatedAt is a parameter so a single recordOutcome call uses one
+// timestamp across the in-memory entry and the persisted snapshot.
+func (h *localHistory) toTagHistory(updatedAt time.Time) *adapter.TagHistory {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := &adapter.TagHistory{
+		ConsecutiveFailures: h.consecutiveFailures,
+		UserFailures:        h.userFailures.Load(),
+		UpdatedAt:           updatedAt,
+	}
+	if len(h.outcomes) > 0 {
+		out.Outcomes = make([]adapter.TimestampedOutcome, len(h.outcomes))
+		for i, e := range h.outcomes {
+			out.Outcomes[i] = adapter.TimestampedOutcome{
+				Outcome:   adapter.Outcome(e.outcome),
+				DelayMs:   e.delayMs,
+				Timestamp: e.timestamp,
+			}
+		}
+	}
+	return out
+}
+
+// localizeOutcomes converts persisted entries to the in-memory form so
+// lastSuccessDelay/demoted work uniformly on either source.
+func localizeOutcomes(entries []adapter.TimestampedOutcome) []timestampedOutcome {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]timestampedOutcome, len(entries))
+	for i, e := range entries {
+		out[i] = timestampedOutcome{
+			outcome:   localOutcome(e.Outcome),
+			delayMs:   e.DelayMs,
+			timestamp: e.Timestamp,
+		}
+	}
+	return out
+}
+
+// hydrateLocalHistory rebuilds a localHistory from a persisted snapshot.
+// Entries exceeding ringMax are dropped from the head so the in-memory
+// ring stays bounded even if the persisted form was larger.
+func hydrateLocalHistory(t *adapter.TagHistory, ringMax int) *localHistory {
+	h := newLocalHistory(ringMax)
+	if t == nil {
+		return h
+	}
+	h.consecutiveFailures = t.ConsecutiveFailures
+	h.userFailures.Store(t.UserFailures)
+	if len(t.Outcomes) == 0 {
+		return h
+	}
+	start := 0
+	if len(t.Outcomes) > h.ringMax {
+		start = len(t.Outcomes) - h.ringMax
+	}
+	h.outcomes = make([]timestampedOutcome, 0, len(t.Outcomes)-start)
+	for _, e := range t.Outcomes[start:] {
+		h.outcomes = append(h.outcomes, timestampedOutcome{
+			outcome:   localOutcome(e.Outcome),
+			delayMs:   e.DelayMs,
+			timestamp: e.Timestamp,
+		})
+	}
+	return h
+}
+
+// lastSuccessDelay returns the delay (ms) of the most recent success, or
+// 0 if none.
+func lastSuccessDelay(entries []timestampedOutcome) uint32 {
+	for i := len(entries) - 1; i >= 0; i-- {
+		if entries[i].outcome == outcomeSuccess {
+			return entries[i].delayMs
+		}
+	}
+	return 0
+}
+
+// hasOutcomeSince reports whether the snapshot contains at least one
+// outcome recorded at or after t.
+func hasOutcomeSince(entries []timestampedOutcome, t time.Time) bool {
+	for i := len(entries) - 1; i >= 0; i-- {
+		if !entries[i].timestamp.Before(t) {
+			return true
+		}
+	}
+	return false
+}
+
+// recentSuccessRate is successes/total over entries with age in window.
+// With total == 0 the rate is meaningless; callers must check total
+// before acting on rate. Ages are clamped to zero to tolerate clock skew.
+func recentSuccessRate(entries []timestampedOutcome, now time.Time, window time.Duration) (rate float64, total uint32) {
+	var succ uint32
+	for _, e := range entries {
+		age := max(0, now.Sub(e.timestamp))
+		if age > window {
+			continue
+		}
+		total++
+		if e.outcome.isSuccess() {
+			succ++
+		}
+	}
+	if total == 0 {
+		return 0, 0
+	}
+	return float64(succ) / float64(total), total
+}
+
+// demoted is true when probe or user-traffic failures cross the
+// consecutive-failure limit, or when the recent probe success rate dips
+// below the threshold with enough sample size to trust the signal.
+func demoted(entries []timestampedOutcome, consecFailures, userFailures uint32, now time.Time, p historyParams) bool {
+	if p.consecutiveFailLimit > 0 && consecFailures >= p.consecutiveFailLimit {
+		return true
+	}
+	if p.consecutiveFailLimit > 0 && userFailures >= p.consecutiveFailLimit {
+		return true
+	}
+	rate, total := recentSuccessRate(entries, now, p.successRateWindow)
+	if total >= p.demoteMinOutcomes && rate < p.demoteSuccessRate {
+		return true
+	}
+	return false
+}

--- a/protocol/group/mutableautoselect_history.go
+++ b/protocol/group/mutableautoselect_history.go
@@ -74,8 +74,7 @@ func newLocalHistory(ringMax int) *localHistory {
 	return &localHistory{ringMax: ringMax}
 }
 
-// append records one outcome, evicting the oldest entry when the ring is
-// full. now is a parameter so tests can drive a fake clock.
+// now is a parameter so tests can drive a fake clock.
 func (h *localHistory) append(o localOutcome, delayMs uint32, now time.Time) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -107,8 +106,6 @@ func (h *localHistory) resetUserFailures() bool {
 
 func (h *localHistory) userFailureCount() uint32 { return h.userFailures.Load() }
 
-// snapshot returns a copy of the outcomes ring along with the running
-// consecutive-failure and user-failure counters.
 func (h *localHistory) snapshot() ([]timestampedOutcome, uint32, uint32) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -186,8 +183,6 @@ func hydrateLocalHistory(t *adapter.TagHistory, ringMax int) *localHistory {
 	return h
 }
 
-// lastSuccessDelay returns the delay (ms) of the most recent success, or
-// 0 if none.
 func lastSuccessDelay(entries []timestampedOutcome) uint32 {
 	for i := len(entries) - 1; i >= 0; i-- {
 		if entries[i].outcome == outcomeSuccess {
@@ -197,8 +192,6 @@ func lastSuccessDelay(entries []timestampedOutcome) uint32 {
 	return 0
 }
 
-// hasOutcomeSince reports whether the snapshot contains at least one
-// outcome recorded at or after t.
 func hasOutcomeSince(entries []timestampedOutcome, t time.Time) bool {
 	for i := len(entries) - 1; i >= 0; i-- {
 		if !entries[i].timestamp.Before(t) {

--- a/protocol/group/mutableautoselect_history.go
+++ b/protocol/group/mutableautoselect_history.go
@@ -8,13 +8,13 @@ import (
 )
 
 const (
-	defaultConsecutiveFailLimit    = 3
-	defaultSoftFailLimit           = 2
-	defaultUserFailureWindow       = 5 * time.Minute
-	defaultUserFailureDedupeWindow = 30 * time.Second
-	defaultDataPlaneIdle           = 60 * time.Second
+	defaultConsecutiveFailLimit     = 3
+	defaultSoftFailLimit            = 2
+	defaultUserFailureWindow        = 5 * time.Minute
+	defaultUserFailureDedupeWindow  = 30 * time.Second
+	defaultDataPlaneIdle            = 60 * time.Second
 	defaultDataPlaneProvedReadBytes = 4096
-	defaultMaxPersistedAge         = 15 * time.Minute
+	defaultMaxPersistedAge          = 15 * time.Minute
 	// switchPenaltyAltFactor is the ratio at which the best alternative
 	// is considered "much slower" than the candidate under evaluation.
 	// When best_alt_delay > self_delay * this factor, the demote rule

--- a/protocol/group/mutableautoselect_history.go
+++ b/protocol/group/mutableautoselect_history.go
@@ -2,239 +2,244 @@ package group
 
 import (
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/getlantern/lantern-box/adapter"
 )
 
-// localOutcome mirrors adapter.Outcome with the same numeric values so
-// hydrate/snapshot convert by direct cast. Additions must append in both
-// enums to keep the cast valid.
-type localOutcome uint8
-
 const (
-	outcomeSuccess localOutcome = iota
-	outcomeTimeout
-	outcomeHandshakeFailure
-)
-
-func (o localOutcome) isSuccess() bool { return o == outcomeSuccess }
-
-type timestampedOutcome struct {
-	outcome   localOutcome
-	delayMs   uint32
-	timestamp time.Time
-}
-
-const (
-	defaultHistoryRingMax       = 20
-	defaultSuccessRateWindow    = time.Hour
-	defaultDemoteMinOutcomes    = 5
-	defaultDemoteSuccessRate    = 0.3
-	defaultConsecutiveFailLimit = 3
-	defaultDataPlaneIdle        = 30 * time.Second
+	defaultConsecutiveFailLimit    = 3
+	defaultSoftFailLimit           = 2
+	defaultUserFailureWindow       = 5 * time.Minute
+	defaultUserFailureDedupeWindow = 30 * time.Second
+	defaultDataPlaneIdle           = 60 * time.Second
+	defaultDataPlaneProvedReadBytes = 4096
+	defaultMaxPersistedAge         = 15 * time.Minute
+	// switchPenaltyAltFactor is the ratio at which the best alternative
+	// is considered "much slower" than the candidate under evaluation.
+	// When best_alt_delay > self_delay * this factor, the demote rule
+	// requires twice as many failures before hard-demoting — switching
+	// the user from a fast member onto a much slower one should need
+	// more evidence than switching between two similar-latency members.
+	switchPenaltyAltFactor = 3
 )
 
 type historyParams struct {
-	ringMax              int
-	successRateWindow    time.Duration
-	demoteSuccessRate    float64
-	demoteMinOutcomes    uint32
-	consecutiveFailLimit uint32
+	consecutiveFailLimit    uint32
+	softFailLimit           uint32
+	userFailureWindow       time.Duration
+	userFailureDedupeWindow time.Duration
 }
 
 func defaultHistoryParams() historyParams {
 	return historyParams{
-		ringMax:              defaultHistoryRingMax,
-		successRateWindow:    defaultSuccessRateWindow,
-		demoteSuccessRate:    defaultDemoteSuccessRate,
-		demoteMinOutcomes:    defaultDemoteMinOutcomes,
-		consecutiveFailLimit: defaultConsecutiveFailLimit,
+		consecutiveFailLimit:    defaultConsecutiveFailLimit,
+		softFailLimit:           defaultSoftFailLimit,
+		userFailureWindow:       defaultUserFailureWindow,
+		userFailureDedupeWindow: defaultUserFailureDedupeWindow,
 	}
 }
 
-// localHistory is the in-memory probe history for one server tag. The
-// outcomes ring and consecutiveFailures track probe outcomes only.
-// userFailures is the laundering-resistant user-traffic counter: a passing
-// probe never decrements it; only a successful non-empty Read through a
-// wrapped data-plane conn does.
+// localHistory is the in-memory selection history for one server tag.
+//
+// The probe-outcome scalars (lastSuccessDelayMs, lastOutcomeAt,
+// consecutiveFailures) and the user-traffic userFailures window are
+// kept on separate tracks. A probe success never clears userFailures,
+// so a censor that lets the probe URL through while dropping the
+// user's traffic shows up as healthy probe scalars alongside elevated
+// userFailures simultaneously — the anti-laundering signal.
+//
+// Failures age out of userFailures naturally on the next mutation,
+// without depending on traffic being routed through the member, which
+// breaks the circular dependency where a hard-demoted candidate would
+// otherwise need a successful Read it could never get to recover.
 type localHistory struct {
 	mu                  sync.Mutex
-	ringMax             int
-	outcomes            []timestampedOutcome
+	lastSuccessDelayMs  uint32
+	lastOutcomeAt       time.Time
 	consecutiveFailures uint32
-	userFailures        atomic.Uint32
+	userFailures        []time.Time
 }
 
-func newLocalHistory(ringMax int) *localHistory {
-	if ringMax <= 0 {
-		ringMax = defaultHistoryRingMax
-	}
-	return &localHistory{ringMax: ringMax}
-}
+func newLocalHistory() *localHistory { return &localHistory{} }
 
-// now is a parameter so tests can drive a fake clock.
-func (h *localHistory) append(o localOutcome, delayMs uint32, now time.Time) {
+// recordProbeSuccess updates the probe scalars on a successful probe.
+// delayMs has already been clamped to ≥1 ms by the caller so the
+// "no measurement" sentinel (0) stays unambiguous.
+func (h *localHistory) recordProbeSuccess(delayMs uint32, now time.Time) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	entry := timestampedOutcome{outcome: o, delayMs: delayMs, timestamp: now}
-	if o != outcomeSuccess {
-		entry.delayMs = 0
-	}
-	if len(h.outcomes) < h.ringMax {
-		h.outcomes = append(h.outcomes, entry)
-	} else {
-		copy(h.outcomes, h.outcomes[1:])
-		h.outcomes[len(h.outcomes)-1] = entry
-	}
-	if o.isSuccess() {
-		h.consecutiveFailures = 0
-	} else {
-		h.consecutiveFailures++
-	}
+	h.lastSuccessDelayMs = delayMs
+	h.lastOutcomeAt = now
+	h.consecutiveFailures = 0
 }
 
-func (h *localHistory) bumpUserFailures() { h.userFailures.Add(1) }
-
-// resetUserFailures zeroes the user-traffic-failure counter and reports
-// whether it was previously non-zero, so the hot path can skip a storage
-// write when nothing changed.
-func (h *localHistory) resetUserFailures() bool {
-	return h.userFailures.Swap(0) != 0
-}
-
-func (h *localHistory) userFailureCount() uint32 { return h.userFailures.Load() }
-
-func (h *localHistory) snapshot() ([]timestampedOutcome, uint32, uint32) {
+// recordProbeFailure increments the consecutive-failure counter and
+// updates lastOutcomeAt. lastSuccessDelayMs is NOT cleared so a member
+// with one transient failure still has a real delay to rank by.
+func (h *localHistory) recordProbeFailure(now time.Time) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	out := make([]timestampedOutcome, len(h.outcomes))
-	copy(out, h.outcomes)
-	return out, h.consecutiveFailures, h.userFailures.Load()
+	h.consecutiveFailures++
+	h.lastOutcomeAt = now
+}
+
+// addUserFailure appends a user-traffic failure timestamp and prunes
+// entries older than window in place. A data-plane stall and a dial
+// error each count as one failure; hard demotion requires three in
+// the window.
+//
+// dedupe collapses bursts to a single failure: if the most recent
+// entry is newer than dedupe, the append is dropped. A single broken
+// outbound with many idle conns hitting their stall timer in sequence
+// would otherwise inflate the count out of proportion to the event.
+// Returns true if the failure was recorded.
+func (h *localHistory) addUserFailure(now time.Time, window, dedupe time.Duration) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if dedupe > 0 && len(h.userFailures) > 0 {
+		last := h.userFailures[len(h.userFailures)-1]
+		if now.Sub(last) < dedupe {
+			return false
+		}
+	}
+	h.userFailures = pruneUserFailures(append(h.userFailures, now), now, window)
+	return true
+}
+
+// userFailureCount returns the number of user-traffic failures inside
+// the sliding window relative to now. Stale entries are pruned in
+// place so the count reflects only the live window.
+func (h *localHistory) userFailureCount(now time.Time, window time.Duration) uint32 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.userFailures = pruneUserFailures(h.userFailures, now, window)
+	return uint32(len(h.userFailures))
+}
+
+func (h *localHistory) snapshot(now time.Time, window time.Duration) (lastDelay uint32, lastAt time.Time, consec uint32, userFails []time.Time) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.userFailures = pruneUserFailures(h.userFailures, now, window)
+	lastDelay = h.lastSuccessDelayMs
+	lastAt = h.lastOutcomeAt
+	consec = h.consecutiveFailures
+	if len(h.userFailures) > 0 {
+		userFails = make([]time.Time, len(h.userFailures))
+		copy(userFails, h.userFailures)
+	}
+	return
 }
 
 // toTagHistory snapshots the localHistory into adapter.TagHistory form.
-// updatedAt is a parameter so a single recordOutcome call uses one
+// updatedAt is a parameter so a single mutation call uses one
 // timestamp across the in-memory entry and the persisted snapshot.
-func (h *localHistory) toTagHistory(updatedAt time.Time) *adapter.TagHistory {
+func (h *localHistory) toTagHistory(updatedAt time.Time, window time.Duration) *adapter.TagHistory {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	h.userFailures = pruneUserFailures(h.userFailures, updatedAt, window)
 	out := &adapter.TagHistory{
+		LastSuccessDelayMs:  h.lastSuccessDelayMs,
+		LastOutcomeAt:       h.lastOutcomeAt,
 		ConsecutiveFailures: h.consecutiveFailures,
-		UserFailures:        h.userFailures.Load(),
 		UpdatedAt:           updatedAt,
 	}
-	if len(h.outcomes) > 0 {
-		out.Outcomes = make([]adapter.TimestampedOutcome, len(h.outcomes))
-		for i, e := range h.outcomes {
-			out.Outcomes[i] = adapter.TimestampedOutcome{
-				Outcome:   adapter.Outcome(e.outcome),
-				DelayMs:   e.delayMs,
-				Timestamp: e.timestamp,
-			}
-		}
+	if len(h.userFailures) > 0 {
+		out.UserFailures = make([]time.Time, len(h.userFailures))
+		copy(out.UserFailures, h.userFailures)
 	}
 	return out
 }
 
-// localizeOutcomes converts persisted entries to the in-memory form so
-// lastSuccessDelay/demoted work uniformly on either source.
-func localizeOutcomes(entries []adapter.TimestampedOutcome) []timestampedOutcome {
-	if len(entries) == 0 {
+// pruneUserFailures returns the subset of failures whose age is within
+// window. Ages are clamped to zero to tolerate clock skew between
+// cached entries and now.
+func pruneUserFailures(failures []time.Time, now time.Time, window time.Duration) []time.Time {
+	if len(failures) == 0 {
 		return nil
 	}
-	out := make([]timestampedOutcome, len(entries))
-	for i, e := range entries {
-		out[i] = timestampedOutcome{
-			outcome:   localOutcome(e.Outcome),
-			delayMs:   e.DelayMs,
-			timestamp: e.Timestamp,
+	if window <= 0 {
+		// window<=0 disables aging — keep what we have.
+		return failures
+	}
+	out := failures[:0]
+	for _, t := range failures {
+		if ageWithin(now, t, window) {
+			out = append(out, t)
 		}
 	}
+	if len(out) == 0 {
+		return nil
+	}
 	return out
+}
+
+// countUserFailuresInWindow returns the number of entries whose age is
+// within window without allocating. Use on the read-only rank hot path
+// where pruneUserFailures' in-place mutation isn't needed.
+func countUserFailuresInWindow(failures []time.Time, now time.Time, window time.Duration) uint32 {
+	if window <= 0 {
+		return uint32(len(failures))
+	}
+	var n uint32
+	for _, t := range failures {
+		if ageWithin(now, t, window) {
+			n++
+		}
+	}
+	return n
+}
+
+// ageWithin reports whether t is within window of now. Negative ages
+// (cached entries with future timestamps from clock skew) clamp to 0
+// so they still count as "in window."
+func ageWithin(now, t time.Time, window time.Duration) bool {
+	age := now.Sub(t)
+	if age < 0 {
+		age = 0
+	}
+	return age < window
 }
 
 // hydrateLocalHistory rebuilds a localHistory from a persisted snapshot.
-// Entries exceeding ringMax are dropped from the head so the in-memory
-// ring stays bounded even if the persisted form was larger.
-func hydrateLocalHistory(t *adapter.TagHistory, ringMax int) *localHistory {
-	h := newLocalHistory(ringMax)
+// Caller has already filtered out entries older than maxPersistedAge
+// (the cutoff lives in the group, not here, so a future change to the
+// cutoff source doesn't require touching hydrate).
+func hydrateLocalHistory(t *adapter.TagHistory, now time.Time, window time.Duration) *localHistory {
+	h := newLocalHistory()
 	if t == nil {
 		return h
 	}
+	h.lastSuccessDelayMs = t.LastSuccessDelayMs
+	h.lastOutcomeAt = t.LastOutcomeAt
 	h.consecutiveFailures = t.ConsecutiveFailures
-	h.userFailures.Store(t.UserFailures)
-	if len(t.Outcomes) == 0 {
-		return h
-	}
-	start := 0
-	if len(t.Outcomes) > h.ringMax {
-		start = len(t.Outcomes) - h.ringMax
-	}
-	h.outcomes = make([]timestampedOutcome, 0, len(t.Outcomes)-start)
-	for _, e := range t.Outcomes[start:] {
-		h.outcomes = append(h.outcomes, timestampedOutcome{
-			outcome:   localOutcome(e.Outcome),
-			delayMs:   e.DelayMs,
-			timestamp: e.Timestamp,
-		})
+	if len(t.UserFailures) > 0 {
+		copies := make([]time.Time, len(t.UserFailures))
+		copy(copies, t.UserFailures)
+		h.userFailures = pruneUserFailures(copies, now, window)
 	}
 	return h
 }
 
-func lastSuccessDelay(entries []timestampedOutcome) uint32 {
-	for i := len(entries) - 1; i >= 0; i-- {
-		if entries[i].outcome == outcomeSuccess {
-			return entries[i].delayMs
-		}
+// demoted scales the hard-demote threshold by switchPenaltyAltFactor
+// when the best alternative is much slower than the candidate's own
+// real-seeded delay: hard-demoting a fast member onto a much slower
+// one is itself a cost, so it requires more evidence. boosted reports
+// whether the scale was applied so callers can log the rescue.
+func demoted(consec, userFailsInWindow, selfMs, bestAltMs uint32, p historyParams) (hard, soft, boosted bool) {
+	limit := p.consecutiveFailLimit
+	if limit > 0 && selfMs > 0 && bestAltMs > selfMs*switchPenaltyAltFactor {
+		limit *= 2
+		boosted = true
 	}
-	return 0
-}
-
-func hasOutcomeSince(entries []timestampedOutcome, t time.Time) bool {
-	for i := len(entries) - 1; i >= 0; i-- {
-		if !entries[i].timestamp.Before(t) {
-			return true
-		}
+	if limit > 0 && consec >= limit {
+		return true, false, boosted
 	}
-	return false
-}
-
-// recentSuccessRate is successes/total over entries with age in window.
-// With total == 0 the rate is meaningless; callers must check total
-// before acting on rate. Ages are clamped to zero to tolerate clock skew.
-func recentSuccessRate(entries []timestampedOutcome, now time.Time, window time.Duration) (rate float64, total uint32) {
-	var succ uint32
-	for _, e := range entries {
-		age := max(0, now.Sub(e.timestamp))
-		if age > window {
-			continue
-		}
-		total++
-		if e.outcome.isSuccess() {
-			succ++
-		}
+	if limit > 0 && userFailsInWindow >= limit {
+		return true, false, boosted
 	}
-	if total == 0 {
-		return 0, 0
+	if p.softFailLimit > 0 && userFailsInWindow >= p.softFailLimit {
+		return false, true, boosted
 	}
-	return float64(succ) / float64(total), total
-}
-
-// demoted is true when probe or user-traffic failures cross the
-// consecutive-failure limit, or when the recent probe success rate dips
-// below the threshold with enough sample size to trust the signal.
-func demoted(entries []timestampedOutcome, consecFailures, userFailures uint32, now time.Time, p historyParams) bool {
-	if p.consecutiveFailLimit > 0 && consecFailures >= p.consecutiveFailLimit {
-		return true
-	}
-	if p.consecutiveFailLimit > 0 && userFailures >= p.consecutiveFailLimit {
-		return true
-	}
-	rate, total := recentSuccessRate(entries, now, p.successRateWindow)
-	if total >= p.demoteMinOutcomes && rate < p.demoteSuccessRate {
-		return true
-	}
-	return false
+	return false, false, boosted
 }

--- a/protocol/group/mutableautoselect_probe.go
+++ b/protocol/group/mutableautoselect_probe.go
@@ -1,0 +1,153 @@
+package group
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	A "github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing/common"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+	"github.com/sagernet/sing/common/ntp"
+)
+
+type probeResult struct {
+	tag     string
+	outcome localOutcome
+	delayMs uint32
+}
+
+// runProbe issues an HTTP GET through out to probeURL under the
+// per-protocol timeout. Success implies a completed handshake; for
+// bandit-supplied URLs it also implies the callback handler received the
+// request.
+func runProbe(
+	ctx context.Context,
+	out A.Outbound,
+	probeURL string,
+	beh protocolBehavior,
+) probeResult {
+	tag := out.Tag()
+	if beh.excludeFromPool || probeURL == "" {
+		return probeResult{tag: tag, outcome: outcomeHandshakeFailure}
+	}
+	linkURL, err := url.Parse(probeURL)
+	if err != nil {
+		return probeResult{tag: tag, outcome: outcomeHandshakeFailure}
+	}
+	hostname := linkURL.Hostname()
+	port := linkURL.Port()
+	if port == "" {
+		switch linkURL.Scheme {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		}
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, beh.probeTimeout)
+	defer cancel()
+
+	start := time.Now()
+	conn, err := out.DialContext(probeCtx, "tcp", M.ParseSocksaddrHostPortStr(hostname, port))
+	if err != nil {
+		return probeResult{tag: tag, outcome: classifyDialError(probeCtx, err)}
+	}
+	defer conn.Close()
+	if earlyConn, ok := common.Cast[N.EarlyConn](conn); ok && earlyConn.NeedHandshake() {
+		start = time.Now()
+	}
+
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, probeURL, nil)
+	if err != nil {
+		return probeResult{tag: tag, outcome: outcomeHandshakeFailure}
+	}
+	if tp := linkURL.Query().Get("tp"); tp != "" {
+		req.Header.Set("traceparent", tp)
+	}
+
+	client := http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return conn, nil
+			},
+			TLSClientConfig: &tls.Config{
+				Time:    ntp.TimeFuncFromContext(probeCtx),
+				RootCAs: A.RootPoolFromContext(probeCtx),
+			},
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	defer client.CloseIdleConnections()
+	resp, err := client.Do(req)
+	if err != nil {
+		return probeResult{tag: tag, outcome: classifyDialError(probeCtx, err)}
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	// 1ms floor so a sub-millisecond probe isn't reported as 0; rank
+	// treats delay==0 as "no recent success" and would drop the winner.
+	delayMs := uint32(time.Since(start) / time.Millisecond)
+	if delayMs == 0 {
+		delayMs = 1
+	}
+	return probeResult{tag: tag, outcome: outcomeSuccess, delayMs: delayMs}
+}
+
+func classifyDialError(ctx context.Context, err error) localOutcome {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return outcomeTimeout
+	}
+	return outcomeHandshakeFailure
+}
+
+// probeAll fans out one probe per job over up to probeConcurrency
+// goroutines, recording each result via recordOutcome and streaming
+// successes through onSuccess (called serialized). Returns when every
+// probe completes or ctx fires.
+func (s *MutableAutoSelect) probeAll(
+	ctx context.Context,
+	jobs []probeJob,
+	onSuccess func(res probeResult),
+) {
+	if len(jobs) == 0 {
+		return
+	}
+	var (
+		wg  sync.WaitGroup
+		mu  sync.Mutex
+		sem = make(chan struct{}, probeConcurrency)
+	)
+	for _, j := range jobs {
+		wg.Add(1)
+		go func(j probeJob) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
+			defer func() { <-sem }()
+			res := runProbe(ctx, j.outbound, j.probeURL, j.beh)
+			s.recordOutcome(res.tag, res.outcome, res.delayMs)
+			if res.outcome != outcomeSuccess || onSuccess == nil {
+				return
+			}
+			mu.Lock()
+			onSuccess(res)
+			mu.Unlock()
+		}(j)
+	}
+	wg.Wait()
+}

--- a/protocol/group/mutableautoselect_probe.go
+++ b/protocol/group/mutableautoselect_probe.go
@@ -3,7 +3,6 @@ package group
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -20,7 +19,7 @@ import (
 
 type probeResult struct {
 	tag     string
-	outcome localOutcome
+	success bool
 	delayMs uint32
 }
 
@@ -36,11 +35,11 @@ func runProbe(
 ) probeResult {
 	tag := out.Tag()
 	if beh.excludeFromPool || probeURL == "" {
-		return probeResult{tag: tag, outcome: outcomeHandshakeFailure}
+		return probeResult{tag: tag}
 	}
 	linkURL, err := url.Parse(probeURL)
 	if err != nil {
-		return probeResult{tag: tag, outcome: outcomeHandshakeFailure}
+		return probeResult{tag: tag}
 	}
 	hostname := linkURL.Hostname()
 	port := linkURL.Port()
@@ -59,7 +58,7 @@ func runProbe(
 	start := time.Now()
 	conn, err := out.DialContext(probeCtx, "tcp", M.ParseSocksaddrHostPortStr(hostname, port))
 	if err != nil {
-		return probeResult{tag: tag, outcome: classifyDialError(probeCtx, err)}
+		return probeResult{tag: tag}
 	}
 	defer conn.Close()
 	if earlyConn, ok := common.Cast[N.EarlyConn](conn); ok && earlyConn.NeedHandshake() {
@@ -68,7 +67,7 @@ func runProbe(
 
 	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, probeURL, nil)
 	if err != nil {
-		return probeResult{tag: tag, outcome: outcomeHandshakeFailure}
+		return probeResult{tag: tag}
 	}
 	if tp := linkURL.Query().Get("tp"); tp != "" {
 		req.Header.Set("traceparent", tp)
@@ -91,7 +90,7 @@ func runProbe(
 	defer client.CloseIdleConnections()
 	resp, err := client.Do(req)
 	if err != nil {
-		return probeResult{tag: tag, outcome: classifyDialError(probeCtx, err)}
+		return probeResult{tag: tag}
 	}
 	io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
@@ -102,20 +101,13 @@ func runProbe(
 	if delayMs == 0 {
 		delayMs = 1
 	}
-	return probeResult{tag: tag, outcome: outcomeSuccess, delayMs: delayMs}
-}
-
-func classifyDialError(ctx context.Context, err error) localOutcome {
-	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return outcomeTimeout
-	}
-	return outcomeHandshakeFailure
+	return probeResult{tag: tag, success: true, delayMs: delayMs}
 }
 
 // probeAll fans out one probe per job over up to probeConcurrency
-// goroutines, recording each result via recordOutcome and streaming
-// successes through onSuccess (called serialized). Returns when every
-// probe completes or ctx fires.
+// goroutines, recording each outcome via recordProbeOutcome and
+// streaming successes through onSuccess (called serialized). Returns
+// when every probe completes or ctx fires.
 func (s *MutableAutoSelect) probeAll(
 	ctx context.Context,
 	jobs []probeJob,
@@ -140,8 +132,8 @@ func (s *MutableAutoSelect) probeAll(
 			}
 			defer func() { <-sem }()
 			res := runProbe(ctx, j.outbound, j.probeURL, j.beh)
-			s.recordOutcome(res.tag, res.outcome, res.delayMs)
-			if res.outcome != outcomeSuccess || onSuccess == nil {
+			s.recordProbeOutcome(res.tag, res.success, res.delayMs)
+			if !res.success || onSuccess == nil {
 				return
 			}
 			mu.Lock()

--- a/protocol/group/mutableautoselect_protocols.go
+++ b/protocol/group/mutableautoselect_protocols.go
@@ -1,0 +1,75 @@
+package group
+
+import (
+	"time"
+
+	C "github.com/sagernet/sing-box/constant"
+
+	lConst "github.com/getlantern/lantern-box/constant"
+)
+
+// protocolBehavior captures the per-protocol knobs needed when probing a
+// candidate.
+type protocolBehavior struct {
+	probeTimeout time.Duration
+	// excludeFromPool: peer/network protocols (tor, unbounded) run
+	// alongside the group with their own connection managers and never
+	// belong in the candidate pool.
+	excludeFromPool bool
+	// substituteDelay, when non-zero, replaces the measured probe delay
+	// for ranking. Set for protocols whose handshake jitter makes RTT
+	// meaningless (samizdat).
+	substituteDelay time.Duration
+}
+
+// samizdatNominalDelay is the spec-fixed synthetic delay used to rank
+// samizdat candidates.
+const samizdatNominalDelay = 1000 * time.Millisecond
+
+func behaviorFor(outboundType string) protocolBehavior {
+	switch outboundType {
+	case lConst.TypeALGeneva:
+		return protocolBehavior{probeTimeout: 3000 * time.Millisecond}
+	case lConst.TypeAmnezia:
+		return protocolBehavior{probeTimeout: 1500 * time.Millisecond}
+	case C.TypeHTTP:
+		return protocolBehavior{probeTimeout: 2000 * time.Millisecond}
+	case C.TypeHysteria:
+		return protocolBehavior{probeTimeout: 1500 * time.Millisecond}
+	case C.TypeHysteria2:
+		return protocolBehavior{probeTimeout: 1500 * time.Millisecond}
+	case lConst.TypeOutline:
+		return protocolBehavior{probeTimeout: 10000 * time.Millisecond}
+	case lConst.TypeReflex:
+		return protocolBehavior{probeTimeout: 3000 * time.Millisecond}
+	case lConst.TypeSamizdat:
+		return protocolBehavior{
+			probeTimeout:    3000 * time.Millisecond,
+			substituteDelay: samizdatNominalDelay,
+		}
+	case C.TypeShadowsocks:
+		return protocolBehavior{probeTimeout: 2000 * time.Millisecond}
+	case C.TypeShadowTLS:
+		return protocolBehavior{probeTimeout: 3000 * time.Millisecond}
+	case C.TypeSOCKS:
+		return protocolBehavior{probeTimeout: 2000 * time.Millisecond}
+	case C.TypeSSH:
+		return protocolBehavior{probeTimeout: 3000 * time.Millisecond}
+	case C.TypeTor:
+		return protocolBehavior{excludeFromPool: true}
+	case C.TypeTrojan:
+		return protocolBehavior{probeTimeout: 3000 * time.Millisecond}
+	case C.TypeTUIC:
+		return protocolBehavior{probeTimeout: 1500 * time.Millisecond}
+	case lConst.TypeUnbounded:
+		return protocolBehavior{excludeFromPool: true}
+	case C.TypeVLESS:
+		return protocolBehavior{probeTimeout: 2000 * time.Millisecond}
+	case C.TypeVMess:
+		return protocolBehavior{probeTimeout: 2000 * time.Millisecond}
+	case C.TypeWireGuard:
+		return protocolBehavior{probeTimeout: 1500 * time.Millisecond}
+	default:
+		return protocolBehavior{probeTimeout: 2000 * time.Millisecond}
+	}
+}

--- a/protocol/group/mutableautoselect_protocols.go
+++ b/protocol/group/mutableautoselect_protocols.go
@@ -22,10 +22,6 @@ type protocolBehavior struct {
 	substituteDelay time.Duration
 }
 
-// samizdatNominalDelay is the spec-fixed synthetic delay used to rank
-// samizdat candidates.
-const samizdatNominalDelay = 1000 * time.Millisecond
-
 func behaviorFor(outboundType string) protocolBehavior {
 	switch outboundType {
 	case lConst.TypeALGeneva:
@@ -43,10 +39,7 @@ func behaviorFor(outboundType string) protocolBehavior {
 	case lConst.TypeReflex:
 		return protocolBehavior{probeTimeout: 3000 * time.Millisecond}
 	case lConst.TypeSamizdat:
-		return protocolBehavior{
-			probeTimeout:    3000 * time.Millisecond,
-			substituteDelay: samizdatNominalDelay,
-		}
+		return protocolBehavior{probeTimeout: 3000 * time.Millisecond}
 	case C.TypeShadowsocks:
 		return protocolBehavior{probeTimeout: 2000 * time.Millisecond}
 	case C.TypeShadowTLS:

--- a/protocol/group/mutableautoselect_test.go
+++ b/protocol/group/mutableautoselect_test.go
@@ -1,0 +1,1183 @@
+package group
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	sbAdapter "github.com/sagernet/sing-box/adapter"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing/common/x/list"
+	"github.com/sagernet/sing/service"
+	"github.com/sagernet/sing/service/pause"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getlantern/lantern-box/adapter"
+	lConst "github.com/getlantern/lantern-box/constant"
+)
+
+// Type returns the protocol type used by behaviorFor; an empty
+// typeName keeps the default (non-excluded, 2s probe timeout), which is
+// the right shape for selection-logic tests that don't care about
+// per-protocol knobs. Set typeName to drive substituteDelay / excluded
+// branches.
+func (m *mockOutbound) Type() string { return m.typeName }
+
+// newTestMUR builds a minimal MutableAutoSelect populated with the given
+// tags backed by mockOutbounds. Members are pre-loaded so callers don't
+// need an outboundMgr; the bg loop is not started.
+func newTestMUR(t *testing.T, tags ...string) (*MutableAutoSelect, map[string]*mockOutbound) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	s := &MutableAutoSelect{
+		ctx:          ctx,
+		cancel:       cancel,
+		logger:       log.NewNOPFactory().Logger(),
+		tags:         append([]string(nil), tags...),
+		urlOverrides: map[string]string{},
+		histories:    map[string]*localHistory{},
+		cfg: mutableAutoSelectConfig{
+			switchTolerance:   50 * time.Millisecond,
+			activeInterval:    time.Hour,
+			idleInterval:      4 * time.Hour,
+			idleThreshold:     10 * time.Minute,
+			ladderFastRetry:   50 * time.Millisecond,
+			ladderTotalBudget: 100 * time.Millisecond,
+			dataPlaneIdle:     time.Hour,
+		},
+		hist:         defaultHistoryParams(),
+		history:      adapter.NewAutoSelectHistoryStorage(),
+		exhaustionCh: make(chan struct{}, 1),
+	}
+	obs := make(map[string]*mockOutbound, len(tags))
+	for _, tag := range tags {
+		ob := &mockOutbound{tag: tag}
+		obs[tag] = ob
+		s.members.Store(tag, sbAdapter.Outbound(ob))
+	}
+	return s, obs
+}
+
+// recordSuccess writes a single fresh success entry to a member's history,
+// returning the timestamp so callers can compute a cycleStart that
+// includes (or excludes) the entry.
+func recordSuccess(s *MutableAutoSelect, tag string, delay uint32) time.Time {
+	now := time.Now()
+	h := s.historyForLocked(tag)
+	h.append(outcomeSuccess, delay, now)
+	return now
+}
+
+func TestRecentSuccessRate(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name      string
+		entries   []timestampedOutcome
+		wantTotal uint32
+		wantRate  float64
+	}{
+		{
+			name: "mixed window with one outside",
+			entries: []timestampedOutcome{
+				{outcome: outcomeSuccess, timestamp: now.Add(-10 * time.Minute)},
+				{outcome: outcomeSuccess, timestamp: now.Add(-20 * time.Minute)},
+				{outcome: outcomeTimeout, timestamp: now.Add(-30 * time.Minute)},
+				{outcome: outcomeSuccess, timestamp: now.Add(-2 * time.Hour)}, // outside window
+			},
+			wantTotal: 3,
+			wantRate:  2.0 / 3.0,
+		},
+		{
+			name: "future-stamped entry clamps to age 0",
+			entries: []timestampedOutcome{
+				{outcome: outcomeSuccess, timestamp: now.Add(time.Hour)},
+			},
+			wantTotal: 1,
+			wantRate:  1.0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rate, total := recentSuccessRate(tt.entries, now, time.Hour)
+			assert.Equal(t, tt.wantTotal, total)
+			assert.InDelta(t, tt.wantRate, rate, 1e-9)
+		})
+	}
+}
+
+func TestDemoted(t *testing.T) {
+	now := time.Now()
+	p := defaultHistoryParams()
+	belowRate := []timestampedOutcome{
+		{outcome: outcomeTimeout, timestamp: now.Add(-1 * time.Minute)},
+		{outcome: outcomeTimeout, timestamp: now.Add(-2 * time.Minute)},
+		{outcome: outcomeTimeout, timestamp: now.Add(-3 * time.Minute)},
+		{outcome: outcomeSuccess, timestamp: now.Add(-4 * time.Minute)},
+	}
+	atRate := append([]timestampedOutcome(nil), belowRate...)
+	atRate = append(atRate, timestampedOutcome{outcome: outcomeTimeout, timestamp: now.Add(-5 * time.Minute)})
+
+	tests := []struct {
+		name      string
+		entries   []timestampedOutcome
+		consec    uint32
+		userFails uint32
+		want      bool
+	}{
+		{"consecutive at limit", nil, p.consecutiveFailLimit, 0, true},
+		{"consecutive below limit", nil, p.consecutiveFailLimit - 1, 0, false},
+		{"user failures at limit", nil, 0, p.consecutiveFailLimit, true},
+		{"user failures below limit", nil, 0, p.consecutiveFailLimit - 1, false},
+		{"rate below min outcomes", belowRate, 0, 0, false},
+		{"rate at min outcomes", atRate, 0, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, demoted(tt.entries, tt.consec, tt.userFails, now, p))
+		})
+	}
+}
+
+func TestLocalHistory_RingBufferEvictsOldest(t *testing.T) {
+	h := newLocalHistory(defaultHistoryRingMax)
+	now := time.Now()
+	for i := 0; i < defaultHistoryRingMax+10; i++ {
+		o := outcomeSuccess
+		if i%2 == 0 {
+			o = outcomeTimeout
+		}
+		h.append(o, 100, now.Add(time.Duration(i)*time.Second))
+	}
+	entries, _, _ := h.snapshot()
+	require.Lenf(t, entries, defaultHistoryRingMax,
+		"ring buffer should cap at %d", defaultHistoryRingMax)
+	expectedFirst := now.Add(10 * time.Second)
+	assert.Falsef(t, entries[0].timestamp.Before(expectedFirst),
+		"oldest entry not evicted: first ts=%v want>=%v", entries[0].timestamp, expectedFirst)
+}
+
+func TestLocalHistory_ConsecutiveFailuresResetOnSuccess(t *testing.T) {
+	h := newLocalHistory(defaultHistoryRingMax)
+	now := time.Now()
+	h.append(outcomeTimeout, 0, now)
+	h.append(outcomeHandshakeFailure, 0, now.Add(time.Second))
+	_, consec, _ := h.snapshot()
+	assert.Equal(t, uint32(2), consec, "two failures should accumulate")
+	h.append(outcomeSuccess, 100, now.Add(2*time.Second))
+	_, consec, _ = h.snapshot()
+	assert.Equal(t, uint32(0), consec, "success should reset consecutive failures")
+}
+
+func TestLocalHistory_UserFailuresAreIndependentOfProbeOutcomes(t *testing.T) {
+	// Regression: a probe success must not reset the user-failure counter.
+	// This is the core anti-laundering invariant.
+	h := newLocalHistory(defaultHistoryRingMax)
+	now := time.Now()
+	h.bumpUserFailures()
+	h.bumpUserFailures()
+	assert.Equal(t, uint32(2), h.userFailureCount(),
+		"user failures should accumulate")
+	h.append(outcomeSuccess, 100, now)
+	assert.Equal(t, uint32(2), h.userFailureCount(),
+		"probe success must NOT reset the user-failure counter")
+	h.resetUserFailures()
+	assert.Equal(t, uint32(0), h.userFailureCount(),
+		"explicit reset (via successful Read) clears the counter")
+}
+
+func TestHasOutcomeSince(t *testing.T) {
+	cutoff := time.Now()
+	entries := []timestampedOutcome{
+		{outcome: outcomeSuccess, timestamp: cutoff.Add(-time.Minute)},
+	}
+	assert.False(t, hasOutcomeSince(entries, cutoff),
+		"entry before cutoff should not be counted")
+	entries = append(entries, timestampedOutcome{outcome: outcomeSuccess, timestamp: cutoff.Add(time.Millisecond)})
+	assert.True(t, hasOutcomeSince(entries, cutoff),
+		"entry at/after cutoff should be counted")
+}
+
+func TestLastSuccessDelay(t *testing.T) {
+	entries := []timestampedOutcome{
+		{outcome: outcomeSuccess, delayMs: 100},
+		{outcome: outcomeTimeout},
+		{outcome: outcomeSuccess, delayMs: 250},
+		{outcome: outcomeHandshakeFailure},
+	}
+	assert.Equal(t, uint32(250), lastSuccessDelay(entries))
+	assert.Equal(t, uint32(0), lastSuccessDelay(nil), "empty history returns 0")
+}
+
+func TestBehaviorFor_Timeouts(t *testing.T) {
+	cases := []struct {
+		typeName string
+		want     time.Duration
+	}{
+		{lConst.TypeALGeneva, 3000 * time.Millisecond},
+		{lConst.TypeAmnezia, 1500 * time.Millisecond},
+		{C.TypeHTTP, 2000 * time.Millisecond},
+		{C.TypeHysteria, 1500 * time.Millisecond},
+		{C.TypeHysteria2, 1500 * time.Millisecond},
+		{lConst.TypeOutline, 10000 * time.Millisecond},
+		{lConst.TypeReflex, 3000 * time.Millisecond},
+		{lConst.TypeSamizdat, 3000 * time.Millisecond},
+		{C.TypeShadowsocks, 2000 * time.Millisecond},
+		{C.TypeShadowTLS, 3000 * time.Millisecond},
+		{C.TypeSOCKS, 2000 * time.Millisecond},
+		{C.TypeSSH, 3000 * time.Millisecond},
+		{C.TypeTrojan, 3000 * time.Millisecond},
+		{C.TypeTUIC, 1500 * time.Millisecond},
+		{C.TypeVLESS, 2000 * time.Millisecond},
+		{C.TypeVMess, 2000 * time.Millisecond},
+		{C.TypeWireGuard, 1500 * time.Millisecond},
+	}
+	for _, c := range cases {
+		assert.Equalf(t, c.want, behaviorFor(c.typeName).probeTimeout,
+			"behaviorFor(%q).probeTimeout", c.typeName)
+	}
+}
+
+func TestBehaviorFor_PeerNetworkProtocolsAreExcluded(t *testing.T) {
+	for _, typeName := range []string{C.TypeTor, lConst.TypeUnbounded} {
+		assert.Truef(t, behaviorFor(typeName).excludeFromPool,
+			"%s should be excluded from candidate pool", typeName)
+	}
+}
+
+func TestBehaviorFor_SamizdatGetsSubstituteDelay(t *testing.T) {
+	beh := behaviorFor(lConst.TypeSamizdat)
+	assert.Equal(t, samizdatNominalDelay, beh.substituteDelay)
+}
+
+// --- selectFor: switch tolerance via sticky-tag hysteresis ---
+
+func TestSelectFor_ThreeTierFallback(t *testing.T) {
+	// Tier ordering: clean > soft > hard. Each row picks the cleanest
+	// non-empty tier; ties within a tier go to lowest delay.
+	tests := []struct {
+		name    string
+		setup   func(s *MutableAutoSelect)
+		wantTag string
+	}{
+		{
+			name: "soft-demoted loses to clean peer",
+			setup: func(s *MutableAutoSelect) {
+				recordSuccess(s, "a", 100)
+				recordSuccess(s, "b", 200)
+				s.historyForLocked("a").bumpUserFailures()
+			},
+			wantTag: "b",
+		},
+		{
+			name: "soft-only pool returns the soft member",
+			setup: func(s *MutableAutoSelect) {
+				s.historyForLocked("a").bumpUserFailures()
+				s.historyForLocked("b").bumpUserFailures()
+			},
+			wantTag: "a",
+		},
+		{
+			name: "all-hard falls through to lowest-delay hard",
+			setup: func(s *MutableAutoSelect) {
+				recordSuccess(s, "a", 100)
+				recordSuccess(s, "b", 200)
+				for i := 0; i < int(s.hist.consecutiveFailLimit); i++ {
+					s.historyForLocked("a").bumpUserFailures()
+					s.historyForLocked("b").bumpUserFailures()
+				}
+			},
+			wantTag: "a",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := newTestMUR(t, "a", "b")
+			s.access.Lock()
+			tt.setup(s)
+			s.access.Unlock()
+			got, err := s.selectFor("tcp")
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.wantTag, got.Tag())
+		})
+	}
+}
+
+func TestSelectFor_SwitchTolerance(t *testing.T) {
+	// switchTolerance is 50ms (test default).
+	tests := []struct {
+		name           string
+		alphaDelay     uint32
+		betaDelay      uint32
+		want           string
+		commentary     string
+	}{
+		{"sticky kept within tolerance", 100, 80, "alpha", "80+50 > 100 → keep alpha"},
+		{"switches when beats tolerance", 100, 40, "beta", "40+50 <= 100 → switch"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := newTestMUR(t, "alpha", "beta")
+			recordSuccess(s, "alpha", tt.alphaDelay)
+			recordSuccess(s, "beta", tt.betaDelay)
+			s.stickyTag.tcp.Store("alpha")
+			got, err := s.selectFor("tcp")
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want, got.Tag(), tt.commentary)
+		})
+	}
+}
+
+func TestSelectFor_ForcedSwitchWhenStickyNotInPool(t *testing.T) {
+	// alpha is sticky but has no fresh success and gets pushed into the
+	// hard tier; beta is clean. The hard-tier alpha is filtered out of
+	// the clean pool, so the forced-switch branch fires.
+	s, _ := newTestMUR(t, "alpha", "beta")
+	recordSuccess(s, "beta", 120)
+	// Push alpha to hard-demote: enough user failures to cross the limit.
+	for i := 0; i < int(s.hist.consecutiveFailLimit); i++ {
+		s.access.Lock()
+		s.historyForLocked("alpha").bumpUserFailures()
+		s.access.Unlock()
+	}
+	s.stickyTag.tcp.Store("alpha")
+
+	got, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "beta", got.Tag(),
+		"sticky alpha demoted to hard tier; clean beta wins the forced switch")
+}
+
+func TestSelectFor_RecordsStickyAfterPick(t *testing.T) {
+	s, _ := newTestMUR(t, "a")
+	recordSuccess(s, "a", 50)
+	_, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	assert.Equal(t, "a", loadString(&s.stickyTag.tcp),
+		"selectFor should record the picked tag as sticky for future calls")
+}
+
+func TestPeekHistoryLocked_DoesNotCreateEntry(t *testing.T) {
+	s, _ := newTestMUR(t, "a")
+	_, ok := s.peekHistoryLocked("a")
+	assert.False(t, ok, "peek must not create a history entry")
+	_, present := s.histories["a"]
+	assert.False(t, present, "peek leaked an empty history entry into the map")
+}
+
+// --- Add / Remove invariants ---
+
+func TestRemove_PreservesTagOrder(t *testing.T) {
+	s, _ := newTestMUR(t, "a", "b", "c", "d")
+	n, err := s.Remove("b")
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	assert.Equal(t, []string{"a", "c", "d"}, s.All())
+}
+
+func TestAdd_DoesNotDuplicateAlreadyListedTag(t *testing.T) {
+	// Simulate a post-Start-failure inconsistency: tag is in s.tags but
+	// missing from s.members. Add must repopulate members without
+	// appending a duplicate to s.tags.
+	s, _ := newTestMUR(t, "a")
+	mgr := &mockOutboundManager{outbounds: map[string]sbAdapter.Outbound{
+		"a": &mockOutbound{tag: "a"},
+	}}
+	s.outboundMgr = mgr
+	s.members.Delete("a") // drop members but leave tags intact
+	n, err := s.Add("a")
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	assert.Equal(t, []string{"a"}, s.All(), "Add must not duplicate the already-listed tag")
+}
+
+// --- SetURLOverrides invalidates history on removed override ---
+
+func TestSetURLOverrides_RemovingOverrideInvalidatesHistory(t *testing.T) {
+	s, _ := newTestMUR(t, "a", "b")
+	s.urlOverrides = map[string]string{"a": "https://override.example/a"}
+	recordSuccess(s, "a", 100)
+	recordSuccess(s, "b", 200)
+
+	s.SetURLOverrides(map[string]string{}) // no overrides at all
+
+	_, aPresent := s.histories["a"]
+	assert.False(t, aPresent, "history for 'a' should be cleared when its override is removed")
+	_, bPresent := s.histories["b"]
+	assert.True(t, bPresent, "history for 'b' should be preserved (no override change)")
+}
+
+// --- runProbeCycle freshness gate ---
+
+func TestRankCandidates_ExcludesEntriesBeforeCycleStart(t *testing.T) {
+	s, _ := newTestMUR(t, "a")
+	recordSuccess(s, "a", 100)
+	cycleStart := time.Now().Add(time.Second) // strictly after the entry
+	ranked := s.rank(time.Now().Add(2*time.Second), cycleStart)
+	assert.Empty(t, ranked, "entries before cycleStart must not appear in the ranked set")
+}
+
+// --- dataPlaneStream stall and idempotent close ---
+
+type stallConn struct{ net.Conn }
+
+func (stallConn) Read(p []byte) (int, error)       { return 0, errors.New("idle") }
+func (stallConn) Write(p []byte) (int, error)      { return 0, errors.New("idle") }
+func (stallConn) Close() error                     { return nil }
+func (stallConn) LocalAddr() net.Addr              { return nil }
+func (stallConn) RemoteAddr() net.Addr             { return nil }
+func (stallConn) SetDeadline(time.Time) error      { return nil }
+func (stallConn) SetReadDeadline(time.Time) error  { return nil }
+func (stallConn) SetWriteDeadline(time.Time) error { return nil }
+
+func TestDataPlaneStream_StallFiresOnce(t *testing.T) {
+	var calls atomic.Uint32
+	d := newDataPlaneStream(stallConn{}, 10*time.Millisecond, func() { calls.Add(1) }, nil, nil)
+	defer d.Close()
+	// Wait past the idle window with margin for scheduler jitter.
+	require.Eventually(t, func() bool { return calls.Load() == 1 },
+		time.Second, 5*time.Millisecond, "stall should have fired by now")
+	// Manually invoking fireStall a second time must be a no-op thanks
+	// to the stalled CAS guard.
+	d.fireStall()
+	assert.Equal(t, uint32(1), calls.Load(), "stalled CAS should suppress duplicate fires")
+}
+
+func TestDataPlaneStream_CloseIsIdempotent(t *testing.T) {
+	d := newDataPlaneStream(stallConn{}, time.Hour, func() {}, nil, nil)
+	require.NoError(t, d.Close())
+	assert.NoError(t, d.Close(), "second Close should be a no-op")
+}
+
+func TestDataPlaneStream_NoStallAfterClose(t *testing.T) {
+	// Regression: Close sets stalled=true before stopping the timer, so a
+	// racing Read/Write that fires the timer one more time after Close
+	// (via a Reset that lost the race with Stop) lands on a no-op
+	// fireStall. This test exercises the CAS guard directly: any fireStall
+	// after Close must be suppressed.
+	var calls atomic.Uint32
+	d := newDataPlaneStream(stallConn{}, time.Hour, func() { calls.Add(1) }, nil, nil)
+	d.Close()
+	d.fireStall()
+	assert.Equal(t, uint32(0), calls.Load(), "no stall callbacks must fire after Close")
+}
+
+func TestDataPlanePacket_NoStallAfterClose(t *testing.T) {
+	var calls atomic.Uint32
+	d := newDataPlanePacket(stallPacketConn{}, time.Hour, func() { calls.Add(1) }, nil, nil)
+	d.Close()
+	d.fireStall()
+	assert.Equal(t, uint32(0), calls.Load(), "no stall callbacks must fire after Close")
+}
+
+type stallPacketConn struct{ net.PacketConn }
+
+func (stallPacketConn) ReadFrom(p []byte) (int, net.Addr, error) {
+	return 0, nil, errors.New("idle")
+}
+func (stallPacketConn) WriteTo(p []byte, _ net.Addr) (int, error) { return 0, errors.New("idle") }
+func (stallPacketConn) Close() error                              { return nil }
+func (stallPacketConn) LocalAddr() net.Addr                       { return nil }
+func (stallPacketConn) SetDeadline(time.Time) error               { return nil }
+func (stallPacketConn) SetReadDeadline(time.Time) error           { return nil }
+func (stallPacketConn) SetWriteDeadline(time.Time) error          { return nil }
+
+// --- runLadder closed-group guard ---
+
+func TestRunLadder_DoesNotEmitExhaustionWhenClosed(t *testing.T) {
+	s, _ := newTestMUR(t, "a")
+	s.cancel() // mark closed before any ladder runs.
+	s.runLadder("")
+	select {
+	case <-s.ExhaustionSignal():
+		t.Errorf("closed group must not emit exhaustion")
+	default:
+	}
+}
+
+// --- persistence via AutoSelectHistoryStorage ---
+
+func TestRecordOutcome_Persists(t *testing.T) {
+	tests := []struct {
+		name           string
+		outcome        localOutcome
+		delayMs        uint32
+		wantOutcome    adapter.Outcome
+		wantDelayMs    uint32
+		wantConsecFail uint32
+	}{
+		{"success", outcomeSuccess, 123, adapter.OutcomeSuccess, 123, 0},
+		{"failure also persisted, consec increments", outcomeTimeout, 0, adapter.OutcomeTimeout, 0, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := newTestMUR(t, "a")
+			s.recordOutcome("a", tt.outcome, tt.delayMs)
+			got := s.history.Load("a")
+			require.NotNil(t, got)
+			require.Len(t, got.Outcomes, 1)
+			assert.Equal(t, tt.wantOutcome, got.Outcomes[0].Outcome)
+			assert.Equal(t, tt.wantDelayMs, got.Outcomes[0].DelayMs)
+			assert.Equal(t, tt.wantConsecFail, got.ConsecutiveFailures)
+		})
+	}
+}
+
+func TestAutoSelectHistoryStorage_StoreAfterCloseDoesNotPanic(t *testing.T) {
+	// Regression: in-flight probe/dataplane callbacks can outlive the
+	// storage on tunnel shutdown. Late Store must drop quietly rather
+	// than panic on a nil internal map.
+	store := adapter.NewAutoSelectHistoryStorage()
+	require.NoError(t, store.Close())
+	assert.NotPanics(t, func() {
+		store.Store("a", &adapter.TagHistory{UpdatedAt: time.Now()})
+		store.Delete("a")
+	}, "Store/Delete after Close must be safe no-ops")
+	assert.Nil(t, store.Load("a"), "post-Close Store must not resurrect data")
+}
+
+func TestRecordOutcome_DropsOutcomesForRemovedTag(t *testing.T) {
+	// Regression: a probe goroutine that started before Remove must not
+	// resurrect the in-memory history entry or restore a deleted entry
+	// in the persistence store.
+	s, _ := newTestMUR(t, "a")
+	mgr := &mockOutboundManager{outbounds: map[string]sbAdapter.Outbound{
+		"a": &mockOutbound{tag: "a"},
+	}}
+	s.outboundMgr = mgr
+
+	// Pre-populate the persistence store, then Remove (which should clear it).
+	s.recordOutcome("a", outcomeSuccess, 100)
+	require.NotNil(t, s.history.Load("a"),
+		"setup: expected persisted entry after success")
+	_, err := s.Remove("a")
+	require.NoError(t, err)
+	require.Nil(t, s.history.Load("a"),
+		"Remove must clear the persisted entry")
+
+	// A late probe outcome must not re-create either layer.
+	s.recordOutcome("a", outcomeSuccess, 200)
+	s.access.Lock()
+	_, exists := s.peekHistoryLocked("a")
+	s.access.Unlock()
+	assert.False(t, exists, "recordOutcome must not resurrect history for a non-member tag")
+	assert.Nil(t, s.history.Load("a"),
+		"recordOutcome must not resurrect the persisted entry")
+}
+
+// --- user-failure anti-laundering ---
+
+func TestRecordUserFailure_BumpsCounterAndIsBoundedByMembership(t *testing.T) {
+	s, _ := newTestMUR(t, "a")
+	s.recordUserFailure("a")
+	s.recordUserFailure("a")
+	s.access.Lock()
+	h, ok := s.peekHistoryLocked("a")
+	s.access.Unlock()
+	require.True(t, ok)
+	assert.Equal(t, uint32(2), h.userFailureCount())
+
+	// A user-failure call for a non-member tag must not resurrect history.
+	s.recordUserFailure("nonexistent")
+	s.access.Lock()
+	_, exists := s.peekHistoryLocked("nonexistent")
+	s.access.Unlock()
+	assert.False(t, exists, "recordUserFailure must not create history for a non-member tag")
+}
+
+func TestDataPlaneStream_UserFailureResetOnReadOnly(t *testing.T) {
+	// Only Read should reset: a Write through a half-broken tunnel may
+	// succeed locally (buffered) while remote receipt fails, so writes
+	// must not count as bidirectional proof.
+	tests := []struct {
+		name      string
+		op        func(d *dataPlaneStream) error
+		wantCount uint32
+	}{
+		{
+			name: "Read resets",
+			op: func(d *dataPlaneStream) error {
+				_, err := d.Read(make([]byte, 8))
+				return err
+			},
+			wantCount: 0,
+		},
+		{
+			name: "Write does not reset",
+			op: func(d *dataPlaneStream) error {
+				_, err := d.Write([]byte("hi"))
+				return err
+			},
+			wantCount: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newLocalHistory(defaultHistoryRingMax)
+			h.bumpUserFailures()
+			d := newDataPlaneStream(echoConn{}, time.Hour, func() {}, nil, func() { h.resetUserFailures() })
+			defer d.Close()
+			require.NoError(t, tt.op(d))
+			assert.Equal(t, tt.wantCount, h.userFailureCount())
+		})
+	}
+}
+
+func TestDemoted_UserFailuresTriggerEvenWithCleanProbes(t *testing.T) {
+	// The whole point of the anti-laundering fix: a server can be
+	// demoted by user-traffic failures alone, even if every probe
+	// outcome in the ring is a success.
+	now := time.Now()
+	p := defaultHistoryParams()
+	hist := []timestampedOutcome{
+		{outcome: outcomeSuccess, timestamp: now.Add(-1 * time.Minute), delayMs: 100},
+		{outcome: outcomeSuccess, timestamp: now.Add(-2 * time.Minute), delayMs: 110},
+		{outcome: outcomeSuccess, timestamp: now.Add(-3 * time.Minute), delayMs: 120},
+	}
+	assert.False(t, demoted(hist, 0, 0, now, p),
+		"healthy probe ring + no user failures: not demoted")
+	assert.True(t, demoted(hist, 0, p.consecutiveFailLimit, now, p),
+		"healthy probe ring but user-failure limit reached: demoted")
+}
+
+// --- selectFor: membership changes & seed-driven cold start ---
+
+func TestSelectFor_PreservesStickyAfterUnrelatedRemove(t *testing.T) {
+	// A Remove that doesn't touch the sticky tag must not flip
+	// selection. (The bug this guards against was a routine server-list
+	// update silently reverting a probe-driven pick back to "first
+	// viable in tag order.")
+	s, _ := newTestMUR(t, "a", "b", "c")
+	recordSuccess(s, "a", 200)
+	recordSuccess(s, "b", 150)
+	recordSuccess(s, "c", 50)
+	s.stickyTag.tcp.Store("c")
+	if _, err := s.Remove("b"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	got, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "c", got.Tag(),
+		"selection should survive Remove of a non-sticky tag")
+}
+
+func TestSelectFor_RepicksWhenStickyGone(t *testing.T) {
+	s, _ := newTestMUR(t, "a", "b", "c")
+	recordSuccess(s, "a", 100)
+	recordSuccess(s, "b", 50)
+	recordSuccess(s, "c", 200)
+	s.stickyTag.tcp.Store("b")
+	if _, err := s.Remove("b"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	got, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Contains(t, []string{"a", "c"}, got.Tag(),
+		"selection should be re-picked from remaining members")
+	assert.NotEqual(t, "b", loadString(&s.stickyTag.tcp),
+		"stickyTag should not still reference the removed member")
+}
+
+func TestSelectFor_PrefersLowestSeededDelay(t *testing.T) {
+	// The cold-start initial pick should consult the
+	// AutoSelectHistoryStorage seed via hydrate-on-Add so the offline
+	// pre-warm informs the first selection — not just "first viable by
+	// tag order."
+	seed := func(delay uint32) *adapter.TagHistory {
+		return &adapter.TagHistory{
+			Outcomes: []adapter.TimestampedOutcome{{
+				Outcome: adapter.OutcomeSuccess, DelayMs: delay, Timestamp: time.Now(),
+			}},
+			UpdatedAt: time.Now(),
+		}
+	}
+	s, obs := newTestMUR(t, "a", "b", "c")
+	s.history.Store("a", seed(500))
+	s.history.Store("b", seed(300))
+	s.history.Store("c", seed(100))
+	// Hydrate in-memory history from storage (mimicking Start/Add).
+	s.access.Lock()
+	for _, tag := range s.tags {
+		s.hydrateHistoryLocked(tag)
+	}
+	s.access.Unlock()
+
+	got, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "c", got.Tag(), "lowest seeded delay should win the cold-start pick")
+	assert.Same(t, sbAdapter.Outbound(obs["c"]), got)
+}
+
+func TestSelectFor_FallsBackToTagOrderWithoutSeed(t *testing.T) {
+	s, _ := newTestMUR(t, "a", "b", "c")
+	got, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "a", got.Tag(),
+		"without seed data, the first viable tag should win the cold start (stable sort)")
+}
+
+func TestSelectFor_UnknownBeatsSubstitutedSeed(t *testing.T) {
+	// Regression: every 3-minute config refresh removed the live
+	// hysteria2 selection and added a fresh hysteria2 with no seed; the
+	// previous recompute biased toward samizdat (substituteDelay
+	// protocol with a real seed) over the unmeasured hysteria2, briefly
+	// flipping the visible selection before the immediate probe cycle
+	// switched back. The unified rank treats a kindUnknown candidate as
+	// strictly better than a kindSubstituted one — probing the unknown
+	// is preferable to committing to a deliberately deprioritized peer.
+	s, obs := newTestMUR(t, "sami", "hysteria2-new")
+	obs["sami"].typeName = lConst.TypeSamizdat
+	s.history.Store("sami", &adapter.TagHistory{
+		Outcomes: []adapter.TimestampedOutcome{{
+			Outcome: adapter.OutcomeSuccess, DelayMs: 120, Timestamp: time.Now(),
+		}},
+		UpdatedAt: time.Now(),
+	})
+	// hysteria2-new has neither in-memory history nor a persisted seed.
+	got, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "hysteria2-new", got.Tag(),
+		"unknown candidate must beat a substituted-delay seed")
+}
+
+// --- adaptive probe cadence ---
+
+func TestNextProbeInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		prep func(s *MutableAutoSelect)
+		want func(s *MutableAutoSelect) time.Duration
+	}{
+		{
+			name: "no traffic observed defaults to idle",
+			prep: func(*MutableAutoSelect) {},
+			want: func(s *MutableAutoSelect) time.Duration { return s.cfg.idleInterval },
+		},
+		{
+			name: "recent traffic selects active",
+			prep: func(s *MutableAutoSelect) { s.bumpActive() },
+			want: func(s *MutableAutoSelect) time.Duration { return s.cfg.activeInterval },
+		},
+		{
+			name: "stale traffic backs off to idle",
+			prep: func(s *MutableAutoSelect) {
+				s.lastActive.Store(time.Now().Add(-2 * s.cfg.idleThreshold).UnixNano())
+			},
+			want: func(s *MutableAutoSelect) time.Duration { return s.cfg.idleInterval },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := newTestMUR(t, "a")
+			tt.prep(s)
+			assert.Equal(t, tt.want(s), s.nextProbeInterval())
+		})
+	}
+}
+
+func TestDataPlaneStream_OnActivityFiresOnNonEmptyIO(t *testing.T) {
+	var activity atomic.Uint32
+	d := newDataPlaneStream(echoConn{}, time.Hour, func() {}, func() { activity.Add(1) }, nil)
+	defer d.Close()
+	if _, err := d.Write([]byte("hi")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	buf := make([]byte, 8)
+	if _, err := d.Read(buf); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	assert.Equal(t, uint32(2), activity.Load(),
+		"onActivity should fire once per non-empty Read/Write")
+}
+
+// echoConn returns n>0 on both Read and Write so the activity-tracking
+// tests have a way to drive both call paths without setting up real I/O.
+type echoConn struct{ net.Conn }
+
+func (echoConn) Read(p []byte) (int, error)       { return len(p), nil }
+func (echoConn) Write(p []byte) (int, error)      { return len(p), nil }
+func (echoConn) Close() error                     { return nil }
+func (echoConn) LocalAddr() net.Addr              { return nil }
+func (echoConn) RemoteAddr() net.Addr             { return nil }
+func (echoConn) SetDeadline(time.Time) error      { return nil }
+func (echoConn) SetReadDeadline(time.Time) error  { return nil }
+func (echoConn) SetWriteDeadline(time.Time) error { return nil }
+
+func TestSetURLOverrides_ClearsPersistedEntryOnChange(t *testing.T) {
+	s, _ := newTestMUR(t, "a")
+	s.recordOutcome("a", outcomeSuccess, 100)
+	require.NotNil(t, s.history.Load("a"), "setup: expected persisted entry")
+	s.SetURLOverrides(map[string]string{"a": "https://override.example/a"})
+	assert.Nil(t, s.history.Load("a"),
+		"override change must clear the persisted entry")
+}
+
+// --- recordUserFailure pushes a member into the soft-demote tier ---
+
+func TestRecordUserFailure_DemotesTagInNextSelectFor(t *testing.T) {
+	// After recordUserFailure("a"), "a" is in the soft tier and the
+	// next selectFor("tcp") picks a clean peer instead — replaces the
+	// old "synchronous clear of cached selection" contract.
+	s, _ := newTestMUR(t, "a", "b")
+	recordSuccess(s, "a", 50)
+	recordSuccess(s, "b", 100)
+	s.stickyTag.tcp.Store("a")
+
+	s.recordUserFailure("a")
+
+	got, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "b", got.Tag(),
+		"soft-demoted a must lose to clean b on the next selectFor")
+}
+
+// --- selectFor: soft-demote three-tier fallback ---
+
+func TestSplitHealthyFor_PrefersCleanOverSoftOverHard(t *testing.T) {
+	ob := &mockOutbound{networks: []string{"tcp", "udp"}}
+	ranked := []rankedCandidate{
+		{outbound: ob, tag: "hard", demote: demoteHard, delayMs: 10},
+		{outbound: ob, tag: "soft", demote: demoteSoft, delayMs: 50},
+		{outbound: ob, tag: "clean", demote: demoteClean, delayMs: 100},
+	}
+	pool := splitHealthyFor(ranked, "tcp")
+	require.Len(t, pool, 1)
+	assert.Equal(t, "clean", pool[0].tag, "clean dominates soft/hard regardless of delay")
+
+	pool = splitHealthyFor(ranked[:2], "tcp")
+	require.Len(t, pool, 1)
+	assert.Equal(t, "soft", pool[0].tag, "soft preferred over hard when no clean exists")
+
+	pool = splitHealthyFor(ranked[:1], "tcp")
+	assert.Equal(t, 1, len(pool), "hard-only returns the hard slice as last resort")
+}
+
+// --- ladder skipStep1 at the first user failure ---
+
+func TestRunLadder_SkipStep1(t *testing.T) {
+	// Step 1 is skipped when the target has any user-failure evidence
+	// (one is enough — well under the demote limit). Without that, the
+	// ladder dials twice: step 1 fast retry plus step 2 re-probe.
+	tests := []struct {
+		name      string
+		userFails int
+		wantDials int
+	}{
+		{"no user failure: step 1 + step 2", 0, 2},
+		{"one user failure: only step 2", 1, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, obs := newTestMUR(t, "a")
+			s.defaultURL = "http://probe.test/"
+			obs["a"].On("DialContext").Return(nil, errors.New("dial denied"))
+			for i := 0; i < tt.userFails; i++ {
+				s.access.Lock()
+				s.historyForLocked("a").bumpUserFailures()
+				s.access.Unlock()
+			}
+			s.runLadder("a")
+			obs["a"].AssertNumberOfCalls(t, "DialContext", tt.wantDials)
+		})
+	}
+}
+
+// --- splitHealthyFor: per-network three-tier fallback ---
+
+func TestSplitHealthyFor_KeepsSoftWhenCleanIsOtherNetwork(t *testing.T) {
+	// The clean candidate is TCP-only; the only UDP-capable member is
+	// soft. Per-network split must return the soft UDP member rather
+	// than nil; the same pool can't be reused across networks.
+	tcpOnly := &mockOutbound{tag: "tcp-only", networks: []string{"tcp"}}
+	bothSoft := &mockOutbound{tag: "both-soft", networks: []string{"tcp", "udp"}}
+	ranked := []rankedCandidate{
+		{outbound: tcpOnly, tag: "tcp-only", demote: demoteClean, delayMs: 10},
+		{outbound: bothSoft, tag: "both-soft", demote: demoteSoft, delayMs: 50},
+	}
+	tcpPool := splitHealthyFor(ranked, "tcp")
+	require.Len(t, tcpPool, 1, "tcp pool should be clean-only")
+	assert.Equal(t, "tcp-only", tcpPool[0].tag)
+
+	udpPool := splitHealthyFor(ranked, "udp")
+	require.Len(t, udpPool, 1, "udp pool should fall through to soft when no clean udp candidate exists")
+	assert.Equal(t, "both-soft", udpPool[0].tag)
+}
+
+func TestSelectFor_PerNetworkPool(t *testing.T) {
+	// Probe-cycle scenario: tcp-only is clean, both-soft is the only
+	// UDP-capable member. Per-network pool selection means TCP gets
+	// the clean tcp-only and UDP falls through to the soft both-soft.
+	s, _ := newTestMUR(t, "tcp-only", "both-soft")
+	tcpOnly := &mockOutbound{tag: "tcp-only", networks: []string{"tcp"}}
+	bothSoft := &mockOutbound{tag: "both-soft", networks: []string{"tcp", "udp"}}
+	s.members.Store("tcp-only", sbAdapter.Outbound(tcpOnly))
+	s.members.Store("both-soft", sbAdapter.Outbound(bothSoft))
+	recordSuccess(s, "tcp-only", 10)
+	recordSuccess(s, "both-soft", 50)
+	// Mark both-soft as soft-demoted.
+	s.access.Lock()
+	s.historyForLocked("both-soft").bumpUserFailures()
+	s.access.Unlock()
+
+	tcp, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	require.NotNil(t, tcp)
+	assert.Equal(t, "tcp-only", tcp.Tag(),
+		"tcp must select the clean tcp-only member")
+
+	udp, err := s.selectFor("udp")
+	require.NoError(t, err)
+	require.NotNil(t, udp)
+	assert.Equal(t, "both-soft", udp.Tag(),
+		"udp must fall through to the soft both-soft member when no clean udp candidate exists")
+}
+
+// --- selectFor kind tie-break ---
+
+func TestSelectFor_PrefersRealSeededOverSubstituted(t *testing.T) {
+	// Both "sami" (substituted via samizdat protocol) and "real" are
+	// clean. s.tags order puts sami first, but selectFor should pick
+	// real because real-seeded < substituted in kindOrder.
+	s, obs := newTestMUR(t, "sami", "real")
+	obs["sami"].typeName = lConst.TypeSamizdat
+	recordSuccess(s, "real", 100)
+	// "sami" needs a success too, otherwise selectFor sees it as
+	// kindUnknown (which would also lose to real, but the test wants
+	// to specifically pin the kindSubstituted-loses-to-kindRealSeeded
+	// invariant).
+	recordSuccess(s, "sami", 5)
+
+	got, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "real", got.Tag(),
+		"real-seeded must win the kind tie-break over substituted even when substituted is first in s.tags")
+}
+
+func TestURLTest_HydratesBeforeRecordingOutcomes(t *testing.T) {
+	// Seed the storage with a prior outcome ring for "a"; URLTest's
+	// lazy-load must hydrate from this snapshot before recording a new
+	// outcome, otherwise the persisted ring gets clobbered by a fresh
+	// one-entry write.
+	s, obs := newTestMUR(t, "a")
+	s.defaultURL = "http://probe.test/"
+	obs["a"].On("DialContext").Return(nil, errors.New("dial denied"))
+	// Route URLTest's lazy-load through outboundMgr by dropping the
+	// pre-populated member; otherwise the hydrate branch is skipped
+	// because the member is already loaded.
+	s.outboundMgr = &mockOutboundManager{outbounds: map[string]sbAdapter.Outbound{
+		"a": obs["a"],
+	}}
+	s.members.Delete("a")
+	prior := time.Now().Add(-time.Minute)
+	s.history.Store("a", &adapter.TagHistory{
+		Outcomes: []adapter.TimestampedOutcome{
+			{Outcome: adapter.OutcomeSuccess, DelayMs: 42, Timestamp: prior},
+		},
+		UpdatedAt: prior,
+	})
+
+	_, _ = s.URLTest(context.Background())
+
+	got := s.history.Load("a")
+	require.NotNil(t, got)
+	require.GreaterOrEqual(t, len(got.Outcomes), 2,
+		"hydrated entry must be appended to, not replaced — expected the seed plus the new failure")
+	assert.Equal(t, adapter.OutcomeSuccess, got.Outcomes[0].Outcome,
+		"the prior success seed must still be the first entry")
+	assert.Equal(t, uint32(42), got.Outcomes[0].DelayMs)
+}
+
+// --- exhaustion signal end-to-end ---
+
+// drainExhaustion empties any pending pre-existing signal so tests can
+// observe the next emission deterministically.
+func drainExhaustion(s *MutableAutoSelect) {
+	select {
+	case <-s.ExhaustionSignal():
+	default:
+	}
+}
+
+func TestExhaustionSignal_FiresOnFullLadderFailure(t *testing.T) {
+	s, obs := newTestMUR(t, "a", "b")
+	s.defaultURL = "http://probe.test/"
+	obs["a"].On("DialContext").Return(nil, errors.New("dial denied"))
+	obs["b"].On("DialContext").Return(nil, errors.New("dial denied"))
+
+	sig := s.ExhaustionSignal()
+	s.runLadder("a")
+
+	select {
+	case _, ok := <-sig:
+		assert.True(t, ok, "exhaustion channel should deliver a value, not be closed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("exhaustion signal not delivered within timeout")
+	}
+}
+
+func TestExhaustionSignal_CoalescesPendingSignal(t *testing.T) {
+	// A stale pending signal must not block a fresh emission. emitExhaustion
+	// drains any unread signal before sending, so the buffered channel always
+	// reflects the latest ladder outcome.
+	s, obs := newTestMUR(t, "a")
+	s.defaultURL = "http://probe.test/"
+	obs["a"].On("DialContext").Return(nil, errors.New("dial denied"))
+
+	// Pre-load the buffer to simulate an unread prior signal.
+	s.exhaustionCh <- struct{}{}
+	require.Equal(t, 1, len(s.exhaustionCh), "setup: buffer should hold the stale signal")
+
+	s.runLadder("a")
+
+	select {
+	case <-s.ExhaustionSignal():
+	case <-time.After(2 * time.Second):
+		t.Fatal("coalesced exhaustion signal not delivered within timeout")
+	}
+	select {
+	case <-s.ExhaustionSignal():
+		t.Fatal("second receive should block: emitExhaustion buffers exactly one signal")
+	default:
+	}
+}
+
+func TestExhaustionSignal_CloseClosesChannelForRangeLoop(t *testing.T) {
+	s, _ := newTestMUR(t, "a")
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range s.ExhaustionSignal() {
+		}
+	}()
+	require.NoError(t, s.Close())
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("range loop did not exit after Close")
+	}
+}
+
+// --- InterfaceUpdated triggers a probe cycle ---
+
+func TestInterfaceUpdated_TriggersReprobe(t *testing.T) {
+	s, obs := newTestMUR(t, "a")
+	s.defaultURL = "http://probe.test/"
+	dialed := make(chan struct{}, 1)
+	obs["a"].On("DialContext").Run(func(mock.Arguments) {
+		select {
+		case dialed <- struct{}{}:
+		default:
+		}
+	}).Return(nil, errors.New("dial denied"))
+
+	s.InterfaceUpdated()
+
+	select {
+	case <-dialed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("InterfaceUpdated did not trigger a probe of member a")
+	}
+	// Wait for the probe cycle to finish so the goroutine's writes to the
+	// mock's Calls log are happens-before our AssertNumberOfCalls read.
+	s.probeMu.Lock()
+	s.probeMu.Unlock()
+	obs["a"].AssertNumberOfCalls(t, "DialContext", 1)
+}
+
+// --- pause.Manager lookup in runBackgroundLoop ---
+
+type fakePauseManager struct {
+	pause.Manager
+	registered atomic.Uint32
+}
+
+func (f *fakePauseManager) IsPaused() bool { return false }
+
+func (f *fakePauseManager) RegisterCallback(pause.Callback) *list.Element[pause.Callback] {
+	f.registered.Add(1)
+	return &list.Element[pause.Callback]{}
+}
+
+func (f *fakePauseManager) UnregisterCallback(*list.Element[pause.Callback]) {}
+
+func TestRunBackgroundLoop_RegistersWithPauseManager(t *testing.T) {
+	pm := &fakePauseManager{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = service.ContextWith[pause.Manager](ctx, pm)
+	s, _ := newTestMUR(t, "a")
+	s.ctx = ctx
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.runBackgroundLoop()
+	}()
+	require.Eventually(t, func() bool { return pm.registered.Load() == 1 },
+		2*time.Second, 10*time.Millisecond, "pause manager callback not registered")
+	cancel()
+	<-done
+}
+
+func TestRunBackgroundLoop_NoPauseManagerIsNoOp(t *testing.T) {
+	// FromContext returns the zero value when no manager is registered;
+	// the loop must skip the RegisterTicker branch without panicking.
+	s, _ := newTestMUR(t, "a")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.ctx = ctx
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.runBackgroundLoop()
+	}()
+	// Give the loop a chance to enter its select; cancel then ensures clean exit.
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runBackgroundLoop did not exit after ctx cancel")
+	}
+}
+
+// --- Close racing emitExhaustion under -race ---
+
+func TestClose_RaceWithEmitExhaustionDoesNotPanic(t *testing.T) {
+	// emitExhaustion sends on exhaustionCh and Close closes it; both
+	// serialize through s.access so the send can never observe a closed
+	// channel. This test stress-runs the two paths in parallel under the
+	// race detector.
+	const iterations = 200
+	for i := 0; i < iterations; i++ {
+		s, _ := newTestMUR(t, "a")
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			s.emitExhaustion()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = s.Close()
+		}()
+		wg.Wait()
+	}
+}

--- a/protocol/group/mutableautoselect_test.go
+++ b/protocol/group/mutableautoselect_test.go
@@ -253,7 +253,6 @@ func TestBehaviorFor_SamizdatGetsSubstituteDelay(t *testing.T) {
 	assert.Equal(t, samizdatNominalDelay, beh.substituteDelay)
 }
 
-// --- selectFor: switch tolerance via sticky-tag hysteresis ---
 
 func TestSelectFor_ThreeTierFallback(t *testing.T) {
 	// Tier ordering: clean > soft > hard. Each row picks the cleanest
@@ -371,7 +370,6 @@ func TestPeekHistoryLocked_DoesNotCreateEntry(t *testing.T) {
 	assert.False(t, present, "peek leaked an empty history entry into the map")
 }
 
-// --- Add / Remove invariants ---
 
 func TestRemove_PreservesTagOrder(t *testing.T) {
 	s, _ := newTestMUR(t, "a", "b", "c", "d")
@@ -396,7 +394,6 @@ func TestAdd_DoesNotDuplicateAlreadyListedTag(t *testing.T) {
 	assert.Equal(t, []string{"a"}, s.All(), "Add must not duplicate the already-listed tag")
 }
 
-// --- SetURLOverrides invalidates history on removed override ---
 
 func TestSetURLOverrides_RemovingOverrideInvalidatesHistory(t *testing.T) {
 	s, _ := newTestMUR(t, "a", "b")
@@ -412,7 +409,6 @@ func TestSetURLOverrides_RemovingOverrideInvalidatesHistory(t *testing.T) {
 	assert.True(t, bPresent, "history for 'b' should be preserved (no override change)")
 }
 
-// --- runProbeCycle freshness gate ---
 
 func TestRankCandidates_ExcludesEntriesBeforeCycleStart(t *testing.T) {
 	s, _ := newTestMUR(t, "a")
@@ -422,7 +418,6 @@ func TestRankCandidates_ExcludesEntriesBeforeCycleStart(t *testing.T) {
 	assert.Empty(t, ranked, "entries before cycleStart must not appear in the ranked set")
 }
 
-// --- dataPlaneStream stall and idempotent close ---
 
 type stallConn struct{ net.Conn }
 
@@ -487,7 +482,6 @@ func (stallPacketConn) SetDeadline(time.Time) error               { return nil }
 func (stallPacketConn) SetReadDeadline(time.Time) error           { return nil }
 func (stallPacketConn) SetWriteDeadline(time.Time) error          { return nil }
 
-// --- runLadder closed-group guard ---
 
 func TestRunLadder_DoesNotEmitExhaustionWhenClosed(t *testing.T) {
 	s, _ := newTestMUR(t, "a")
@@ -500,7 +494,6 @@ func TestRunLadder_DoesNotEmitExhaustionWhenClosed(t *testing.T) {
 	}
 }
 
-// --- persistence via AutoSelectHistoryStorage ---
 
 func TestRecordOutcome_Persists(t *testing.T) {
 	tests := []struct {
@@ -570,7 +563,6 @@ func TestRecordOutcome_DropsOutcomesForRemovedTag(t *testing.T) {
 		"recordOutcome must not resurrect the persisted entry")
 }
 
-// --- user-failure anti-laundering ---
 
 func TestRecordUserFailure_BumpsCounterAndIsBoundedByMembership(t *testing.T) {
 	s, _ := newTestMUR(t, "a")
@@ -645,7 +637,6 @@ func TestDemoted_UserFailuresTriggerEvenWithCleanProbes(t *testing.T) {
 		"healthy probe ring but user-failure limit reached: demoted")
 }
 
-// --- selectFor: membership changes & seed-driven cold start ---
 
 func TestSelectFor_PreservesStickyAfterUnrelatedRemove(t *testing.T) {
 	// A Remove that doesn't touch the sticky tag must not flip
@@ -743,7 +734,6 @@ func TestSelectFor_UnknownBeatsSubstitutedSeed(t *testing.T) {
 		"unknown candidate must beat a substituted-delay seed")
 }
 
-// --- adaptive probe cadence ---
 
 func TestNextProbeInterval(t *testing.T) {
 	tests := []struct {
@@ -815,7 +805,6 @@ func TestSetURLOverrides_ClearsPersistedEntryOnChange(t *testing.T) {
 		"override change must clear the persisted entry")
 }
 
-// --- recordUserFailure pushes a member into the soft-demote tier ---
 
 func TestRecordUserFailure_DemotesTagInNextSelectFor(t *testing.T) {
 	// After recordUserFailure("a"), "a" is in the soft tier and the
@@ -835,7 +824,6 @@ func TestRecordUserFailure_DemotesTagInNextSelectFor(t *testing.T) {
 		"soft-demoted a must lose to clean b on the next selectFor")
 }
 
-// --- selectFor: soft-demote three-tier fallback ---
 
 func TestSplitHealthyFor_PrefersCleanOverSoftOverHard(t *testing.T) {
 	ob := &mockOutbound{networks: []string{"tcp", "udp"}}
@@ -856,7 +844,6 @@ func TestSplitHealthyFor_PrefersCleanOverSoftOverHard(t *testing.T) {
 	assert.Equal(t, 1, len(pool), "hard-only returns the hard slice as last resort")
 }
 
-// --- ladder skipStep1 at the first user failure ---
 
 func TestRunLadder_SkipStep1(t *testing.T) {
 	// Step 1 is skipped when the target has any user-failure evidence
@@ -886,7 +873,6 @@ func TestRunLadder_SkipStep1(t *testing.T) {
 	}
 }
 
-// --- splitHealthyFor: per-network three-tier fallback ---
 
 func TestSplitHealthyFor_KeepsSoftWhenCleanIsOtherNetwork(t *testing.T) {
 	// The clean candidate is TCP-only; the only UDP-capable member is
@@ -936,7 +922,6 @@ func TestSelectFor_PerNetworkPool(t *testing.T) {
 		"udp must fall through to the soft both-soft member when no clean udp candidate exists")
 }
 
-// --- selectFor kind tie-break ---
 
 func TestSelectFor_PrefersRealSeededOverSubstituted(t *testing.T) {
 	// Both "sami" (substituted via samizdat protocol) and "real" are
@@ -992,7 +977,6 @@ func TestURLTest_HydratesBeforeRecordingOutcomes(t *testing.T) {
 	assert.Equal(t, uint32(42), got.Outcomes[0].DelayMs)
 }
 
-// --- exhaustion signal end-to-end ---
 
 // drainExhaustion empties any pending pre-existing signal so tests can
 // observe the next emission deterministically.
@@ -1062,7 +1046,6 @@ func TestExhaustionSignal_CloseClosesChannelForRangeLoop(t *testing.T) {
 	}
 }
 
-// --- InterfaceUpdated triggers a probe cycle ---
 
 func TestInterfaceUpdated_TriggersReprobe(t *testing.T) {
 	s, obs := newTestMUR(t, "a")
@@ -1089,7 +1072,6 @@ func TestInterfaceUpdated_TriggersReprobe(t *testing.T) {
 	obs["a"].AssertNumberOfCalls(t, "DialContext", 1)
 }
 
-// --- pause.Manager lookup in runBackgroundLoop ---
 
 type fakePauseManager struct {
 	pause.Manager
@@ -1146,7 +1128,6 @@ func TestRunBackgroundLoop_NoPauseManagerIsNoOp(t *testing.T) {
 	}
 }
 
-// --- Close racing emitExhaustion under -race ---
 
 func TestClose_RaceWithEmitExhaustionDoesNotPanic(t *testing.T) {
 	// emitExhaustion sends on exhaustionCh and Close closes it; both

--- a/protocol/group/mutableautoselect_test.go
+++ b/protocol/group/mutableautoselect_test.go
@@ -23,11 +23,8 @@ import (
 	lConst "github.com/getlantern/lantern-box/constant"
 )
 
-// Type returns the protocol type used by behaviorFor; an empty
-// typeName keeps the default (non-excluded, 2s probe timeout), which is
-// the right shape for selection-logic tests that don't care about
-// per-protocol knobs. Set typeName to drive substituteDelay / excluded
-// branches.
+// Type returns m.typeName so tests can drive behaviorFor branches
+// (substituteDelay, excluded). Empty typeName keeps the default.
 func (m *mockOutbound) Type() string { return m.typeName }
 
 // newTestMUR builds a minimal MutableAutoSelect populated with the given
@@ -177,8 +174,7 @@ func TestLocalHistory_ConsecutiveFailuresResetOnSuccess(t *testing.T) {
 }
 
 func TestLocalHistory_UserFailuresAreIndependentOfProbeOutcomes(t *testing.T) {
-	// Regression: a probe success must not reset the user-failure counter.
-	// This is the core anti-laundering invariant.
+	// A probe success must not reset the user-failure counter.
 	h := newLocalHistory(defaultHistoryRingMax)
 	now := time.Now()
 	h.bumpUserFailures()
@@ -386,9 +382,8 @@ func TestRemove_PreservesTagOrder(t *testing.T) {
 }
 
 func TestAdd_DoesNotDuplicateAlreadyListedTag(t *testing.T) {
-	// Simulate a post-Start-failure inconsistency: tag is in s.tags but
-	// missing from s.members. Add must repopulate members without
-	// appending a duplicate to s.tags.
+	// When s.tags lists a tag but s.members is missing it, Add must
+	// repopulate members without appending a duplicate to s.tags.
 	s, _ := newTestMUR(t, "a")
 	mgr := &mockOutboundManager{outbounds: map[string]sbAdapter.Outbound{
 		"a": &mockOutbound{tag: "a"},
@@ -534,9 +529,9 @@ func TestRecordOutcome_Persists(t *testing.T) {
 }
 
 func TestAutoSelectHistoryStorage_StoreAfterCloseDoesNotPanic(t *testing.T) {
-	// Regression: in-flight probe/dataplane callbacks can outlive the
-	// storage on tunnel shutdown. Late Store must drop quietly rather
-	// than panic on a nil internal map.
+	// In-flight probe/dataplane callbacks can outlive the storage on
+	// tunnel shutdown. Late Store must drop quietly rather than panic
+	// on a nil internal map.
 	store := adapter.NewAutoSelectHistoryStorage()
 	require.NoError(t, store.Close())
 	assert.NotPanics(t, func() {
@@ -654,9 +649,7 @@ func TestDemoted_UserFailuresTriggerEvenWithCleanProbes(t *testing.T) {
 
 func TestSelectFor_PreservesStickyAfterUnrelatedRemove(t *testing.T) {
 	// A Remove that doesn't touch the sticky tag must not flip
-	// selection. (The bug this guards against was a routine server-list
-	// update silently reverting a probe-driven pick back to "first
-	// viable in tag order.")
+	// selection.
 	s, _ := newTestMUR(t, "a", "b", "c")
 	recordSuccess(s, "a", 200)
 	recordSuccess(s, "b", 150)
@@ -731,14 +724,9 @@ func TestSelectFor_FallsBackToTagOrderWithoutSeed(t *testing.T) {
 }
 
 func TestSelectFor_UnknownBeatsSubstitutedSeed(t *testing.T) {
-	// Regression: every 3-minute config refresh removed the live
-	// hysteria2 selection and added a fresh hysteria2 with no seed; the
-	// previous recompute biased toward samizdat (substituteDelay
-	// protocol with a real seed) over the unmeasured hysteria2, briefly
-	// flipping the visible selection before the immediate probe cycle
-	// switched back. The unified rank treats a kindUnknown candidate as
-	// strictly better than a kindSubstituted one — probing the unknown
-	// is preferable to committing to a deliberately deprioritized peer.
+	// The unified rank treats a kindUnknown candidate as strictly
+	// better than a kindSubstituted one — probing the unknown is
+	// preferable to committing to a deliberately deprioritized peer.
 	s, obs := newTestMUR(t, "sami", "hysteria2-new")
 	obs["sami"].typeName = lConst.TypeSamizdat
 	s.history.Store("sami", &adapter.TagHistory{

--- a/protocol/group/mutableautoselect_test.go
+++ b/protocol/group/mutableautoselect_test.go
@@ -46,9 +46,9 @@ func newTestMUR(t *testing.T, tags ...string) (*MutableAutoSelect, map[string]*m
 			activeInterval:    time.Hour,
 			idleInterval:      4 * time.Hour,
 			idleThreshold:     10 * time.Minute,
-			ladderFastRetry:   50 * time.Millisecond,
 			ladderTotalBudget: 100 * time.Millisecond,
 			dataPlaneIdle:     time.Hour,
+			maxPersistedAge:   defaultMaxPersistedAge,
 		},
 		hist:         defaultHistoryParams(),
 		history:      adapter.NewAutoSelectHistoryStorage(),
@@ -63,153 +63,187 @@ func newTestMUR(t *testing.T, tags ...string) (*MutableAutoSelect, map[string]*m
 	return s, obs
 }
 
-// recordSuccess writes a single fresh success entry to a member's history,
-// returning the timestamp so callers can compute a cycleStart that
-// includes (or excludes) the entry.
+// recordSuccess writes a single fresh probe success to a member's
+// history, returning the timestamp so callers can compute a cycleStart
+// that includes (or excludes) the entry.
 func recordSuccess(s *MutableAutoSelect, tag string, delay uint32) time.Time {
 	now := time.Now()
 	h := s.historyForLocked(tag)
-	h.append(outcomeSuccess, delay, now)
+	h.recordProbeSuccess(delay, now)
 	return now
 }
 
-func TestRecentSuccessRate(t *testing.T) {
+func TestPruneUserFailures(t *testing.T) {
 	now := time.Now()
 	tests := []struct {
-		name      string
-		entries   []timestampedOutcome
-		wantTotal uint32
-		wantRate  float64
+		name   string
+		in     []time.Time
+		window time.Duration
+		want   int
 	}{
-		{
-			name: "mixed window with one outside",
-			entries: []timestampedOutcome{
-				{outcome: outcomeSuccess, timestamp: now.Add(-10 * time.Minute)},
-				{outcome: outcomeSuccess, timestamp: now.Add(-20 * time.Minute)},
-				{outcome: outcomeTimeout, timestamp: now.Add(-30 * time.Minute)},
-				{outcome: outcomeSuccess, timestamp: now.Add(-2 * time.Hour)}, // outside window
-			},
-			wantTotal: 3,
-			wantRate:  2.0 / 3.0,
-		},
-		{
-			name: "future-stamped entry clamps to age 0",
-			entries: []timestampedOutcome{
-				{outcome: outcomeSuccess, timestamp: now.Add(time.Hour)},
-			},
-			wantTotal: 1,
-			wantRate:  1.0,
-		},
+		{"empty", nil, time.Minute, 0},
+		{"all in window", []time.Time{now.Add(-1 * time.Minute), now.Add(-2 * time.Minute)}, 5 * time.Minute, 2},
+		{"some aged out", []time.Time{now.Add(-1 * time.Minute), now.Add(-10 * time.Minute)}, 5 * time.Minute, 1},
+		{"future-stamped clamps age to 0", []time.Time{now.Add(time.Hour)}, 5 * time.Minute, 1},
+		{"all aged out returns nil", []time.Time{now.Add(-10 * time.Minute)}, 5 * time.Minute, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rate, total := recentSuccessRate(tt.entries, now, time.Hour)
-			assert.Equal(t, tt.wantTotal, total)
-			assert.InDelta(t, tt.wantRate, rate, 1e-9)
+			got := pruneUserFailures(append([]time.Time(nil), tt.in...), now, tt.window)
+			assert.Len(t, got, tt.want)
 		})
 	}
 }
 
 func TestDemoted(t *testing.T) {
-	now := time.Now()
 	p := defaultHistoryParams()
-	belowRate := []timestampedOutcome{
-		{outcome: outcomeTimeout, timestamp: now.Add(-1 * time.Minute)},
-		{outcome: outcomeTimeout, timestamp: now.Add(-2 * time.Minute)},
-		{outcome: outcomeTimeout, timestamp: now.Add(-3 * time.Minute)},
-		{outcome: outcomeSuccess, timestamp: now.Add(-4 * time.Minute)},
-	}
-	atRate := append([]timestampedOutcome(nil), belowRate...)
-	atRate = append(atRate, timestampedOutcome{outcome: outcomeTimeout, timestamp: now.Add(-5 * time.Minute)})
-
 	tests := []struct {
 		name      string
-		entries   []timestampedOutcome
 		consec    uint32
 		userFails uint32
-		want      bool
+		wantHard  bool
+		wantSoft  bool
 	}{
-		{"consecutive at limit", nil, p.consecutiveFailLimit, 0, true},
-		{"consecutive below limit", nil, p.consecutiveFailLimit - 1, 0, false},
-		{"user failures at limit", nil, 0, p.consecutiveFailLimit, true},
-		{"user failures below limit", nil, 0, p.consecutiveFailLimit - 1, false},
-		{"rate below min outcomes", belowRate, 0, 0, false},
-		{"rate at min outcomes", atRate, 0, 0, true},
+		{"clean", 0, 0, false, false},
+		{"consecutive at limit", p.consecutiveFailLimit, 0, true, false},
+		{"consecutive below limit", p.consecutiveFailLimit - 1, 0, false, false},
+		{"user failures at hard limit", 0, p.consecutiveFailLimit, true, false},
+		{"user failures at soft limit", 0, p.softFailLimit, false, true},
+		{"one user failure stays clean", 0, 1, false, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, demoted(tt.entries, tt.consec, tt.userFails, now, p))
+			// Use selfMs=0 so the switch-penalty boost can't apply.
+			hard, soft, _ := demoted(tt.consec, tt.userFails, 0, 0, p)
+			assert.Equal(t, tt.wantHard, hard, "hard")
+			assert.Equal(t, tt.wantSoft, soft, "soft")
 		})
 	}
 }
 
-func TestLocalHistory_RingBufferEvictsOldest(t *testing.T) {
-	h := newLocalHistory(defaultHistoryRingMax)
-	now := time.Now()
-	for i := 0; i < defaultHistoryRingMax+10; i++ {
-		o := outcomeSuccess
-		if i%2 == 0 {
-			o = outcomeTimeout
-		}
-		h.append(o, 100, now.Add(time.Duration(i)*time.Second))
-	}
-	entries, _, _ := h.snapshot()
-	require.Lenf(t, entries, defaultHistoryRingMax,
-		"ring buffer should cap at %d", defaultHistoryRingMax)
-	expectedFirst := now.Add(10 * time.Second)
-	assert.Falsef(t, entries[0].timestamp.Before(expectedFirst),
-		"oldest entry not evicted: first ts=%v want>=%v", entries[0].timestamp, expectedFirst)
+func TestDemoted_SwitchPenaltyBoost(t *testing.T) {
+	p := defaultHistoryParams()
+	require.Equal(t, uint32(3), p.consecutiveFailLimit, "test assumes default limit of 3")
+
+	// Without a faster self or a much slower alternative, the boost
+	// doesn't apply and the rule trips at the base limit.
+	hard, _, boosted := demoted(3, 0, 100, 150, p)
+	assert.True(t, hard, "alt within latency factor must not boost")
+	assert.False(t, boosted)
+
+	// With a much slower alternative, the limit doubles. Three failures
+	// no longer trip the rule; six do. consec-only failures don't flip
+	// to soft (soft is reserved for user-traffic-side failures), so the
+	// rescued state is fully clean.
+	hard, soft, boosted := demoted(3, 0, 100, 990, p)
+	assert.False(t, hard, "boosted limit must hold at 3 failures")
+	assert.False(t, soft, "consec-only failures rescued by boost stay clean")
+	assert.True(t, boosted, "boost flag must announce the rescue")
+
+	hard, _, boosted = demoted(6, 0, 100, 990, p)
+	assert.True(t, hard, "boosted limit must trip at 2x base")
+	assert.True(t, boosted)
+
+	// selfMs==0 (unknown delay) disables the boost.
+	hard, _, boosted = demoted(3, 0, 0, 990, p)
+	assert.True(t, hard, "unknown self-delay must not boost")
+	assert.False(t, boosted)
+
+	// User-failures path is also doubled.
+	hard, _, boosted = demoted(0, 3, 100, 990, p)
+	assert.False(t, hard, "user_failures path must also be boosted")
+	assert.True(t, boosted)
+	hard, _, _ = demoted(0, 6, 100, 990, p)
+	assert.True(t, hard, "boosted user_failures must still trip at 2x base")
 }
 
 func TestLocalHistory_ConsecutiveFailuresResetOnSuccess(t *testing.T) {
-	h := newLocalHistory(defaultHistoryRingMax)
+	h := newLocalHistory()
 	now := time.Now()
-	h.append(outcomeTimeout, 0, now)
-	h.append(outcomeHandshakeFailure, 0, now.Add(time.Second))
-	_, consec, _ := h.snapshot()
+	h.recordProbeFailure(now)
+	h.recordProbeFailure(now.Add(time.Second))
+	_, _, consec, _ := h.snapshot(now, time.Hour)
 	assert.Equal(t, uint32(2), consec, "two failures should accumulate")
-	h.append(outcomeSuccess, 100, now.Add(2*time.Second))
-	_, consec, _ = h.snapshot()
+	h.recordProbeSuccess(100, now.Add(2*time.Second))
+	_, _, consec, _ = h.snapshot(now, time.Hour)
 	assert.Equal(t, uint32(0), consec, "success should reset consecutive failures")
 }
 
-func TestLocalHistory_UserFailuresAreIndependentOfProbeOutcomes(t *testing.T) {
-	// A probe success must not reset the user-failure counter.
-	h := newLocalHistory(defaultHistoryRingMax)
+func TestLocalHistory_FailureDoesNotClearLastSuccessDelay(t *testing.T) {
+	// A member with one transient failure must still have a real delay
+	// measurement to rank by; the failure shows up in consecutive_failures
+	// rather than by erasing the delay.
+	h := newLocalHistory()
 	now := time.Now()
-	h.bumpUserFailures()
-	h.bumpUserFailures()
-	assert.Equal(t, uint32(2), h.userFailureCount(),
-		"user failures should accumulate")
-	h.append(outcomeSuccess, 100, now)
-	assert.Equal(t, uint32(2), h.userFailureCount(),
-		"probe success must NOT reset the user-failure counter")
-	h.resetUserFailures()
-	assert.Equal(t, uint32(0), h.userFailureCount(),
-		"explicit reset (via successful Read) clears the counter")
+	h.recordProbeSuccess(150, now)
+	h.recordProbeFailure(now.Add(time.Second))
+	lastDelay, _, consec, _ := h.snapshot(now, time.Hour)
+	assert.Equal(t, uint32(150), lastDelay, "lastSuccessDelay must survive a subsequent failure")
+	assert.Equal(t, uint32(1), consec, "consecutive failures bump")
 }
 
-func TestHasOutcomeSince(t *testing.T) {
-	cutoff := time.Now()
-	entries := []timestampedOutcome{
-		{outcome: outcomeSuccess, timestamp: cutoff.Add(-time.Minute)},
-	}
-	assert.False(t, hasOutcomeSince(entries, cutoff),
-		"entry before cutoff should not be counted")
-	entries = append(entries, timestampedOutcome{outcome: outcomeSuccess, timestamp: cutoff.Add(time.Millisecond)})
-	assert.True(t, hasOutcomeSince(entries, cutoff),
-		"entry at/after cutoff should be counted")
+func TestLocalHistory_UserFailuresIndependentOfProbeOutcomes(t *testing.T) {
+	// A probe success must not clear user failures: probe and user
+	// destinations live behind different classifiers, and a censor that
+	// lets the probe through while dropping user traffic must not be
+	// laundered to clean by a passing probe.
+	h := newLocalHistory()
+	now := time.Now()
+	h.addUserFailure(now, 5*time.Minute, 0)
+	h.addUserFailure(now.Add(time.Second), 5*time.Minute, 0)
+	assert.Equal(t, uint32(2), h.userFailureCount(now.Add(2*time.Second), 5*time.Minute))
+	h.recordProbeSuccess(100, now.Add(3*time.Second))
+	assert.Equal(t, uint32(2), h.userFailureCount(now.Add(4*time.Second), 5*time.Minute),
+		"probe success must NOT clear the user-failure window")
 }
 
-func TestLastSuccessDelay(t *testing.T) {
-	entries := []timestampedOutcome{
-		{outcome: outcomeSuccess, delayMs: 100},
-		{outcome: outcomeTimeout},
-		{outcome: outcomeSuccess, delayMs: 250},
-		{outcome: outcomeHandshakeFailure},
+func TestLocalHistory_UserFailuresAgeOut(t *testing.T) {
+	// Failures age out of the window naturally — no explicit reset
+	// path. A member that recovers self-clears in one userFailureWindow
+	// regardless of whether traffic gets routed through it.
+	h := newLocalHistory()
+	now := time.Now()
+	h.addUserFailure(now, 5*time.Minute, 0)
+	h.addUserFailure(now.Add(time.Minute), 5*time.Minute, 0)
+	assert.Equal(t, uint32(2), h.userFailureCount(now.Add(time.Minute), 5*time.Minute))
+	// Six minutes later, both are stale.
+	assert.Equal(t, uint32(0), h.userFailureCount(now.Add(6*time.Minute), 5*time.Minute),
+		"failures must age out of the window without an explicit reset")
+}
+
+func TestLocalHistory_AddUserFailureDedupesBurst(t *testing.T) {
+	// A single broken outbound with many orphaned conns hitting their
+	// stall timer in sequence would otherwise inflate the count out of
+	// proportion to the event. The dedupe window collapses bursts to
+	// one failure.
+	h := newLocalHistory()
+	now := time.Now()
+	dedupe := 30 * time.Second
+
+	require.True(t, h.addUserFailure(now, 5*time.Minute, dedupe), "first failure must record")
+	require.False(t, h.addUserFailure(now.Add(time.Second), 5*time.Minute, dedupe), "burst within dedupe must drop")
+	require.False(t, h.addUserFailure(now.Add(29*time.Second), 5*time.Minute, dedupe), "still within dedupe must drop")
+	assert.Equal(t, uint32(1), h.userFailureCount(now.Add(30*time.Second), 5*time.Minute), "burst collapsed to one")
+
+	require.True(t, h.addUserFailure(now.Add(30*time.Second), 5*time.Minute, dedupe), "at-or-past dedupe must record")
+	assert.Equal(t, uint32(2), h.userFailureCount(now.Add(30*time.Second), 5*time.Minute))
+}
+
+func TestHydrateLocalHistory_DropsAgedUserFailures(t *testing.T) {
+	now := time.Now()
+	persisted := &adapter.TagHistory{
+		LastSuccessDelayMs: 120,
+		LastOutcomeAt:      now.Add(-time.Minute),
+		UserFailures: []time.Time{
+			now.Add(-30 * time.Minute), // outside 5-min window
+			now.Add(-1 * time.Minute),  // inside window
+		},
+		UpdatedAt: now.Add(-time.Minute),
 	}
-	assert.Equal(t, uint32(250), lastSuccessDelay(entries))
-	assert.Equal(t, uint32(0), lastSuccessDelay(nil), "empty history returns 0")
+	h := hydrateLocalHistory(persisted, now, 5*time.Minute)
+	lastDelay, _, _, userFails := h.snapshot(now, 5*time.Minute)
+	assert.Equal(t, uint32(120), lastDelay)
+	assert.Len(t, userFails, 1, "stale user-failure timestamp must be dropped on hydrate")
 }
 
 func TestBehaviorFor_Timeouts(t *testing.T) {
@@ -248,15 +282,57 @@ func TestBehaviorFor_PeerNetworkProtocolsAreExcluded(t *testing.T) {
 	}
 }
 
-func TestBehaviorFor_SamizdatGetsSubstituteDelay(t *testing.T) {
-	beh := behaviorFor(lConst.TypeSamizdat)
-	assert.Equal(t, samizdatNominalDelay, beh.substituteDelay)
+func TestRank_SwitchPenaltyOnlyAppliesToRealSeeded(t *testing.T) {
+	// A kindUnknown candidate (no probe yet) must never be boosted —
+	// the boost compares its delay against its peers' best, but its
+	// own delay is 0 (sentinel for "no data"), not a real measurement.
+	// Without the kindRealSeeded gate, the limit would double off a
+	// synthetic 0-vs-real comparison.
+	s, _ := newTestMUR(t, "fast-real", "unknown-mid", "slow-real")
+	recordSuccess(s, "fast-real", 100) // 100ms — fastest, would be boosted
+	recordSuccess(s, "slow-real", 990) // 990ms — the much-slower alternative
+	// "unknown-mid" intentionally has no probe success — kindUnknown.
+
+	// Three user-failures on each — enough to trip the base limit.
+	addUserFailureN(s, "fast-real", int(s.hist.consecutiveFailLimit))
+	addUserFailureN(s, "unknown-mid", int(s.hist.consecutiveFailLimit))
+
+	s.access.Lock()
+	ranked := s.rank(time.Now(), time.Time{})
+	s.access.Unlock()
+
+	var fast, unknown rankedCandidate
+	for _, c := range ranked {
+		switch c.tag {
+		case "fast-real":
+			fast = c
+		case "unknown-mid":
+			unknown = c
+		}
+	}
+	require.NotEmpty(t, fast.tag, "fast-real must appear in rank")
+	require.NotEmpty(t, unknown.tag, "unknown-mid must appear in rank")
+
+	assert.Equal(t, demoteSoft, fast.demote,
+		"fast-real should be rescued from hard-demote (best alt 990ms is >3x its 100ms)")
+	assert.Equal(t, demoteHard, unknown.demote,
+		"unknown-mid must not be rescued — its 0ms self-delay is a sentinel, not a measurement")
 }
 
+// addUserFailureN appends n failures to tag's in-memory history.
+// Passes dedupe=0 so the helper can deterministically seed any count
+// without depending on the dedupe window.
+func addUserFailureN(s *MutableAutoSelect, tag string, n int) {
+	s.access.Lock()
+	defer s.access.Unlock()
+	h := s.historyForLocked(tag)
+	now := time.Now()
+	for i := 0; i < n; i++ {
+		h.addUserFailure(now.Add(time.Duration(i)*time.Millisecond), s.hist.userFailureWindow, 0)
+	}
+}
 
 func TestSelectFor_ThreeTierFallback(t *testing.T) {
-	// Tier ordering: clean > soft > hard. Each row picks the cleanest
-	// non-empty tier; ties within a tier go to lowest delay.
 	tests := []struct {
 		name    string
 		setup   func(s *MutableAutoSelect)
@@ -267,15 +343,15 @@ func TestSelectFor_ThreeTierFallback(t *testing.T) {
 			setup: func(s *MutableAutoSelect) {
 				recordSuccess(s, "a", 100)
 				recordSuccess(s, "b", 200)
-				s.historyForLocked("a").bumpUserFailures()
+				addUserFailureN(s, "a", int(s.hist.softFailLimit))
 			},
 			wantTag: "b",
 		},
 		{
 			name: "soft-only pool returns the soft member",
 			setup: func(s *MutableAutoSelect) {
-				s.historyForLocked("a").bumpUserFailures()
-				s.historyForLocked("b").bumpUserFailures()
+				addUserFailureN(s, "a", int(s.hist.softFailLimit))
+				addUserFailureN(s, "b", int(s.hist.softFailLimit))
 			},
 			wantTag: "a",
 		},
@@ -284,10 +360,8 @@ func TestSelectFor_ThreeTierFallback(t *testing.T) {
 			setup: func(s *MutableAutoSelect) {
 				recordSuccess(s, "a", 100)
 				recordSuccess(s, "b", 200)
-				for i := 0; i < int(s.hist.consecutiveFailLimit); i++ {
-					s.historyForLocked("a").bumpUserFailures()
-					s.historyForLocked("b").bumpUserFailures()
-				}
+				addUserFailureN(s, "a", int(s.hist.consecutiveFailLimit))
+				addUserFailureN(s, "b", int(s.hist.consecutiveFailLimit))
 			},
 			wantTag: "a",
 		},
@@ -295,9 +369,7 @@ func TestSelectFor_ThreeTierFallback(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s, _ := newTestMUR(t, "a", "b")
-			s.access.Lock()
 			tt.setup(s)
-			s.access.Unlock()
 			got, err := s.selectFor("tcp")
 			require.NoError(t, err)
 			require.NotNil(t, got)
@@ -307,13 +379,12 @@ func TestSelectFor_ThreeTierFallback(t *testing.T) {
 }
 
 func TestSelectFor_SwitchTolerance(t *testing.T) {
-	// switchTolerance is 50ms (test default).
 	tests := []struct {
-		name           string
-		alphaDelay     uint32
-		betaDelay      uint32
-		want           string
-		commentary     string
+		name       string
+		alphaDelay uint32
+		betaDelay  uint32
+		want       string
+		commentary string
 	}{
 		{"sticky kept within tolerance", 100, 80, "alpha", "80+50 > 100 → keep alpha"},
 		{"switches when beats tolerance", 100, 40, "beta", "40+50 <= 100 → switch"},
@@ -333,17 +404,9 @@ func TestSelectFor_SwitchTolerance(t *testing.T) {
 }
 
 func TestSelectFor_ForcedSwitchWhenStickyNotInPool(t *testing.T) {
-	// alpha is sticky but has no fresh success and gets pushed into the
-	// hard tier; beta is clean. The hard-tier alpha is filtered out of
-	// the clean pool, so the forced-switch branch fires.
 	s, _ := newTestMUR(t, "alpha", "beta")
 	recordSuccess(s, "beta", 120)
-	// Push alpha to hard-demote: enough user failures to cross the limit.
-	for i := 0; i < int(s.hist.consecutiveFailLimit); i++ {
-		s.access.Lock()
-		s.historyForLocked("alpha").bumpUserFailures()
-		s.access.Unlock()
-	}
+	addUserFailureN(s, "alpha", int(s.hist.consecutiveFailLimit))
 	s.stickyTag.tcp.Store("alpha")
 
 	got, err := s.selectFor("tcp")
@@ -358,18 +421,38 @@ func TestSelectFor_RecordsStickyAfterPick(t *testing.T) {
 	recordSuccess(s, "a", 50)
 	_, err := s.selectFor("tcp")
 	require.NoError(t, err)
+	assert.Equal(t, "a", loadString(&s.stickyTag.tcp))
+}
+
+func TestSelectForExcluding_SkipsTargetAndDoesNotMutateSticky(t *testing.T) {
+	s, _ := newTestMUR(t, "a", "b")
+	recordSuccess(s, "a", 30)
+	recordSuccess(s, "b", 50)
+	s.stickyTag.tcp.Store("a")
+
+	got, err := s.selectForExcluding("tcp", "a")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "b", got.Tag(), "fast-failover must skip the excluded tag")
 	assert.Equal(t, "a", loadString(&s.stickyTag.tcp),
-		"selectFor should record the picked tag as sticky for future calls")
+		"a fast-failover pick must not poison the sticky tag")
+}
+
+func TestSelectForExcluding_NoAlternateReturnsError(t *testing.T) {
+	s, _ := newTestMUR(t, "a")
+	recordSuccess(s, "a", 50)
+	got, err := s.selectForExcluding("tcp", "a")
+	assert.Error(t, err)
+	assert.Nil(t, got)
 }
 
 func TestPeekHistoryLocked_DoesNotCreateEntry(t *testing.T) {
 	s, _ := newTestMUR(t, "a")
 	_, ok := s.peekHistoryLocked("a")
-	assert.False(t, ok, "peek must not create a history entry")
+	assert.False(t, ok)
 	_, present := s.histories["a"]
 	assert.False(t, present, "peek leaked an empty history entry into the map")
 }
-
 
 func TestRemove_PreservesTagOrder(t *testing.T) {
 	s, _ := newTestMUR(t, "a", "b", "c", "d")
@@ -380,20 +463,17 @@ func TestRemove_PreservesTagOrder(t *testing.T) {
 }
 
 func TestAdd_DoesNotDuplicateAlreadyListedTag(t *testing.T) {
-	// When s.tags lists a tag but s.members is missing it, Add must
-	// repopulate members without appending a duplicate to s.tags.
 	s, _ := newTestMUR(t, "a")
 	mgr := &mockOutboundManager{outbounds: map[string]sbAdapter.Outbound{
 		"a": &mockOutbound{tag: "a"},
 	}}
 	s.outboundMgr = mgr
-	s.members.Delete("a") // drop members but leave tags intact
+	s.members.Delete("a")
 	n, err := s.Add("a")
 	require.NoError(t, err)
 	require.Equal(t, 1, n)
-	assert.Equal(t, []string{"a"}, s.All(), "Add must not duplicate the already-listed tag")
+	assert.Equal(t, []string{"a"}, s.All())
 }
-
 
 func TestSetURLOverrides_RemovingOverrideInvalidatesHistory(t *testing.T) {
 	s, _ := newTestMUR(t, "a", "b")
@@ -401,7 +481,7 @@ func TestSetURLOverrides_RemovingOverrideInvalidatesHistory(t *testing.T) {
 	recordSuccess(s, "a", 100)
 	recordSuccess(s, "b", 200)
 
-	s.SetURLOverrides(map[string]string{}) // no overrides at all
+	s.SetURLOverrides(map[string]string{})
 
 	_, aPresent := s.histories["a"]
 	assert.False(t, aPresent, "history for 'a' should be cleared when its override is removed")
@@ -409,15 +489,15 @@ func TestSetURLOverrides_RemovingOverrideInvalidatesHistory(t *testing.T) {
 	assert.True(t, bPresent, "history for 'b' should be preserved (no override change)")
 }
 
-
-func TestRankCandidates_ExcludesEntriesBeforeCycleStart(t *testing.T) {
+func TestRank_ExcludesEntriesBeforeCycleStart(t *testing.T) {
 	s, _ := newTestMUR(t, "a")
 	recordSuccess(s, "a", 100)
-	cycleStart := time.Now().Add(time.Second) // strictly after the entry
+	cycleStart := time.Now().Add(time.Second)
+	s.access.Lock()
 	ranked := s.rank(time.Now().Add(2*time.Second), cycleStart)
+	s.access.Unlock()
 	assert.Empty(t, ranked, "entries before cycleStart must not appear in the ranked set")
 }
-
 
 type stallConn struct{ net.Conn }
 
@@ -430,33 +510,78 @@ func (stallConn) SetDeadline(time.Time) error      { return nil }
 func (stallConn) SetReadDeadline(time.Time) error  { return nil }
 func (stallConn) SetWriteDeadline(time.Time) error { return nil }
 
-func TestDataPlaneStream_StallFiresOnce(t *testing.T) {
+func TestDataPlaneStream_StallSuppressedUntilProven(t *testing.T) {
+	// A handshake-only conn that never delivers payload is "established
+	// but inactive" — the stall timer fires but onStall is suppressed
+	// because provedReadBytes hasn't been crossed.
 	var calls atomic.Uint32
-	d := newDataPlaneStream(stallConn{}, 10*time.Millisecond, func() { calls.Add(1) }, nil, nil)
+	const provedReadBytes = 100
+	d := newDataPlaneStream(stallConn{}, 10*time.Millisecond, provedReadBytes,
+		func() { calls.Add(1) }, nil)
 	defer d.Close()
-	// Wait past the idle window with margin for scheduler jitter.
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, uint32(0), calls.Load(),
+		"unproven conn going idle is not a stall")
+}
+
+func TestDataPlaneStream_StallFiresAfterProven(t *testing.T) {
+	// Once cumulative Read bytes cross provedReadBytes AND the most recent
+	// IO was a Write that hasn't been answered, the next idle window
+	// fires onStall exactly once.
+	var calls atomic.Uint32
+	const provedReadBytes = 50
+	d := newDataPlaneStream(echoConn{}, 30*time.Millisecond, provedReadBytes,
+		func() { calls.Add(1) }, nil)
+	defer d.Close()
+	// Drive enough Read bytes to prove the conn.
+	if _, err := d.Read(make([]byte, provedReadBytes)); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	require.True(t, d.proven.Load(), "Read should have proven the conn")
+	// Drive a Write so the watchdog sees "we sent bytes, no response."
+	if _, err := d.Write([]byte("ping")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	require.True(t, d.lastWasWrite.Load(), "Write should set the last-was-write gate")
+	// Wait past the idle window.
 	require.Eventually(t, func() bool { return calls.Load() == 1 },
-		time.Second, 5*time.Millisecond, "stall should have fired by now")
-	// Manually invoking fireStall a second time must be a no-op thanks
-	// to the stalled CAS guard.
+		time.Second, 5*time.Millisecond, "proven stall should have fired by now")
+
 	d.fireStall()
-	assert.Equal(t, uint32(1), calls.Load(), "stalled CAS should suppress duplicate fires")
+	assert.Equal(t, uint32(1), calls.Load(), "fired CAS should suppress duplicate fires")
+}
+
+func TestDataPlaneStream_StallSuppressedOnReadOnlyIdle(t *testing.T) {
+	// A proven conn whose last IO was a Read is user-idle, not broken:
+	// the response arrived and the user stopped sending. Suppress the
+	// stall to avoid demoting a healthy outbound on a quiet HTTPS
+	// keep-alive.
+	var calls atomic.Uint32
+	const provedReadBytes = 50
+	d := newDataPlaneStream(echoConn{}, 30*time.Millisecond, provedReadBytes,
+		func() { calls.Add(1) }, nil)
+	defer d.Close()
+	if _, err := d.Read(make([]byte, provedReadBytes)); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	require.True(t, d.proven.Load(), "Read should have proven the conn")
+	require.False(t, d.lastWasWrite.Load(), "Read-only conn must not set the last-was-write gate")
+	time.Sleep(80 * time.Millisecond)
+	assert.Equal(t, uint32(0), calls.Load(),
+		"proven conn with read-only history must not fire stall")
 }
 
 func TestDataPlaneStream_CloseIsIdempotent(t *testing.T) {
-	d := newDataPlaneStream(stallConn{}, time.Hour, func() {}, nil, nil)
+	d := newDataPlaneStream(stallConn{}, time.Hour, 0, func() {}, nil)
 	require.NoError(t, d.Close())
 	assert.NoError(t, d.Close(), "second Close should be a no-op")
 }
 
 func TestDataPlaneStream_NoStallAfterClose(t *testing.T) {
-	// Regression: Close sets stalled=true before stopping the timer, so a
-	// racing Read/Write that fires the timer one more time after Close
-	// (via a Reset that lost the race with Stop) lands on a no-op
-	// fireStall. This test exercises the CAS guard directly: any fireStall
-	// after Close must be suppressed.
 	var calls atomic.Uint32
-	d := newDataPlaneStream(stallConn{}, time.Hour, func() { calls.Add(1) }, nil, nil)
+	d := newDataPlaneStream(stallConn{}, time.Hour, 0, func() { calls.Add(1) }, nil)
+	d.proven.Store(true)      // simulate a proven conn so fireStall isn't gated on the proven check
+	d.lastWasWrite.Store(true) // ...nor on the write-without-read gate
 	d.Close()
 	d.fireStall()
 	assert.Equal(t, uint32(0), calls.Load(), "no stall callbacks must fire after Close")
@@ -464,7 +589,9 @@ func TestDataPlaneStream_NoStallAfterClose(t *testing.T) {
 
 func TestDataPlanePacket_NoStallAfterClose(t *testing.T) {
 	var calls atomic.Uint32
-	d := newDataPlanePacket(stallPacketConn{}, time.Hour, func() { calls.Add(1) }, nil, nil)
+	d := newDataPlanePacket(stallPacketConn{}, time.Hour, 0, func() { calls.Add(1) }, nil)
+	d.proven.Store(true)
+	d.lastWasWrite.Store(true)
 	d.Close()
 	d.fireStall()
 	assert.Equal(t, uint32(0), calls.Load(), "no stall callbacks must fire after Close")
@@ -482,10 +609,9 @@ func (stallPacketConn) SetDeadline(time.Time) error               { return nil }
 func (stallPacketConn) SetReadDeadline(time.Time) error           { return nil }
 func (stallPacketConn) SetWriteDeadline(time.Time) error          { return nil }
 
-
 func TestRunLadder_DoesNotEmitExhaustionWhenClosed(t *testing.T) {
 	s, _ := newTestMUR(t, "a")
-	s.cancel() // mark closed before any ladder runs.
+	s.cancel()
 	s.runLadder("")
 	select {
 	case <-s.ExhaustionSignal():
@@ -494,153 +620,170 @@ func TestRunLadder_DoesNotEmitExhaustionWhenClosed(t *testing.T) {
 	}
 }
 
-
-func TestRecordOutcome_Persists(t *testing.T) {
+func TestRecordProbeOutcome_Persists(t *testing.T) {
 	tests := []struct {
-		name           string
-		outcome        localOutcome
-		delayMs        uint32
-		wantOutcome    adapter.Outcome
-		wantDelayMs    uint32
-		wantConsecFail uint32
+		name         string
+		success      bool
+		delayMs      uint32
+		wantDelayMs  uint32
+		wantConsec   uint32
 	}{
-		{"success", outcomeSuccess, 123, adapter.OutcomeSuccess, 123, 0},
-		{"failure also persisted, consec increments", outcomeTimeout, 0, adapter.OutcomeTimeout, 0, 1},
+		{"success records delay and zeroes consecutive", true, 123, 123, 0},
+		{"failure increments consecutive, preserves delay", false, 0, 0, 1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s, _ := newTestMUR(t, "a")
-			s.recordOutcome("a", tt.outcome, tt.delayMs)
+			s.recordProbeOutcome("a", tt.success, tt.delayMs)
 			got := s.history.Load("a")
 			require.NotNil(t, got)
-			require.Len(t, got.Outcomes, 1)
-			assert.Equal(t, tt.wantOutcome, got.Outcomes[0].Outcome)
-			assert.Equal(t, tt.wantDelayMs, got.Outcomes[0].DelayMs)
-			assert.Equal(t, tt.wantConsecFail, got.ConsecutiveFailures)
+			assert.Equal(t, tt.wantDelayMs, got.LastSuccessDelayMs)
+			assert.Equal(t, tt.wantConsec, got.ConsecutiveFailures)
 		})
 	}
 }
 
 func TestAutoSelectHistoryStorage_StoreAfterCloseDoesNotPanic(t *testing.T) {
-	// In-flight probe/dataplane callbacks can outlive the storage on
-	// tunnel shutdown. Late Store must drop quietly rather than panic
-	// on a nil internal map.
 	store := adapter.NewAutoSelectHistoryStorage()
 	require.NoError(t, store.Close())
 	assert.NotPanics(t, func() {
 		store.Store("a", &adapter.TagHistory{UpdatedAt: time.Now()})
 		store.Delete("a")
-	}, "Store/Delete after Close must be safe no-ops")
-	assert.Nil(t, store.Load("a"), "post-Close Store must not resurrect data")
+	})
+	assert.Nil(t, store.Load("a"))
 }
 
-func TestRecordOutcome_DropsOutcomesForRemovedTag(t *testing.T) {
-	// Regression: a probe goroutine that started before Remove must not
-	// resurrect the in-memory history entry or restore a deleted entry
-	// in the persistence store.
+func TestRecordProbeOutcome_DropsOutcomesForRemovedTag(t *testing.T) {
+	// A probe goroutine that started before Remove must not resurrect
+	// the in-memory history entry or restore a deleted entry in the
+	// persistence store.
 	s, _ := newTestMUR(t, "a")
 	mgr := &mockOutboundManager{outbounds: map[string]sbAdapter.Outbound{
 		"a": &mockOutbound{tag: "a"},
 	}}
 	s.outboundMgr = mgr
 
-	// Pre-populate the persistence store, then Remove (which should clear it).
-	s.recordOutcome("a", outcomeSuccess, 100)
-	require.NotNil(t, s.history.Load("a"),
-		"setup: expected persisted entry after success")
+	s.recordProbeOutcome("a", true, 100)
+	require.NotNil(t, s.history.Load("a"))
 	_, err := s.Remove("a")
 	require.NoError(t, err)
-	require.Nil(t, s.history.Load("a"),
-		"Remove must clear the persisted entry")
+	require.Nil(t, s.history.Load("a"))
 
-	// A late probe outcome must not re-create either layer.
-	s.recordOutcome("a", outcomeSuccess, 200)
+	s.recordProbeOutcome("a", true, 200)
 	s.access.Lock()
 	_, exists := s.peekHistoryLocked("a")
 	s.access.Unlock()
-	assert.False(t, exists, "recordOutcome must not resurrect history for a non-member tag")
-	assert.Nil(t, s.history.Load("a"),
-		"recordOutcome must not resurrect the persisted entry")
+	assert.False(t, exists, "recordProbeOutcome must not resurrect history for a non-member tag")
+	assert.Nil(t, s.history.Load("a"))
 }
 
-
-func TestRecordUserFailure_BumpsCounterAndIsBoundedByMembership(t *testing.T) {
+func TestRecordUserFailure_AppendsAndBoundedByMembership(t *testing.T) {
 	s, _ := newTestMUR(t, "a")
-	s.recordUserFailure("a")
-	s.recordUserFailure("a")
+	assert.True(t, s.recordUserFailure("a"), "first call must persist")
+	assert.False(t, s.recordUserFailure("a"), "immediate burst must return false (deduped)")
 	s.access.Lock()
 	h, ok := s.peekHistoryLocked("a")
 	s.access.Unlock()
 	require.True(t, ok)
-	assert.Equal(t, uint32(2), h.userFailureCount())
+	assert.Equal(t, uint32(1), h.userFailureCount(time.Now(), s.hist.userFailureWindow),
+		"successive calls within dedupe window must collapse")
 
-	// A user-failure call for a non-member tag must not resurrect history.
-	s.recordUserFailure("nonexistent")
+	assert.False(t, s.recordUserFailure("nonexistent"), "non-member must return false")
 	s.access.Lock()
 	_, exists := s.peekHistoryLocked("nonexistent")
 	s.access.Unlock()
-	assert.False(t, exists, "recordUserFailure must not create history for a non-member tag")
+	assert.False(t, exists)
 }
 
-func TestDataPlaneStream_UserFailureResetOnReadOnly(t *testing.T) {
-	// Only Read should reset: a Write through a half-broken tunnel may
-	// succeed locally (buffered) while remote receipt fails, so writes
-	// must not count as bidirectional proof.
-	tests := []struct {
-		name      string
-		op        func(d *dataPlaneStream) error
-		wantCount uint32
-	}{
-		{
-			name: "Read resets",
-			op: func(d *dataPlaneStream) error {
-				_, err := d.Read(make([]byte, 8))
-				return err
-			},
-			wantCount: 0,
-		},
-		{
-			name: "Write does not reset",
-			op: func(d *dataPlaneStream) error {
-				_, err := d.Write([]byte("hi"))
-				return err
-			},
-			wantCount: 1,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			h := newLocalHistory(defaultHistoryRingMax)
-			h.bumpUserFailures()
-			d := newDataPlaneStream(echoConn{}, time.Hour, func() {}, nil, func() { h.resetUserFailures() })
-			defer d.Close()
-			require.NoError(t, tt.op(d))
-			assert.Equal(t, tt.wantCount, h.userFailureCount())
-		})
-	}
+func TestMakeHooks_StallAppendsSingleUserFailure(t *testing.T) {
+	// A stall counts as one failure — same weight as a single dial
+	// error. The demote rule hits hard at three failures in window, not
+	// one. (Spec change from earlier "one-shot hard demote.")
+	s, _ := newTestMUR(t, "a")
+	onStall, _ := s.makeHooks("a")
+	onStall()
+	s.access.Lock()
+	h, ok := s.peekHistoryLocked("a")
+	s.access.Unlock()
+	require.True(t, ok)
+	assert.Equal(t, uint32(1), h.userFailureCount(time.Now(), s.hist.userFailureWindow),
+		"a single stall must contribute exactly one user-failure timestamp")
 }
 
-func TestDemoted_UserFailuresTriggerEvenWithCleanProbes(t *testing.T) {
-	// The whole point of the anti-laundering fix: a server can be
-	// demoted by user-traffic failures alone, even if every probe
-	// outcome in the ring is a success.
-	now := time.Now()
-	p := defaultHistoryParams()
-	hist := []timestampedOutcome{
-		{outcome: outcomeSuccess, timestamp: now.Add(-1 * time.Minute), delayMs: 100},
-		{outcome: outcomeSuccess, timestamp: now.Add(-2 * time.Minute), delayMs: 110},
-		{outcome: outcomeSuccess, timestamp: now.Add(-3 * time.Minute), delayMs: 120},
-	}
-	assert.False(t, demoted(hist, 0, 0, now, p),
-		"healthy probe ring + no user failures: not demoted")
-	assert.True(t, demoted(hist, 0, p.consecutiveFailLimit, now, p),
-		"healthy probe ring but user-failure limit reached: demoted")
+func TestRecordUserFailure_DemotesTagInNextSelectFor(t *testing.T) {
+	s, _ := newTestMUR(t, "a", "b")
+	recordSuccess(s, "a", 50)
+	recordSuccess(s, "b", 100)
+	s.stickyTag.tcp.Store("a")
+
+	// addUserFailureN bypasses the dedupe window, so the soft-limit
+	// failures land deterministically without depending on wall time.
+	addUserFailureN(s, "a", int(s.hist.softFailLimit))
+
+	got, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "b", got.Tag(),
+		"soft-demoted a must lose to clean b on the next selectFor")
 }
 
+func TestSplitHealthyFor_PrefersCleanOverSoftOverHard(t *testing.T) {
+	ob := &mockOutbound{networks: []string{"tcp", "udp"}}
+	ranked := []rankedCandidate{
+		{outbound: ob, tag: "hard", demote: demoteHard, delayMs: 10},
+		{outbound: ob, tag: "soft", demote: demoteSoft, delayMs: 50},
+		{outbound: ob, tag: "clean", demote: demoteClean, delayMs: 100},
+	}
+	pool := splitHealthyFor(ranked, "tcp")
+	require.Len(t, pool, 1)
+	assert.Equal(t, "clean", pool[0].tag)
+
+	pool = splitHealthyFor(ranked[:2], "tcp")
+	require.Len(t, pool, 1)
+	assert.Equal(t, "soft", pool[0].tag)
+
+	pool = splitHealthyFor(ranked[:1], "tcp")
+	assert.Equal(t, 1, len(pool))
+}
+
+func TestSplitHealthyFor_KeepsSoftWhenCleanIsOtherNetwork(t *testing.T) {
+	tcpOnly := &mockOutbound{tag: "tcp-only", networks: []string{"tcp"}}
+	bothSoft := &mockOutbound{tag: "both-soft", networks: []string{"tcp", "udp"}}
+	ranked := []rankedCandidate{
+		{outbound: tcpOnly, tag: "tcp-only", demote: demoteClean, delayMs: 10},
+		{outbound: bothSoft, tag: "both-soft", demote: demoteSoft, delayMs: 50},
+	}
+	tcpPool := splitHealthyFor(ranked, "tcp")
+	require.Len(t, tcpPool, 1, "tcp pool should be clean-only")
+	assert.Equal(t, "tcp-only", tcpPool[0].tag)
+
+	udpPool := splitHealthyFor(ranked, "udp")
+	require.Len(t, udpPool, 1, "udp pool should fall through to soft when no clean udp candidate exists")
+	assert.Equal(t, "both-soft", udpPool[0].tag)
+}
+
+func TestSelectFor_PerNetworkPool(t *testing.T) {
+	s, _ := newTestMUR(t, "tcp-only", "both-soft")
+	tcpOnly := &mockOutbound{tag: "tcp-only", networks: []string{"tcp"}}
+	bothSoft := &mockOutbound{tag: "both-soft", networks: []string{"tcp", "udp"}}
+	s.members.Store("tcp-only", sbAdapter.Outbound(tcpOnly))
+	s.members.Store("both-soft", sbAdapter.Outbound(bothSoft))
+	recordSuccess(s, "tcp-only", 10)
+	recordSuccess(s, "both-soft", 50)
+	addUserFailureN(s, "both-soft", int(s.hist.softFailLimit))
+
+	tcp, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	require.NotNil(t, tcp)
+	assert.Equal(t, "tcp-only", tcp.Tag())
+
+	udp, err := s.selectFor("udp")
+	require.NoError(t, err)
+	require.NotNil(t, udp)
+	assert.Equal(t, "both-soft", udp.Tag())
+}
 
 func TestSelectFor_PreservesStickyAfterUnrelatedRemove(t *testing.T) {
-	// A Remove that doesn't touch the sticky tag must not flip
-	// selection.
 	s, _ := newTestMUR(t, "a", "b", "c")
 	recordSuccess(s, "a", 200)
 	recordSuccess(s, "b", 150)
@@ -652,8 +795,7 @@ func TestSelectFor_PreservesStickyAfterUnrelatedRemove(t *testing.T) {
 	got, err := s.selectFor("tcp")
 	require.NoError(t, err)
 	require.NotNil(t, got)
-	assert.Equal(t, "c", got.Tag(),
-		"selection should survive Remove of a non-sticky tag")
+	assert.Equal(t, "c", got.Tag())
 }
 
 func TestSelectFor_RepicksWhenStickyGone(t *testing.T) {
@@ -668,30 +810,22 @@ func TestSelectFor_RepicksWhenStickyGone(t *testing.T) {
 	got, err := s.selectFor("tcp")
 	require.NoError(t, err)
 	require.NotNil(t, got)
-	assert.Contains(t, []string{"a", "c"}, got.Tag(),
-		"selection should be re-picked from remaining members")
-	assert.NotEqual(t, "b", loadString(&s.stickyTag.tcp),
-		"stickyTag should not still reference the removed member")
+	assert.Contains(t, []string{"a", "c"}, got.Tag())
+	assert.NotEqual(t, "b", loadString(&s.stickyTag.tcp))
 }
 
 func TestSelectFor_PrefersLowestSeededDelay(t *testing.T) {
-	// The cold-start initial pick should consult the
-	// AutoSelectHistoryStorage seed via hydrate-on-Add so the offline
-	// pre-warm informs the first selection — not just "first viable by
-	// tag order."
 	seed := func(delay uint32) *adapter.TagHistory {
 		return &adapter.TagHistory{
-			Outcomes: []adapter.TimestampedOutcome{{
-				Outcome: adapter.OutcomeSuccess, DelayMs: delay, Timestamp: time.Now(),
-			}},
-			UpdatedAt: time.Now(),
+			LastSuccessDelayMs: delay,
+			LastOutcomeAt:      time.Now(),
+			UpdatedAt:          time.Now(),
 		}
 	}
 	s, obs := newTestMUR(t, "a", "b", "c")
 	s.history.Store("a", seed(500))
 	s.history.Store("b", seed(300))
 	s.history.Store("c", seed(100))
-	// Hydrate in-memory history from storage (mimicking Start/Add).
 	s.access.Lock()
 	for _, tag := range s.tags {
 		s.hydrateHistoryLocked(tag)
@@ -701,7 +835,7 @@ func TestSelectFor_PrefersLowestSeededDelay(t *testing.T) {
 	got, err := s.selectFor("tcp")
 	require.NoError(t, err)
 	require.NotNil(t, got)
-	assert.Equal(t, "c", got.Tag(), "lowest seeded delay should win the cold-start pick")
+	assert.Equal(t, "c", got.Tag())
 	assert.Same(t, sbAdapter.Outbound(obs["c"]), got)
 }
 
@@ -710,30 +844,28 @@ func TestSelectFor_FallsBackToTagOrderWithoutSeed(t *testing.T) {
 	got, err := s.selectFor("tcp")
 	require.NoError(t, err)
 	require.NotNil(t, got)
-	assert.Equal(t, "a", got.Tag(),
-		"without seed data, the first viable tag should win the cold start (stable sort)")
+	assert.Equal(t, "a", got.Tag())
 }
 
-func TestSelectFor_UnknownBeatsSubstitutedSeed(t *testing.T) {
-	// The unified rank treats a kindUnknown candidate as strictly
-	// better than a kindSubstituted one — probing the unknown is
-	// preferable to committing to a deliberately deprioritized peer.
-	s, obs := newTestMUR(t, "sami", "hysteria2-new")
-	obs["sami"].typeName = lConst.TypeSamizdat
-	s.history.Store("sami", &adapter.TagHistory{
-		Outcomes: []adapter.TimestampedOutcome{{
-			Outcome: adapter.OutcomeSuccess, DelayMs: 120, Timestamp: time.Now(),
-		}},
-		UpdatedAt: time.Now(),
-	})
-	// hysteria2-new has neither in-memory history nor a persisted seed.
-	got, err := s.selectFor("tcp")
-	require.NoError(t, err)
-	require.NotNil(t, got)
-	assert.Equal(t, "hysteria2-new", got.Tag(),
-		"unknown candidate must beat a substituted-delay seed")
+func TestHydrate_DropsStaleSnapshot(t *testing.T) {
+	// Persisted snapshots older than maxPersistedAge are dropped on
+	// hydrate — a bandit-driven candidate set typically rotates every
+	// 60 s – 15 min, so an hour-old entry usually describes a member
+	// that no longer exists.
+	s, _ := newTestMUR(t, "a")
+	stale := &adapter.TagHistory{
+		LastSuccessDelayMs: 100,
+		UpdatedAt:          time.Now().Add(-2 * defaultMaxPersistedAge),
+	}
+	s.history.Store("a", stale)
+	s.access.Lock()
+	delete(s.histories, "a")
+	s.hydrateHistoryLocked("a")
+	_, ok := s.histories["a"]
+	s.access.Unlock()
+	assert.False(t, ok, "stale snapshot must not hydrate")
+	assert.Nil(t, s.history.Load("a"), "stale snapshot must be deleted on hydrate too")
 }
-
 
 func TestNextProbeInterval(t *testing.T) {
 	tests := []struct {
@@ -770,7 +902,7 @@ func TestNextProbeInterval(t *testing.T) {
 
 func TestDataPlaneStream_OnActivityFiresOnNonEmptyIO(t *testing.T) {
 	var activity atomic.Uint32
-	d := newDataPlaneStream(echoConn{}, time.Hour, func() {}, func() { activity.Add(1) }, nil)
+	d := newDataPlaneStream(echoConn{}, time.Hour, 0, func() {}, func() { activity.Add(1) })
 	defer d.Close()
 	if _, err := d.Write([]byte("hi")); err != nil {
 		t.Fatalf("Write: %v", err)
@@ -783,8 +915,6 @@ func TestDataPlaneStream_OnActivityFiresOnNonEmptyIO(t *testing.T) {
 		"onActivity should fire once per non-empty Read/Write")
 }
 
-// echoConn returns n>0 on both Read and Write so the activity-tracking
-// tests have a way to drive both call paths without setting up real I/O.
 type echoConn struct{ net.Conn }
 
 func (echoConn) Read(p []byte) (int, error)       { return len(p), nil }
@@ -798,193 +928,10 @@ func (echoConn) SetWriteDeadline(time.Time) error { return nil }
 
 func TestSetURLOverrides_ClearsPersistedEntryOnChange(t *testing.T) {
 	s, _ := newTestMUR(t, "a")
-	s.recordOutcome("a", outcomeSuccess, 100)
-	require.NotNil(t, s.history.Load("a"), "setup: expected persisted entry")
+	s.recordProbeOutcome("a", true, 100)
+	require.NotNil(t, s.history.Load("a"))
 	s.SetURLOverrides(map[string]string{"a": "https://override.example/a"})
-	assert.Nil(t, s.history.Load("a"),
-		"override change must clear the persisted entry")
-}
-
-
-func TestRecordUserFailure_DemotesTagInNextSelectFor(t *testing.T) {
-	// After recordUserFailure("a"), "a" is in the soft tier and the
-	// next selectFor("tcp") picks a clean peer instead — replaces the
-	// old "synchronous clear of cached selection" contract.
-	s, _ := newTestMUR(t, "a", "b")
-	recordSuccess(s, "a", 50)
-	recordSuccess(s, "b", 100)
-	s.stickyTag.tcp.Store("a")
-
-	s.recordUserFailure("a")
-
-	got, err := s.selectFor("tcp")
-	require.NoError(t, err)
-	require.NotNil(t, got)
-	assert.Equal(t, "b", got.Tag(),
-		"soft-demoted a must lose to clean b on the next selectFor")
-}
-
-
-func TestSplitHealthyFor_PrefersCleanOverSoftOverHard(t *testing.T) {
-	ob := &mockOutbound{networks: []string{"tcp", "udp"}}
-	ranked := []rankedCandidate{
-		{outbound: ob, tag: "hard", demote: demoteHard, delayMs: 10},
-		{outbound: ob, tag: "soft", demote: demoteSoft, delayMs: 50},
-		{outbound: ob, tag: "clean", demote: demoteClean, delayMs: 100},
-	}
-	pool := splitHealthyFor(ranked, "tcp")
-	require.Len(t, pool, 1)
-	assert.Equal(t, "clean", pool[0].tag, "clean dominates soft/hard regardless of delay")
-
-	pool = splitHealthyFor(ranked[:2], "tcp")
-	require.Len(t, pool, 1)
-	assert.Equal(t, "soft", pool[0].tag, "soft preferred over hard when no clean exists")
-
-	pool = splitHealthyFor(ranked[:1], "tcp")
-	assert.Equal(t, 1, len(pool), "hard-only returns the hard slice as last resort")
-}
-
-
-func TestRunLadder_SkipStep1(t *testing.T) {
-	// Step 1 is skipped when the target has any user-failure evidence
-	// (one is enough — well under the demote limit). Without that, the
-	// ladder dials twice: step 1 fast retry plus step 2 re-probe.
-	tests := []struct {
-		name      string
-		userFails int
-		wantDials int
-	}{
-		{"no user failure: step 1 + step 2", 0, 2},
-		{"one user failure: only step 2", 1, 1},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s, obs := newTestMUR(t, "a")
-			s.defaultURL = "http://probe.test/"
-			obs["a"].On("DialContext").Return(nil, errors.New("dial denied"))
-			for i := 0; i < tt.userFails; i++ {
-				s.access.Lock()
-				s.historyForLocked("a").bumpUserFailures()
-				s.access.Unlock()
-			}
-			s.runLadder("a")
-			obs["a"].AssertNumberOfCalls(t, "DialContext", tt.wantDials)
-		})
-	}
-}
-
-
-func TestSplitHealthyFor_KeepsSoftWhenCleanIsOtherNetwork(t *testing.T) {
-	// The clean candidate is TCP-only; the only UDP-capable member is
-	// soft. Per-network split must return the soft UDP member rather
-	// than nil; the same pool can't be reused across networks.
-	tcpOnly := &mockOutbound{tag: "tcp-only", networks: []string{"tcp"}}
-	bothSoft := &mockOutbound{tag: "both-soft", networks: []string{"tcp", "udp"}}
-	ranked := []rankedCandidate{
-		{outbound: tcpOnly, tag: "tcp-only", demote: demoteClean, delayMs: 10},
-		{outbound: bothSoft, tag: "both-soft", demote: demoteSoft, delayMs: 50},
-	}
-	tcpPool := splitHealthyFor(ranked, "tcp")
-	require.Len(t, tcpPool, 1, "tcp pool should be clean-only")
-	assert.Equal(t, "tcp-only", tcpPool[0].tag)
-
-	udpPool := splitHealthyFor(ranked, "udp")
-	require.Len(t, udpPool, 1, "udp pool should fall through to soft when no clean udp candidate exists")
-	assert.Equal(t, "both-soft", udpPool[0].tag)
-}
-
-func TestSelectFor_PerNetworkPool(t *testing.T) {
-	// Probe-cycle scenario: tcp-only is clean, both-soft is the only
-	// UDP-capable member. Per-network pool selection means TCP gets
-	// the clean tcp-only and UDP falls through to the soft both-soft.
-	s, _ := newTestMUR(t, "tcp-only", "both-soft")
-	tcpOnly := &mockOutbound{tag: "tcp-only", networks: []string{"tcp"}}
-	bothSoft := &mockOutbound{tag: "both-soft", networks: []string{"tcp", "udp"}}
-	s.members.Store("tcp-only", sbAdapter.Outbound(tcpOnly))
-	s.members.Store("both-soft", sbAdapter.Outbound(bothSoft))
-	recordSuccess(s, "tcp-only", 10)
-	recordSuccess(s, "both-soft", 50)
-	// Mark both-soft as soft-demoted.
-	s.access.Lock()
-	s.historyForLocked("both-soft").bumpUserFailures()
-	s.access.Unlock()
-
-	tcp, err := s.selectFor("tcp")
-	require.NoError(t, err)
-	require.NotNil(t, tcp)
-	assert.Equal(t, "tcp-only", tcp.Tag(),
-		"tcp must select the clean tcp-only member")
-
-	udp, err := s.selectFor("udp")
-	require.NoError(t, err)
-	require.NotNil(t, udp)
-	assert.Equal(t, "both-soft", udp.Tag(),
-		"udp must fall through to the soft both-soft member when no clean udp candidate exists")
-}
-
-
-func TestSelectFor_PrefersRealSeededOverSubstituted(t *testing.T) {
-	// Both "sami" (substituted via samizdat protocol) and "real" are
-	// clean. s.tags order puts sami first, but selectFor should pick
-	// real because real-seeded < substituted in kindOrder.
-	s, obs := newTestMUR(t, "sami", "real")
-	obs["sami"].typeName = lConst.TypeSamizdat
-	recordSuccess(s, "real", 100)
-	// "sami" needs a success too, otherwise selectFor sees it as
-	// kindUnknown (which would also lose to real, but the test wants
-	// to specifically pin the kindSubstituted-loses-to-kindRealSeeded
-	// invariant).
-	recordSuccess(s, "sami", 5)
-
-	got, err := s.selectFor("tcp")
-	require.NoError(t, err)
-	require.NotNil(t, got)
-	assert.Equal(t, "real", got.Tag(),
-		"real-seeded must win the kind tie-break over substituted even when substituted is first in s.tags")
-}
-
-func TestURLTest_HydratesBeforeRecordingOutcomes(t *testing.T) {
-	// Seed the storage with a prior outcome ring for "a"; URLTest's
-	// lazy-load must hydrate from this snapshot before recording a new
-	// outcome, otherwise the persisted ring gets clobbered by a fresh
-	// one-entry write.
-	s, obs := newTestMUR(t, "a")
-	s.defaultURL = "http://probe.test/"
-	obs["a"].On("DialContext").Return(nil, errors.New("dial denied"))
-	// Route URLTest's lazy-load through outboundMgr by dropping the
-	// pre-populated member; otherwise the hydrate branch is skipped
-	// because the member is already loaded.
-	s.outboundMgr = &mockOutboundManager{outbounds: map[string]sbAdapter.Outbound{
-		"a": obs["a"],
-	}}
-	s.members.Delete("a")
-	prior := time.Now().Add(-time.Minute)
-	s.history.Store("a", &adapter.TagHistory{
-		Outcomes: []adapter.TimestampedOutcome{
-			{Outcome: adapter.OutcomeSuccess, DelayMs: 42, Timestamp: prior},
-		},
-		UpdatedAt: prior,
-	})
-
-	_, _ = s.URLTest(context.Background())
-
-	got := s.history.Load("a")
-	require.NotNil(t, got)
-	require.GreaterOrEqual(t, len(got.Outcomes), 2,
-		"hydrated entry must be appended to, not replaced — expected the seed plus the new failure")
-	assert.Equal(t, adapter.OutcomeSuccess, got.Outcomes[0].Outcome,
-		"the prior success seed must still be the first entry")
-	assert.Equal(t, uint32(42), got.Outcomes[0].DelayMs)
-}
-
-
-// drainExhaustion empties any pending pre-existing signal so tests can
-// observe the next emission deterministically.
-func drainExhaustion(s *MutableAutoSelect) {
-	select {
-	case <-s.ExhaustionSignal():
-	default:
-	}
+	assert.Nil(t, s.history.Load("a"))
 }
 
 func TestExhaustionSignal_FiresOnFullLadderFailure(t *testing.T) {
@@ -1005,16 +952,12 @@ func TestExhaustionSignal_FiresOnFullLadderFailure(t *testing.T) {
 }
 
 func TestExhaustionSignal_CoalescesPendingSignal(t *testing.T) {
-	// A stale pending signal must not block a fresh emission. emitExhaustion
-	// drains any unread signal before sending, so the buffered channel always
-	// reflects the latest ladder outcome.
 	s, obs := newTestMUR(t, "a")
 	s.defaultURL = "http://probe.test/"
 	obs["a"].On("DialContext").Return(nil, errors.New("dial denied"))
 
-	// Pre-load the buffer to simulate an unread prior signal.
 	s.exhaustionCh <- struct{}{}
-	require.Equal(t, 1, len(s.exhaustionCh), "setup: buffer should hold the stale signal")
+	require.Equal(t, 1, len(s.exhaustionCh))
 
 	s.runLadder("a")
 
@@ -1025,7 +968,7 @@ func TestExhaustionSignal_CoalescesPendingSignal(t *testing.T) {
 	}
 	select {
 	case <-s.ExhaustionSignal():
-		t.Fatal("second receive should block: emitExhaustion buffers exactly one signal")
+		t.Fatal("second receive should block")
 	default:
 	}
 }
@@ -1046,6 +989,18 @@ func TestExhaustionSignal_CloseClosesChannelForRangeLoop(t *testing.T) {
 	}
 }
 
+func TestRunLadder_NoStep1Retry(t *testing.T) {
+	// The ladder is just a full re-probe — there is no "fast retry of
+	// the failing member" anymore. After one ladder run, the failing
+	// member is dialed exactly once (the probe cycle's single dial),
+	// not twice.
+	s, obs := newTestMUR(t, "a")
+	s.defaultURL = "http://probe.test/"
+	obs["a"].On("DialContext").Return(nil, errors.New("dial denied"))
+
+	s.runLadder("a")
+	obs["a"].AssertNumberOfCalls(t, "DialContext", 1)
+}
 
 func TestInterfaceUpdated_TriggersReprobe(t *testing.T) {
 	s, obs := newTestMUR(t, "a")
@@ -1065,13 +1020,10 @@ func TestInterfaceUpdated_TriggersReprobe(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("InterfaceUpdated did not trigger a probe of member a")
 	}
-	// Wait for the probe cycle to finish so the goroutine's writes to the
-	// mock's Calls log are happens-before our AssertNumberOfCalls read.
 	s.probeMu.Lock()
 	s.probeMu.Unlock()
 	obs["a"].AssertNumberOfCalls(t, "DialContext", 1)
 }
-
 
 type fakePauseManager struct {
 	pause.Manager
@@ -1101,14 +1053,12 @@ func TestRunBackgroundLoop_RegistersWithPauseManager(t *testing.T) {
 		s.runBackgroundLoop()
 	}()
 	require.Eventually(t, func() bool { return pm.registered.Load() == 1 },
-		2*time.Second, 10*time.Millisecond, "pause manager callback not registered")
+		2*time.Second, 10*time.Millisecond)
 	cancel()
 	<-done
 }
 
 func TestRunBackgroundLoop_NoPauseManagerIsNoOp(t *testing.T) {
-	// FromContext returns the zero value when no manager is registered;
-	// the loop must skip the RegisterTicker branch without panicking.
 	s, _ := newTestMUR(t, "a")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1118,7 +1068,6 @@ func TestRunBackgroundLoop_NoPauseManagerIsNoOp(t *testing.T) {
 		defer close(done)
 		s.runBackgroundLoop()
 	}()
-	// Give the loop a chance to enter its select; cancel then ensures clean exit.
 	time.Sleep(10 * time.Millisecond)
 	cancel()
 	select {
@@ -1128,12 +1077,7 @@ func TestRunBackgroundLoop_NoPauseManagerIsNoOp(t *testing.T) {
 	}
 }
 
-
 func TestClose_RaceWithEmitExhaustionDoesNotPanic(t *testing.T) {
-	// emitExhaustion sends on exhaustionCh and Close closes it; both
-	// serialize through s.access so the send can never observe a closed
-	// channel. This test stress-runs the two paths in parallel under the
-	// race detector.
 	const iterations = 200
 	for i := 0; i < iterations; i++ {
 		s, _ := newTestMUR(t, "a")
@@ -1150,3 +1094,4 @@ func TestClose_RaceWithEmitExhaustionDoesNotPanic(t *testing.T) {
 		wg.Wait()
 	}
 }
+

--- a/protocol/group/mutableautoselect_test.go
+++ b/protocol/group/mutableautoselect_test.go
@@ -580,7 +580,7 @@ func TestDataPlaneStream_CloseIsIdempotent(t *testing.T) {
 func TestDataPlaneStream_NoStallAfterClose(t *testing.T) {
 	var calls atomic.Uint32
 	d := newDataPlaneStream(stallConn{}, time.Hour, 0, func() { calls.Add(1) }, nil)
-	d.proven.Store(true)      // simulate a proven conn so fireStall isn't gated on the proven check
+	d.proven.Store(true)       // simulate a proven conn so fireStall isn't gated on the proven check
 	d.lastWasWrite.Store(true) // ...nor on the write-without-read gate
 	d.Close()
 	d.fireStall()
@@ -622,11 +622,11 @@ func TestRunLadder_DoesNotEmitExhaustionWhenClosed(t *testing.T) {
 
 func TestRecordProbeOutcome_Persists(t *testing.T) {
 	tests := []struct {
-		name         string
-		success      bool
-		delayMs      uint32
-		wantDelayMs  uint32
-		wantConsec   uint32
+		name        string
+		success     bool
+		delayMs     uint32
+		wantDelayMs uint32
+		wantConsec  uint32
 	}{
 		{"success records delay and zeroes consecutive", true, 123, 123, 0},
 		{"failure increments consecutive, preserves delay", false, 0, 0, 1},
@@ -1094,4 +1094,3 @@ func TestClose_RaceWithEmitExhaustionDoesNotPanic(t *testing.T) {
 		wg.Wait()
 	}
 }
-

--- a/protocol/group/urltest_test.go
+++ b/protocol/group/urltest_test.go
@@ -75,6 +75,9 @@ func (m *mockOutbound) Tag() string {
 }
 
 func (m *mockOutbound) Network() []string {
+	if len(m.networks) > 0 {
+		return m.networks
+	}
 	return []string{"tcp", "udp"}
 }
 

--- a/protocol/register.go
+++ b/protocol/register.go
@@ -88,6 +88,7 @@ func registerOutbounds(registry *outbound.Registry) {
 	group.RegisterFallback(registry)
 	group.RegisterMutableSelector(registry)
 	group.RegisterMutableURLTest(registry)
+	group.RegisterMutableAutoSelect(registry)
 }
 
 func registerEndpoints(registry *endpoint.Registry) {


### PR DESCRIPTION
## Summary

New `mutableautoselect` outbound group that complements `mutableurltest` by distinguishing probe-URL health from real user-traffic health. Targets the connection-oscillation case ([engineering#3484](https://github.com/getlantern/engineering/issues/3484)) where a tunnel handshakes successfully, probes pass on every cycle, but bytes stop flowing — and the URL-test layer keeps re-picking the same dead server because the probe URL says it's healthy.

## Why

`MutableURLTest` treats a passing probe URL as full health. In hostile networks where DPI lets the probe through but throttles user traffic — or where a tunnel handshakes successfully but stops carrying data — a failing outbound looks healthy on every cycle. There is no signal that distinguishes "this server probes fine" from "this server is actually carrying bytes."

## What's in this PR

### Laundering-resistant user-failure window
Each member carries a sliding window of `user_failures` timestamps, separate from `consecutive_failures`. Appended on dial errors, listen errors, and data-plane stalls. **Probe successes never touch it** — a passing probe URL cannot launder a failing outbound. Failures age out naturally over `userFailureWindow` (default 5 min) without depending on traffic being routed through the demoted member. A `userFailureDedupeWindow` (default 30 s) collapses bursts on the same outbound into one entry, so a broken outbound with N orphaned keep-alive conns hitting their stall timer in sequence doesn't inflate one event into many.

### Data-plane stall watchdog
Every dialed conn and listened packet conn is wrapped (`dataPlaneStream` / `dataPlanePacket`) with a per-conn `time.AfterFunc` idle timer (default 60 s). Two gates have to clear before a stall counts:
- **proven** — the conn has delivered ≥ `provedReadBytes` (default 4096) of cumulative non-empty Read payload, distinguishing a stalled tunnel from a handshake-only or keepalive-only conn that never carried traffic.
- **last-was-write** — the most recent non-empty IO was a Write, i.e. we sent bytes and got nothing back. A proven conn whose last activity was a Read is the user going idle on a healthy keep-alive, not a broken tunnel.

When both gates clear and the timer expires, the wrapper appends one user-failure timestamp and triggers the reconnection ladder. CAS-guarded one-shot per conn so a late read returning bytes just before `Close` can't deliver a phantom stall.

### Three-tier demote ranking, per network
Candidates rank by `(demoteLevel, candidateKind, delayMs)`:
- `clean` — fewer than `softFailLimit` user-failures in window, and consecutive-failure threshold not tripped.
- `soft` — `userFailsInWindow >= softFailLimit` (default 2). Loses to every clean peer but beats hard. A single transient stall is not enough; two within `userFailureWindow` is corroboration.
- `hard` — `consec >= consecutiveFailLimit` or `userFailsInWindow >= consecutiveFailLimit` (default 3).

`splitHealthyFor` filters by network first, then returns clean → soft → filtered (hard as last resort). Per-network filtering matters because a clean TCP-only candidate must not starve a soft UDP-only peer.

### Switch-penalty boost
The hard-demote threshold doubles when the candidate has a real-seeded delay and the best real-seeded alternative is more than 3× slower (`switchPenaltyAltFactor`). Hard-demoting a 100 ms member onto a 990 ms alternative on three transient failures is itself a cost; the boost requires more evidence when switching is meaningfully worse. Synthetic and unknown delays are excluded from the `bestAlt` comparison so the rescue is anchored on real measurements only.

### Switch-tolerance hysteresis
`applyStickiness` keeps the previous sticky tag unless a new winner beats it by `SwitchToleranceMs` (default 50 ms). Dampens churn from tiny probe-time deltas. TCP and UDP have independent sticky tags.

### Dial-site fast failover
Before the ladder runs, a `DialContext` / `ListenPacket` error retries the dial once against the next-best member from the current rank, excluding the failing tag. The active 3-minute probe cadence keeps history fresh enough to pick a working alternative without re-probing. Only one alternate is attempted; the dial caller already retries on its own schedule.

### Reconnection ladder
Triggered from dial/listen errors (after the fast-failover step) and from the stall watchdog. Full parallel re-probe across the candidate pool inside a `ladderTotalBudgetSeconds` (default 10 s) deadline. The ladder kick is gated on the user-failure dedupe: if the triggering event was deduped, the ladder skips so orphan-conn cascades don't trigger N redundant probe sweeps. If no candidate succeeds within the budget, the group emits one value on the buffered exhaustion channel. Concurrent ladder invocations collapse via a CAS guard.

### Adaptive background probe cadence
A low-priority background loop keeps alternative members warm, registered with sing-box's pause manager. Faster active interval (default 180 s) when traffic has flowed recently through a wrapped conn; slower idle interval (default 900 s) otherwise. Brand-new groups with no observed traffic are treated as idle so we don't burn the fast cadence on a tunnel nobody is using.

### Persistent history
A new `AutoSelectHistoryStorage` service interface lets hosts plug in durable storage. The group writes a full `TagHistory` snapshot (probe scalars + `user_failures` window) after every state-changing mutation. The included in-memory implementation is the default; hosts wiring durable storage register their own and wire `SetHook` to flush snapshots out-of-band. On `Add`, history is lazy-hydrated; persisted entries older than `maxPersistedAgeSeconds` (default 15 min) are dropped on hydrate so a stale snapshot from a previous poll window doesn't start the member innocent. On `Remove` or URL-override change, the affected entries are dropped.

### Exhaustion signal
`ExhaustionSignaler` interface. The group sends a value on a buffered channel when the ladder's full budget elapses with no successful candidate, letting the host refetch `/config-new` instead of endlessly re-probing the same dead set.

### Per-protocol probe behavior
Each protocol gets a probe timeout suited to its handshake cost: longer for multi-step handshakes like algeneva/ssh/shadowtls/reflex/trojan, longest for self-probing protocols like outline (`StrategyFinder` discovers a winning strategy on first use), and shorter for UDP-based protocols where blocked ports time out silently rather than failing fast. Peer/network protocols (`tor`, `unbounded`) are excluded from the candidate pool entirely — they run alongside the group with their own connection managers.

### Candidate kind (tie-break under demote tier)
- `kindRealSeeded` — measured delay from a real probe.
- `kindUnknown` — no in-memory data, no persisted seed.

## Configurable knobs

`option.MutableAutoSelectOutboundOptions` exposes every threshold (demote limits, user-failure window + dedupe window, max persisted age, cadence intervals, idle threshold, switch tolerance, ladder budget, data-plane idle + proved-read bytes) as a config field with documented defaults.