### PR TITLE
metrics: per-session download goodput histogram

### DIFF
--- a/tracker/metrics/conn.go
+++ b/tracker/metrics/conn.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"net"
+	"sync/atomic"
 	"time"
 )
 
@@ -11,6 +12,7 @@ type Conn struct {
 	attrs     *attributes
 	tracker   *MetricsTracker
 	startTime time.Time
+	rxBytes   atomic.Int64
 }
 
 // NewConn creates a new Conn instance.
@@ -27,6 +29,7 @@ func NewConn(conn net.Conn, attrs *attributes, tracker *MetricsTracker) net.Conn
 func (c *Conn) Read(b []byte) (n int, err error) {
 	n, err = c.Conn.Read(b)
 	if n > 0 {
+		c.rxBytes.Add(int64(n))
 		c.tracker.TrackIO(rx, n, c.attrs)
 	}
 	return
@@ -45,6 +48,7 @@ func (c *Conn) Write(b []byte) (n int, err error) {
 func (c *Conn) Close() error {
 	duration := time.Since(c.startTime).Milliseconds()
 	c.tracker.Leave(duration, c.attrs)
+	c.tracker.recordGoodput(c.rxBytes.Load(), duration, c.attrs)
 	return c.Conn.Close()
 }
 

--- a/tracker/metrics/metrics.go
+++ b/tracker/metrics/metrics.go
@@ -23,20 +23,22 @@ type countryLookupRequest struct {
 }
 
 type metricsManager struct {
-	meter    metric.Meter
-	ProxyIO  metric.Int64Counter
-	conns    metric.Int64UpDownCounter
-	duration metric.Int64Histogram
+	meter          metric.Meter
+	ProxyIO        metric.Int64Counter
+	conns          metric.Int64UpDownCounter
+	duration       metric.Int64Histogram
+	sessionGoodput metric.Float64Histogram
 
 	countryLookup  geo.CountryLookup
 	countryLookupC chan countryLookupRequest
 }
 
 var metrics = &metricsManager{
-	ProxyIO:       &noop.Int64Counter{},
-	conns:         &noop.Int64UpDownCounter{},
-	duration:      &noop.Int64Histogram{},
-	countryLookup: geo.NoLookup{},
+	ProxyIO:        &noop.Int64Counter{},
+	conns:          &noop.Int64UpDownCounter{},
+	duration:       &noop.Int64Histogram{},
+	sessionGoodput: &noop.Float64Histogram{},
+	countryLookup:  geo.NoLookup{},
 }
 
 func SetupMetricsManager(countryLookup geo.CountryLookup) {
@@ -53,6 +55,17 @@ func SetupMetricsManager(countryLookup geo.CountryLookup) {
 	duration, err := meter.Int64Histogram("sing.connection_duration", metric.WithDescription("Connection duration"))
 	if err == nil {
 		metrics.duration = duration
+	}
+	// Track per-session download goodput (received bytes / connection seconds),
+	// recorded once at close for sessions that moved at least goodputMinBytes.
+	// Sliceable by track (resource attr) × cloud.region (resource attr) ×
+	// geo.country.iso_code (point attr) so the bandit experiment evaluator can
+	// compare a challenger track's median goodput against the incumbent's.
+	goodput, err := meter.Float64Histogram("proxy.session.goodput",
+		metric.WithUnit("By/s"),
+		metric.WithDescription("Per-session download goodput: received bytes / connection seconds"))
+	if err == nil {
+		metrics.sessionGoodput = goodput
 	}
 
 	if countryLookup != nil {

--- a/tracker/metrics/metrics.go
+++ b/tracker/metrics/metrics.go
@@ -56,14 +56,16 @@ func SetupMetricsManager(countryLookup geo.CountryLookup) {
 	if err == nil {
 		metrics.duration = duration
 	}
-	// Track per-session download goodput (received bytes / connection seconds),
-	// recorded once at close for sessions that moved at least goodputMinBytes.
-	// Sliceable by track (resource attr) × cloud.region (resource attr) ×
-	// geo.country.iso_code (point attr) so the bandit experiment evaluator can
-	// compare a challenger track's median goodput against the incumbent's.
+	// Track per-session download goodput (received bytes per second of connection
+	// lifetime), recorded once at close for sessions that moved at least
+	// goodputMinBytes. Sliceable by track (resource attr) × cloud.region (resource
+	// attr) × geo.country.iso_code (point attr) so the bandit experiment evaluator
+	// can compare a challenger track's median goodput against the incumbent's. Unit
+	// "bytes/s" matches proxy.io's "bytes" spelling for consistency within this
+	// package's metrics.
 	goodput, err := meter.Float64Histogram("proxy.session.goodput",
-		metric.WithUnit("By/s"),
-		metric.WithDescription("Per-session download goodput: received bytes / connection seconds"))
+		metric.WithUnit("bytes/s"),
+		metric.WithDescription("Per-session download goodput: received bytes per second of connection lifetime"))
 	if err == nil {
 		metrics.sessionGoodput = goodput
 	}

--- a/tracker/metrics/packet_conn.go
+++ b/tracker/metrics/packet_conn.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/sagernet/sing/common/buf"
@@ -14,6 +15,7 @@ type PacketConn struct {
 	attrs     *attributes
 	tracker   *MetricsTracker
 	startTime time.Time
+	rxBytes   atomic.Int64
 }
 
 // NewPacketConn creates a new PacketConn instance.
@@ -33,6 +35,7 @@ func (c *PacketConn) ReadPacket(buffer *buf.Buffer) (destination M.Socksaddr, er
 		return dest, err
 	}
 	if buffer.Len() > 0 {
+		c.rxBytes.Add(int64(buffer.Len()))
 		c.tracker.TrackIO(rx, buffer.Len(), c.attrs)
 	}
 	return dest, nil
@@ -50,6 +53,7 @@ func (c *PacketConn) WritePacket(buffer *buf.Buffer, destination M.Socksaddr) er
 func (c *PacketConn) Close() error {
 	duration := time.Since(c.startTime).Milliseconds()
 	c.tracker.Leave(duration, c.attrs)
+	c.tracker.recordGoodput(c.rxBytes.Load(), duration, c.attrs)
 	return c.PacketConn.Close()
 }
 

--- a/tracker/metrics/tracker.go
+++ b/tracker/metrics/tracker.go
@@ -144,7 +144,13 @@ func (t *MetricsTracker) recordGoodput(rxBytes, durationMs int64, attrs *attribu
 		return
 	}
 	goodput := float64(rxBytes) / (float64(durationMs) / 1000.0)
-	a := append(attrs.AsSlice(), semconv.NetworkIODirectionKey.String(string(rx)))
+	// Copy into a slice sized for the extra element rather than appending onto
+	// AsSlice()'s result in place, so we never share a backing array with a
+	// concurrent reporter.
+	base := attrs.AsSlice()
+	a := make([]attribute.KeyValue, 0, len(base)+1)
+	a = append(a, base...)
+	a = append(a, semconv.NetworkIODirectionKey.String(string(rx)))
 	metrics.sessionGoodput.Record(context.Background(), goodput, metric.WithAttributes(a...))
 }
 

--- a/tracker/metrics/tracker.go
+++ b/tracker/metrics/tracker.go
@@ -20,6 +20,12 @@ const (
 	tx ioAttr = "transmit"
 
 	ccNa = "n/a"
+
+	// goodputMinBytes is the minimum received bytes a session must have moved
+	// before its goodput sample is recorded. Filters out idle/tiny connections
+	// whose bytes/duration is dominated by setup and idle time rather than
+	// actual transfer speed.
+	goodputMinBytes = 1_000_000
 )
 
 type ioAttr string
@@ -125,6 +131,21 @@ func (t *MetricsTracker) Leave(duration int64, attrs *attributes) {
 	a := attrs.AsSlice()
 	metrics.duration.Record(context.Background(), duration, metric.WithAttributes(a...))
 	metrics.conns.Add(context.Background(), -1, metric.WithAttributes(a...))
+}
+
+// recordGoodput records a session's download goodput (received bytes per
+// connection second) at close, for sessions that moved at least
+// goodputMinBytes. durationMs is the connection's open time; it includes idle
+// periods, so this is a floor on true transfer speed — but both arms of a
+// bandit experiment are measured identically, so it's a fair relative signal,
+// and the byte floor filters the worst idle-dominated noise.
+func (t *MetricsTracker) recordGoodput(rxBytes, durationMs int64, attrs *attributes) {
+	if rxBytes < goodputMinBytes || durationMs <= 0 {
+		return
+	}
+	goodput := float64(rxBytes) / (float64(durationMs) / 1000.0)
+	a := append(attrs.AsSlice(), semconv.NetworkIODirectionKey.String(string(rx)))
+	metrics.sessionGoodput.Record(context.Background(), goodput, metric.WithAttributes(a...))
 }
 
 type attributes struct {

--- a/tracker/metrics/tracker.go
+++ b/tracker/metrics/tracker.go
@@ -134,7 +134,7 @@ func (t *MetricsTracker) Leave(duration int64, attrs *attributes) {
 }
 
 // recordGoodput records a session's download goodput (received bytes per
-// connection second) at close, for sessions that moved at least
+// second of connection lifetime) at close, for sessions that moved at least
 // goodputMinBytes. durationMs is the connection's open time; it includes idle
 // periods, so this is a floor on true transfer speed — but both arms of a
 // bandit experiment are measured identically, so it's a fair relative signal,

--- a/tracker/metrics/tracker_test.go
+++ b/tracker/metrics/tracker_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 	"testing/synctest"
+	"time"
 
 	sdkotel "go.opentelemetry.io/otel"
 
@@ -219,6 +220,119 @@ func TestDeviceConnectedSpanNoClientInfo(t *testing.T) {
 	emitDeviceConnectedSpan(context.Background())
 	assert.Empty(t, exporter.GetSpans(),
 		"no span should be emitted without client info")
+}
+
+// TestSessionGoodput verifies the per-session download goodput histogram is
+// emitted once at close for a session that moved >= goodputMinBytes, with the
+// value ~= received bytes / connection seconds and a receive direction tag.
+func TestSessionGoodput(t *testing.T) {
+	synctest.Run(func() {
+		reader := metric.NewManualReader()
+		provider := metric.NewMeterProvider(metric.WithReader(reader))
+		sdkotel.SetMeterProvider(provider)
+
+		SetupMetricsManager(geo.NoLookup{})
+
+		ctx := context.Background()
+		mt := NewTracker(ctx)
+		defer mt.Close()
+
+		client, server := net.Pipe()
+		defer client.Close()
+		serverTracked := mt.RoutedConnection(ctx, server, adapter.InboundContext{}, nil, nil)
+
+		const n = 1_100_000 // above the 1MB goodput threshold
+		done := make(chan int, 1)
+		go func() {
+			buf := make([]byte, n)
+			got := 0
+			for got < n {
+				r, err := serverTracked.Read(buf[got:])
+				if err != nil {
+					break
+				}
+				got += r
+			}
+			done <- got
+		}()
+		_, err := client.Write(make([]byte, n))
+		require.NoError(t, err)
+		require.Equal(t, n, <-done)
+
+		// Advance virtual time so the connection has a ~1s open duration.
+		time.Sleep(time.Second)
+		synctest.Wait()
+
+		require.NoError(t, serverTracked.Close())
+		synctest.Wait()
+
+		var rm metricdata.ResourceMetrics
+		reader.Collect(ctx, &rm)
+
+		count, sum, found := histogramCountSum(rm, "proxy.session.goodput")
+		require.True(t, found, "goodput histogram should be emitted for a >=1MB session")
+		assert.Equal(t, uint64(1), count, "exactly one goodput sample")
+		// ~1s open duration → goodput ~= received bytes per second.
+		assert.InDelta(t, float64(n), sum, float64(n)*0.05)
+
+		attrs := extractAttrs(rm, "proxy.session.goodput")
+		assert.Equal(t, "receive", attrs["network.io.direction"])
+	})
+}
+
+// TestSessionGoodputBelowThreshold verifies a sub-threshold session emits no
+// goodput sample.
+func TestSessionGoodputBelowThreshold(t *testing.T) {
+	synctest.Run(func() {
+		reader := metric.NewManualReader()
+		provider := metric.NewMeterProvider(metric.WithReader(reader))
+		sdkotel.SetMeterProvider(provider)
+
+		SetupMetricsManager(geo.NoLookup{})
+
+		ctx := context.Background()
+		mt := NewTracker(ctx)
+		defer mt.Close()
+
+		client, server := net.Pipe()
+		defer client.Close()
+		serverTracked := mt.RoutedConnection(ctx, server, adapter.InboundContext{}, nil, nil)
+
+		small := []byte("only a few bytes, well under the threshold")
+		done := make(chan struct{})
+		go func() {
+			buf := make([]byte, len(small))
+			_, _ = serverTracked.Read(buf)
+			close(done)
+		}()
+		_, err := client.Write(small)
+		require.NoError(t, err)
+		<-done
+		time.Sleep(time.Second)
+		synctest.Wait()
+
+		require.NoError(t, serverTracked.Close())
+		synctest.Wait()
+
+		var rm metricdata.ResourceMetrics
+		reader.Collect(ctx, &rm)
+		_, _, found := histogramCountSum(rm, "proxy.session.goodput")
+		assert.False(t, found, "no goodput sample below the byte threshold")
+	})
+}
+
+func histogramCountSum(rm metricdata.ResourceMetrics, name string) (uint64, float64, bool) {
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			if d, ok := m.Data.(metricdata.Histogram[float64]); ok && len(d.DataPoints) > 0 {
+				return d.DataPoints[0].Count, d.DataPoints[0].Sum, true
+			}
+		}
+	}
+	return 0, 0, false
 }
 
 func extractCountersByAttribute(rm metricdata.ResourceMetrics, name string) map[string]int64 {

--- a/tracker/metrics/tracker_test.go
+++ b/tracker/metrics/tracker_test.go
@@ -239,6 +239,7 @@ func TestSessionGoodput(t *testing.T) {
 
 		client, server := net.Pipe()
 		defer client.Close()
+		defer server.Close()
 		serverTracked := mt.RoutedConnection(ctx, server, adapter.InboundContext{}, nil, nil)
 
 		const n = 1_100_000 // above the 1MB goodput threshold
@@ -296,6 +297,7 @@ func TestSessionGoodputBelowThreshold(t *testing.T) {
 
 		client, server := net.Pipe()
 		defer client.Close()
+		defer server.Close()
 		serverTracked := mt.RoutedConnection(ctx, server, adapter.InboundContext{}, nil, nil)
 
 		small := []byte("only a few bytes, well under the threshold")


### PR DESCRIPTION
## Why

The measurement signal for Lantern's automatic bandit experimentation system (lantern-cloud PR #2874). To decide whether a challenger track (a new protocol/datacenter combination) actually delivers a *big win*, the evaluator needs a real per-session throughput signal it can compare between the challenger track and the incumbent, per region×country. `proxy.io` (a byte counter) can't give a rate/distribution; this adds one.

## What

`proxy.session.goodput` — a `Float64Histogram` (unit `By/s`) recorded **once at connection close** = `received bytes / connection seconds`, for sessions that moved **≥ 1 MB**.

- Both **TCP** (`conn.go`) and **UDP** (`packet_conn.go`) now accumulate per-connection received bytes (atomic) and emit at `Close()`. UDP matters because hysteria2/tuic/wireguard are packet-based.
- Tagged with `network.io.direction=receive` plus the existing attribute set, so it's sliceable by **`track` × `cloud.region`** (resource attrs from `OTEL_RESOURCE_ATTRIBUTES`) **× `geo.country.iso_code`** (point attr) — exactly the strata the experiment evaluator compares.
- No `device_id` tag (cardinality).

Since the challenger and control are separate tracks, the *arm is the track* — no per-connection experiment tagging needed; the evaluator queries this histogram's p50 by track name per stratum.

## Caveat (documented in code)

Duration is connection **open time** (includes idle), so goodput is a *floor* on true transfer speed. Both experiment arms are measured identically, so it's a fair *relative* signal, and the ≥1 MB floor filters idle-dominated noise. "Active transfer time" is a possible future refinement.

## Tests

`TestSessionGoodput` (≥1 MB session → one sample, value ≈ bytes/sec, receive tag) and `TestSessionGoodputBelowThreshold` (sub-threshold → no sample), mirroring the existing synctest harness. `go build ./...` clean; `GOEXPERIMENT=synctest go test ./tracker/metrics/` all green (run under go1.24.7 to match CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)