### PR TITLE
feat(protocol): derive supported protocols from registries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.6
 
 replace github.com/sagernet/sing => github.com/getlantern/sing v0.7.18-lantern
 
-replace github.com/sagernet/sing-box => github.com/getlantern/sing-box-minimal v1.12.22-lantern
+replace github.com/sagernet/sing-box => github.com/getlantern/sing-box-minimal v1.12.22-lantern.0.20260529221144-439651539f38
 
 replace github.com/sagernet/wireguard-go => github.com/getlantern/wireguard-go v0.0.1-beta.7.0.20251208214020-d78e69f1eff4
 

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb/go.mod h1:GkPT5P9JoOTIRXRmFWxYgu1hhXgTFFTNc2hoG7WQc3g=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=
 github.com/getlantern/sing v0.7.18-lantern/go.mod h1:ARkL0gM13/Iv5VCZmci/NuoOlePoIsW0m7BWfln/Hak=
-github.com/getlantern/sing-box-minimal v1.12.22-lantern h1:dZXg3jJu8dZGvBAptoJ7L2Gmwe9bSPFRRZlUVT/O8CM=
-github.com/getlantern/sing-box-minimal v1.12.22-lantern/go.mod h1:LzlFRel9E92gX0HXWCdsxgeg+kuAEPzLR+Znixk9EI4=
+github.com/getlantern/sing-box-minimal v1.12.22-lantern.0.20260529221144-439651539f38 h1:OfT3vn+nXMM9/D3clpakm1no8Hby3CuSg39DpV09Shg=
+github.com/getlantern/sing-box-minimal v1.12.22-lantern.0.20260529221144-439651539f38/go.mod h1:LzlFRel9E92gX0HXWCdsxgeg+kuAEPzLR+Znixk9EI4=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5 h1:6ITBYqNkLbVZ1tQNXwmH8N80rZtvyW6IZa8L6EAhBQo=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5/go.mod h1:gx3dPUhZtQszPX5C+TshhxPXQHlY5t4gMnOOMA+viPA=
 github.com/getlantern/water v0.7.1-alpha.0.20260309190745-bd547c14b4aa h1:goZee1cURbWPiqX1xyjfwLB/zByQ50hEwonnnyLmcJQ=

