### PR TITLE
feat(samizdat): normalize HTTP/2 read errors via WrapH2

### DIFF
--- a/protocol/samizdat/conn.go
+++ b/protocol/samizdat/conn.go
@@ -1,0 +1,38 @@
+package samizdat
+
+import (
+	"net"
+
+	"github.com/sagernet/sing/common/baderror"
+	"github.com/sagernet/sing/common/bufio/deadline"
+)
+
+// wrapConn normalizes HTTP/2 read errors on a samizdat stream conn.
+//
+// The samizdat transport carries proxied traffic over HTTP/2 streams, so a
+// torn-down stream surfaces golang.org/x/net/http2 errors such as
+// "http2: response body closed" or "; CANCEL". baderror.WrapH2 maps those to
+// net.ErrClosed so the router treats them as an ordinary connection close
+// rather than a transport fault.
+//
+// UoT packet conns are not wrapped directly: they read through the samizdat
+// stream conn returned by samizdatDialer.DialContext, which is wrapped here,
+// so their read errors are already normalized at the stream layer.
+//
+// wrapConn is deliberately opaque: it does not expose Upstream(), so sing-box
+// cannot unwrap past it and read the underlying conn directly, which would
+// bypass the normalization. The cost of that opacity is the
+// NeedAdditionalReadDeadline hint sing-box would otherwise discover through the
+// Upstream() chain, so it is forwarded explicitly.
+type wrapConn struct {
+	net.Conn
+}
+
+func (c *wrapConn) Read(b []byte) (int, error) {
+	n, err := c.Conn.Read(b)
+	return n, baderror.WrapH2(err)
+}
+
+func (c *wrapConn) NeedAdditionalReadDeadline() bool {
+	return deadline.NeedAdditionalReadDeadline(c.Conn)
+}

--- a/protocol/samizdat/inbound.go
+++ b/protocol/samizdat/inbound.go
@@ -157,6 +157,8 @@ func NewInbound(
 // which is required because the samizdat H2 handler closes the stream
 // when the Handler function returns.
 func (i *Inbound) handleConnection(ctx context.Context, conn net.Conn, destination string) {
+	conn = &wrapConn{Conn: conn}
+
 	var metadata adapter.InboundContext
 	metadata.Inbound = i.Tag()
 	metadata.InboundType = i.Type()

--- a/protocol/samizdat/outbound.go
+++ b/protocol/samizdat/outbound.go
@@ -42,7 +42,11 @@ type samizdatDialer struct {
 }
 
 func (d *samizdatDialer) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
-	return d.client.DialContext(ctx, network, destination.String())
+	conn, err := d.client.DialContext(ctx, network, destination.String())
+	if err != nil {
+		return nil, err
+	}
+	return &wrapConn{Conn: conn}, nil
 }
 
 func (d *samizdatDialer) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
@@ -149,7 +153,11 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 	switch N.NetworkName(network) {
 	case N.NetworkTCP:
 		o.logger.InfoContext(ctx, "outbound connection to ", destination)
-		return o.client.DialContext(ctx, network, destination.String())
+		conn, err := o.client.DialContext(ctx, network, destination.String())
+		if err != nil {
+			return nil, err
+		}
+		return &wrapConn{Conn: conn}, nil
 	case N.NetworkUDP:
 		o.logger.InfoContext(ctx, "outbound UoT packet connection to ", destination)
 		return o.uotClient.DialContext(ctx, network, destination)


### PR DESCRIPTION
This pull request introduces a new `wrapConn` type to normalize HTTP/2 read errors on samizdat stream connections, ensuring that errors from torn-down streams are consistently mapped to `net.ErrClosed`. This prevents the router from misinterpreting normal connection closures as transport faults. The `wrapConn` is now applied to both inbound and outbound connections, and its design intentionally hides the underlying connection to enforce error normalization.

**Error normalization and connection wrapping:**

* Added the `wrapConn` type in `conn.go` to wrap `net.Conn` and normalize HTTP/2 read errors using `baderror.WrapH2`, ensuring consistent error handling for closed streams. The wrapper also forwards the `NeedAdditionalReadDeadline` hint.
* Updated `handleConnection` in `inbound.go` to wrap inbound connections with `wrapConn`, so all inbound traffic benefits from error normalization.
* Modified `samizdatDialer.DialContext` and `Outbound.DialContext` in `outbound.go` to wrap outbound connections with `wrapConn`, ensuring outbound connections also have normalized error handling. [[1]](diffhunk://#diff-df2dadbdcd7c80011c642731e6a9104acd3979ab72feb410b44de02c9c291080L45-R49) [[2]](diffhunk://#diff-df2dadbdcd7c80011c642731e6a9104acd3979ab72feb410b44de02c9c291080L152-R160)

closes getlantern/engineering/issues/3544
related to getlantern/engineering/issues/3463