### PR TITLE
build: bump keepcurrent for sync memory fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65 // indirect
 	github.com/getlantern/hex v0.0.0-20220104173244-ad7e4b9194dc // indirect
 	github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 // indirect
-	github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 // indirect
+	github.com/getlantern/keepcurrent v0.0.0-20260616091602-0364abd4ecd2 // indirect
 	github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 // indirect
 	github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5 // indirect
 	github.com/go-chi/chi/v5 v5.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/getlantern/hex v0.0.0-20220104173244-ad7e4b9194dc/go.mod h1:D9RWpXy/E
 github.com/getlantern/hidden v0.0.0-20190325191715-f02dbb02be55/go.mod h1:6mmzY2kW1TOOrVy+r41Za2MxXM+hhqTtY3oBKd2AgFA=
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2yaur9Qk3rHYD414j3Q1rl7+L0AylxrE=
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
-github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 h1:iLWm6S/47Hfk7FjW6yaD+1h6kO7C/iauV0DkVia/bXU=
-github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
+github.com/getlantern/keepcurrent v0.0.0-20260616091602-0364abd4ecd2 h1:ZNkfDGgqtKrX2CEs/SryCx31Qe8GEu2a+HAmeyX2UU4=
+github.com/getlantern/keepcurrent v0.0.0-20260616091602-0364abd4ecd2/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395/go.mod h1:3JpJgwi4KEI6rS9loOAvcBp+F2jP65d0tTg2GQcTPBU=
 github.com/getlantern/ops v0.0.0-20190325191751-d70cb0d6f85f/go.mod h1:D5ao98qkA6pxftxoqzibIBBrLSUli+kYnJqrgBf9cIA=


### PR DESCRIPTION
Bumps `github.com/getlantern/keepcurrent` to include [keepcurrent#9](https://github.com/getlantern/keepcurrent/pull/9).

## Why

Several 1 GB VPS were tripping the SigNoz **"Host memory usage high"** alert (10 m avg `system.memory.usage` > 85%). Heap pprof from the `lantern-box` binary showed the dominant live allocation was `io.ReadAll` (75 MB / 173 MB ≈ 44% of the Go heap), all from:

```
io.ReadAll → keepcurrent.(*byteChannel).UpdateFrom → (*Runner).syncOnce → Start.func2
```

That's `getlantern/geo` syncing the **MaxMind GeoLite2 mmdb (~75 MB)** via `keepcurrent.FromTarGz(FromWeb(...))`. The payload was buffered with `io.ReadAll`, which grows by repeated reallocation — churning through a chain of ever-larger backing arrays (the 75/60/48/38… MB generations seen in the heap) on every sync. On a 1 GB box that transient churn dominated RSS.

## What

keepcurrent#9 pre-sizes those reads from the reader's known length (HTTP `Content-Length`, archive entry size, in-memory `Len()`), turning the multi-realloc read into a single allocation, with an overflow/OOM cap that falls back to `io.ReadAll` for bogus sizes. No public API change.

This PR is just the dependency bump (`go get keepcurrent@0364abd && go mod tidy`); keepcurrent remains an indirect dependency. Build is green.