--- a/protocol/amnezia/endpoint.go
+++ b/protocol/amnezia/endpoint.go
@@ -1,3 +1,5 @@
+//go:build with_wireguard
+
 package amnezia
 
 import (

--- a/protocol/amnezia/endpoint_stub.go
+++ b/protocol/amnezia/endpoint_stub.go
@@ -14,6 +14,7 @@ import (
 	"github.com/getlantern/lantern-box/option"
 )
 
+// register a constructor that always errors to follow sing-box's convention
 func RegisterEndpoint(registry *endpoint.Registry) {
 	endpoint.Register[option.AmneziaEndpointOptions](registry, constant.TypeAmnezia,
 		func(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.AmneziaEndpointOptions) (adapter.Endpoint, error) {

--- a/protocol/amnezia/endpoint_stub.go
+++ b/protocol/amnezia/endpoint_stub.go
@@ -1,0 +1,23 @@
+//go:build !with_wireguard
+
+package amnezia
+
+import (
+	"context"
+	"errors"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/endpoint"
+	"github.com/sagernet/sing-box/log"
+
+	"github.com/getlantern/lantern-box/constant"
+	"github.com/getlantern/lantern-box/option"
+)
+
+func RegisterEndpoint(registry *endpoint.Registry) {
+	endpoint.Register[option.AmneziaEndpointOptions](registry, constant.TypeAmnezia,
+		func(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.AmneziaEndpointOptions) (adapter.Endpoint, error) {
+			return nil, errors.New(`Amnezia is not included in this build, rebuild with -tags with_wireguard`)
+		},
+	)
+}

--- a/protocol/register.go
+++ b/protocol/register.go
@@ -9,9 +9,11 @@ import (
 	"github.com/sagernet/sing-box/adapter/endpoint"
 	"github.com/sagernet/sing-box/adapter/inbound"
 	"github.com/sagernet/sing-box/adapter/outbound"
+	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/experimental/libbox"
 	"github.com/sagernet/sing/service"
 
+	"github.com/getlantern/lantern-box/constant"
 	"github.com/getlantern/lantern-box/protocol/algeneva"
 	"github.com/getlantern/lantern-box/protocol/amnezia"
 	"github.com/getlantern/lantern-box/protocol/group"
@@ -22,11 +24,6 @@ import (
 	"github.com/getlantern/lantern-box/protocol/water"
 )
 
-type _registry interface {
-	adapter.Registry
-	CreateOptions(string) (any, bool)
-}
-
 var supportedProtocols []string
 
 func init() {
@@ -34,17 +31,11 @@ func init() {
 	// tags, we can't hardcode this list and must collect it from the registries themselves.
 
 	ctx := RegisterProtocols(libbox.BaseContext(nil))
-	getProtos := func(reg _registry) []string {
+	getProtos := func(reg adapter.Registry) []string {
 		if reg == nil {
 			return nil
 		}
-		p := reg.Registered()
-		// sing-box still registers all protocols regardless but the registered constructor returns
-		// an error when the build tag is ommitted, so we remove ones that error
-		return slices.DeleteFunc(p, func(s string) bool {
-			_, ok := reg.CreateOptions(s)
-			return !ok
-		})
+		return reg.Registered()
 	}
 
 	iprotos := getProtos(service.FromContext[adapter.InboundRegistry](ctx))
@@ -59,6 +50,13 @@ func init() {
 	}
 	for _, p := range eprotos {
 		protocolSet[p] = struct{}{}
+	}
+	if !with_wireguard {
+		delete(protocolSet, constant.TypeAmnezia)
+		delete(protocolSet, C.TypeWireGuard)
+	}
+	if !with_ts {
+		delete(protocolSet, C.TypeTailscale)
 	}
 	supportedProtocols = slices.Collect(maps.Keys(protocolSet))
 }

--- a/protocol/register.go
+++ b/protocol/register.go
@@ -2,11 +2,14 @@ package protocol
 
 import (
 	"context"
+	"maps"
+	"slices"
 
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/adapter/endpoint"
 	"github.com/sagernet/sing-box/adapter/inbound"
 	"github.com/sagernet/sing-box/adapter/outbound"
+	"github.com/sagernet/sing-box/experimental/libbox"
 	"github.com/sagernet/sing/service"
 
 	"github.com/getlantern/lantern-box/protocol/algeneva"
@@ -19,30 +22,45 @@ import (
 	"github.com/getlantern/lantern-box/protocol/water"
 )
 
-var supportedProtocols = []string{
-	// custom protocols
-	"algeneva",
-	"amnezia",
-	"outline",
-	"reflex",
-	"samizdat",
-	"unbounded",
-	"water",
+type _registry interface {
+	adapter.Registry
+	CreateOptions(string) (any, bool)
+}
 
-	// sing-box built-in protocols
-	"http",
-	"hysteria",
-	"hysteria2",
-	"shadowsocks",
-	"shadowtls",
-	"socks",
-	"ssh",
-	"tor",
-	"trojan",
-	"tuic",
-	"vless",
-	"vmess",
-	"wireguard",
+var supportedProtocols []string
+
+func init() {
+	// collect supported protocols from all registries. since what's supported depends on the build
+	// tags, we can't hardcode this list and must collect it from the registries themselves.
+
+	ctx := RegisterProtocols(libbox.BaseContext(nil))
+	getProtos := func(reg _registry) []string {
+		if reg == nil {
+			return nil
+		}
+		p := reg.Registered()
+		// sing-box still registers all protocols regardless but the registered constructor returns
+		// an error when the build tag is ommitted, so we remove ones that error
+		return slices.DeleteFunc(p, func(s string) bool {
+			_, ok := reg.CreateOptions(s)
+			return !ok
+		})
+	}
+
+	iprotos := getProtos(service.FromContext[adapter.InboundRegistry](ctx))
+	oprotos := getProtos(service.FromContext[adapter.OutboundRegistry](ctx))
+	eprotos := getProtos(service.FromContext[adapter.EndpointRegistry](ctx))
+	protocolSet := make(map[string]struct{})
+	for _, p := range iprotos {
+		protocolSet[p] = struct{}{}
+	}
+	for _, p := range oprotos {
+		protocolSet[p] = struct{}{}
+	}
+	for _, p := range eprotos {
+		protocolSet[p] = struct{}{}
+	}
+	supportedProtocols = slices.Collect(maps.Keys(protocolSet))
 }
 
 // RegisterProtocols registers all lantern-box protocols to the given context's registries.

--- a/protocol/with_ts.go
+++ b/protocol/with_ts.go
@@ -1,0 +1,5 @@
+//go:build with_tailscale
+
+package protocol
+
+const with_ts = true

--- a/protocol/with_wireguard.go
+++ b/protocol/with_wireguard.go
@@ -1,0 +1,5 @@
+//go:build with_wireguard
+
+package protocol
+
+const with_wireguard = true

--- a/protocol/without_ts.go
+++ b/protocol/without_ts.go
@@ -1,0 +1,5 @@
+//go:build !with_tailscale
+
+package protocol
+
+const with_ts = false

--- a/protocol/without_wireguard.go
+++ b/protocol/without_wireguard.go
@@ -1,0 +1,5 @@
+//go:build !with_wireguard
+
+package protocol
+
+const with_wireguard = false


### PR DESCRIPTION
This pull request introduces dynamic detection of supported protocols based on build tags, replacing the previous hardcoded list. It also adds build tag handling for the Amnezia protocol and updates a dependency version in `go.mod`. The main impact is improved flexibility and accuracy in protocol support reporting, especially in builds with optional features like WireGuard.

**Dynamic protocol registration and build tag handling:**

* Replaces the hardcoded `supportedProtocols` list in `protocol/register.go` with a dynamic mechanism that queries protocol registries at runtime, ensuring only protocols actually supported by the current build (based on build tags) are reported. This uses new helper logic to collect and deduplicate protocols from inbound, outbound, and endpoint registries.
* Adds build tag handling for the Amnezia protocol by splitting its endpoint registration into two files: `endpoint.go` (enabled with the `with_wireguard` build tag) and `endpoint_stub.go` (used when the tag is not set). The stub returns an error if Amnezia is not included in the build, providing clear feedback to developers and users. [[1]](diffhunk://#diff-9eaadb9ce40220c238d1ae7ab72b13420c7709e830f8794c7db35e54b847736fR1-R2) [[2]](diffhunk://#diff-458db5eee9bc99086ea14bb575091b197c7e4095b47107d9dc77bb6dfe0c9187R1-R23)

**Dependency update:**

* Updates the replacement for `github.com/sagernet/sing-box` in `go.mod` to a new Lantern-specific version, ensuring the correct dependency is used for this build.

**Minor codebase improvements:**

* Imports new utility packages (`maps`, `slices`) and `libbox` to support the dynamic protocol registration logic.