### PR TITLE
feat: adding log id field to log messages

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -160,6 +160,7 @@ func (l *slogLogger) log(ctx context.Context, level slog.Level, args []any) stri
 	}
 	if ctx != nil {
 		if id, hasId := log.IDFromContext(ctx); hasId {
+			args = append(args, slog.Uint64("id", uint64(id.ID)))
 			args = append(args, slog.Duration("duration", time.Since(id.CreatedAt)))
 		}
 	}

--- a/log/log.go
+++ b/log/log.go
@@ -160,7 +160,7 @@ func (l *slogLogger) log(ctx context.Context, level slog.Level, args []any) stri
 	}
 	if ctx != nil {
 		if id, hasId := log.IDFromContext(ctx); hasId {
-			args = append(args, slog.Uint64("id", uint64(id.ID)))
+			args = append(args, slog.Any("id", id.ID))
 			args = append(args, slog.Duration("duration", time.Since(id.CreatedAt)))
 		}
 	}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -46,6 +46,20 @@ func TestLogging(t *testing.T) {
 	}
 }
 
+func TestContextID(t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	f := &factory{handler: handler}
+	sl := &slogLogger{factory: f}
+
+	ctx := log.ContextWithNewID(context.Background())
+	sl.Log(ctx, log.LevelInfo, "test message")
+
+	out := buf.String()
+	assert.Contains(t, out, "id=", "expected context ID in log output")
+	assert.Contains(t, out, "duration=", "expected duration in log output")
+}
+
 func TestLevel(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
Currently there's no way to track which log messages belong to which request and that makes it difficult to track the errors from the beginning. With this ID field I hope to be able to identify all the flow from a log request, if it failed on the DNS part, or if it failed on the outbound part or anywhere else.