### PR TITLE
fix(samizdat): forward CloseWrite so TCP half-close isn't silently dropped

### DIFF
--- a/protocol/samizdat/conn.go
+++ b/protocol/samizdat/conn.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sagernet/sing/common/baderror"
 	"github.com/sagernet/sing/common/bufio/deadline"
+	N "github.com/sagernet/sing/common/network"
 )
 
 // wrapConn normalizes HTTP/2 read errors on a samizdat stream conn.
@@ -21,9 +22,10 @@ import (
 //
 // wrapConn is deliberately opaque: it does not expose Upstream(), so sing-box
 // cannot unwrap past it and read the underlying conn directly, which would
-// bypass the normalization. The cost of that opacity is the
-// NeedAdditionalReadDeadline hint sing-box would otherwise discover through the
-// Upstream() chain, so it is forwarded explicitly.
+// bypass the normalization. The cost of that opacity is that capabilities
+// sing-box would otherwise discover through the Upstream() chain must be
+// forwarded explicitly: the NeedAdditionalReadDeadline hint and TCP half-close
+// (CloseWrite), below.
 type wrapConn struct {
 	net.Conn
 }
@@ -35,4 +37,13 @@ func (c *wrapConn) Read(b []byte) (int, error) {
 
 func (c *wrapConn) NeedAdditionalReadDeadline() bool {
 	return deadline.NeedAdditionalReadDeadline(c.Conn)
+}
+
+// CloseWrite forwards TCP half-close to the underlying samizdat stream conn,
+// which maps it to an HTTP/2 END_STREAM (request side closed, response side
+// kept open). Without it, wrapConn hides the stream's CloseWrite (Upstream is
+// blocked above) and the sing-box relay silently downgrades half-close to a
+// full close.
+func (c *wrapConn) CloseWrite() error {
+	return N.CloseWrite(c.Conn)
 }

--- a/protocol/samizdat/conn_halfclose_test.go
+++ b/protocol/samizdat/conn_halfclose_test.go
@@ -1,0 +1,40 @@
+package samizdat
+
+import (
+	"net"
+	"testing"
+
+	"github.com/sagernet/sing/common"
+	N "github.com/sagernet/sing/common/network"
+)
+
+// halfCloseConn records whether CloseWrite reached the underlying conn.
+type halfCloseConn struct {
+	net.Conn
+	closeWriteCalled bool
+}
+
+func (c *halfCloseConn) CloseWrite() error {
+	c.closeWriteCalled = true
+	return nil
+}
+
+// wrapConn deliberately blocks Upstream() to preserve H2 error normalization,
+// so it must forward CloseWrite explicitly — otherwise sing-box's relay
+// (bufio.CopyConn) can't detect half-close support and silently downgrades a
+// half-close to a full close, tearing down request/response traffic early.
+func TestWrapConnForwardsCloseWrite(t *testing.T) {
+	inner := &halfCloseConn{}
+	wc := &wrapConn{Conn: inner}
+
+	// The relay gates half-close on exactly this cast.
+	if _, ok := common.Cast[N.WriteCloser](wc); !ok {
+		t.Fatal("wrapConn is not detectable as N.WriteCloser; half-close would be dropped")
+	}
+	if err := N.CloseWrite(wc); err != nil {
+		t.Fatalf("CloseWrite returned error: %v", err)
+	}
+	if !inner.closeWriteCalled {
+		t.Fatal("CloseWrite was not forwarded to the underlying stream conn")
+	}
+}


### PR DESCRIPTION
## Problem

`samizdat.wrapConn` wraps the stream conn to normalize HTTP/2 read errors, and **deliberately blocks `Upstream()`** so sing-box can't unwrap past it and bypass that normalization. It forwarded the `NeedAdditionalReadDeadline` hint explicitly — but **`CloseWrite` was overlooked.**

Consequence: sing-box's relay (`sing/common/bufio.CopyConn`) gates TCP half-close on `Cast[N.WriteCloser](conn)`. Since `wrapConn` exposed neither `CloseWrite()` nor `Upstream()`, that cast **failed**, so the relay took the full-close branch — **every half-close on a samizdat conn silently downgraded to a full close.** For peers that signal end-of-upload with `shutdown(SHUT_WR)` and then wait for the response (HTTP without Content-Length, gRPC, request-then-wait protocols), that tears the connection down early.

This is the silent-fallback failure mode of feature-detected half-close: no error, no warning — just degraded behavior.

## The capability already existed — `wrapConn` was the only wall

```mermaid
sequenceDiagram
    autonumber
    participant R as relay<br/>sing bufio.CopyConn
    participant W as wrapConn<br/>lantern-box samizdat/conn.go
    participant S as streamConn<br/>samizdat/streamconn.go
    participant H as h2StreamRWC<br/>samizdat/h2transport.go

    R->>W: Cast[WriteCloser](conn) ?
    rect rgba(255, 200, 200, 0.3)
        Note over W: BEFORE 🐛 no CloseWrite + Upstream() blocked<br/>→ cast fails → relay does a full Close on upload EOF
    end
    Note over W: AFTER ✅ CloseWrite() present → cast succeeds
    R->>W: upload EOF → N.CloseWrite(conn)
    W->>S: N.CloseWrite(c.Conn)
    S->>H: rwc.CloseWrite()
    H-->>R: HTTP/2 END_STREAM<br/>request side closed, response side stays open
```

`streamConn.CloseWrite` → `h2StreamRWC.CloseWrite` already sends an HTTP/2 `END_STREAM` (request side closed, response side kept open). `wrapConn` just hid it.

## Fix

Forward `CloseWrite` from `wrapConn` to the underlying conn (via `N.CloseWrite`, which reaches the H2 stream through the cast). This preserves the deliberate `Upstream()` opacity — it only adds the one capability that was being silently lost. `CloseRead` is intentionally **not** added: `streamConn` doesn't implement it, so advertising it would be the same false-capability anti-pattern this fixes.

## Test

`TestWrapConnForwardsCloseWrite` asserts `wrapConn` is detectable as `N.WriteCloser` (the relay's gate) and that `N.CloseWrite` reaches the underlying conn.

## Scope

Found during an audit of half-close (`CloseWrite`) support across lantern-box transports. Others: outline/reflex unwrap correctly via sing/`*tls.Conn`; the `datacap`/`metrics`/`clientcontext` chain wrappers all expose `Upstream()`; `unbounded` is datagram (N/A). `water` (`WATERConn`/`asyncCloseConn`) has the same wrapper gap but the underlying WASM conn likely can't half-close anyway — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
