### PR TITLE
feat(metrics): add optional ASN lookup to proxy.io labels

### DIFF
--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -30,6 +30,8 @@ func init() {
 	runCmd.Flags().String("config", "config.json", "Configuration file path")
 	runCmd.Flags().String("geo-city-url", "https://lanterngeo.lantern.io/GeoLite2-City.mmdb.tar.gz", "URL for downloading GeoLite2-City database")
 	runCmd.Flags().String("city-database-name", "GeoLite2-City.mmdb", "Filename for storing GeoLite2-City database")
+	runCmd.Flags().String("geo-asn-url", "", "URL for downloading GeoLite2-ASN database (enables client.asn metric label)")
+	runCmd.Flags().String("asn-database-name", "GeoLite2-ASN.mmdb", "Filename for storing GeoLite2-ASN database")
 	runCmd.Flags().String("datacap-url", "", "Datacap server URL")
 	runCmd.Flags().String("proxy-info", "", "Path to proxy info INI file")
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -103,14 +103,27 @@ func preRun(cmd *cobra.Command, args []string) {
 
 	geoCityURL, _ := cmd.Flags().GetString("geo-city-url")
 	cityDatabaseName, _ := cmd.Flags().GetString("city-database-name")
+	var countryLookup geo.CountryLookup = geo.NoLookup{}
 	if geoCityURL != "" && cityDatabaseName != "" {
-		geolookup := geo.FromWeb(
+		countryLookup = geo.FromWeb(
 			geoCityURL, cityDatabaseName,
 			24*time.Hour, cityDatabaseName,
 			geo.CountryCode,
 		)
-		metrics.SetupMetricsManager(geolookup)
 	}
+
+	geoASNURL, _ := cmd.Flags().GetString("geo-asn-url")
+	asnDatabaseName, _ := cmd.Flags().GetString("asn-database-name")
+	var asnLookup geo.ISPLookup = geo.NoLookup{}
+	if geoASNURL != "" && asnDatabaseName != "" {
+		asnLookup = geo.FromWeb(
+			geoASNURL, asnDatabaseName,
+			24*time.Hour, asnDatabaseName,
+			geo.ASN,
+		)
+	}
+
+	metrics.SetupMetricsManager(countryLookup, asnLookup)
 	if otel.Enabled() {
 		log.Info("telemetry enabled")
 

--- a/tracker/metrics/metrics.go
+++ b/tracker/metrics/metrics.go
@@ -15,11 +15,19 @@ import (
 	"go.opentelemetry.io/otel/metric/noop"
 )
 
-const countryLookupWorkers = 4
+const (
+	countryLookupWorkers = 4
+	asnLookupWorkers     = 4
+)
 
 type countryLookupRequest struct {
 	ip      net.IP
 	country *atomic.Value
+}
+
+type asnLookupRequest struct {
+	ip  net.IP
+	asn *atomic.Value
 }
 
 type metricsManager struct {
@@ -30,6 +38,9 @@ type metricsManager struct {
 
 	countryLookup  geo.CountryLookup
 	countryLookupC chan countryLookupRequest
+
+	asnLookup  geo.ISPLookup
+	asnLookupC chan asnLookupRequest
 }
 
 var metrics = &metricsManager{
@@ -39,7 +50,7 @@ var metrics = &metricsManager{
 	countryLookup: geo.NoLookup{},
 }
 
-func SetupMetricsManager(countryLookup geo.CountryLookup) {
+func SetupMetricsManager(countryLookup geo.CountryLookup, asnLookup geo.ISPLookup) {
 	meter := otel.GetMeterProvider().Meter("lantern-box")
 	if pIO, err := meter.Int64Counter("proxy.io", metric.WithUnit("bytes")); err == nil {
 		metrics.ProxyIO = pIO
@@ -65,11 +76,27 @@ func SetupMetricsManager(countryLookup geo.CountryLookup) {
 		}
 	}
 
+	if asnLookup != nil {
+		metrics.asnLookup = asnLookup
+	}
+	if _, ok := asnLookup.(geo.NoLookup); !ok && asnLookup != nil {
+		metrics.asnLookupC = make(chan asnLookupRequest, 256)
+		for range asnLookupWorkers {
+			go asnLookupWorker(metrics.asnLookupC, metrics.asnLookup)
+		}
+	}
+
 	metrics.meter = meter
 }
 
 func countryLookupWorker(ch <-chan countryLookupRequest, lookup geo.CountryLookup) {
 	for req := range ch {
 		req.country.Store(lookup.CountryCode(req.ip))
+	}
+}
+
+func asnLookupWorker(ch <-chan asnLookupRequest, lookup geo.ISPLookup) {
+	for req := range ch {
+		req.asn.Store(lookup.ASN(req.ip))
 	}
 }

--- a/tracker/metrics/tracker.go
+++ b/tracker/metrics/tracker.go
@@ -130,6 +130,7 @@ func (t *MetricsTracker) Leave(duration int64, attrs *attributes) {
 type attributes struct {
 	attrs   []attribute.KeyValue
 	country atomic.Value // string
+	asn     atomic.Value // string
 	client  *clientcontext.ClientInfo
 }
 
@@ -137,6 +138,9 @@ func (a *attributes) AsSlice() []attribute.KeyValue {
 	s := append(a.attrs,
 		semconv.GeoCountryISOCodeKey.String(a.country.Load().(string)),
 	)
+	if asn := a.asn.Load().(string); asn != "" {
+		s = append(s, semconv.ClientAsnKey.String(asn))
+	}
 	if a.client != nil {
 		s = append(s,
 			semconv.ClientPlatformKey.String(a.client.Platform),
@@ -157,12 +161,17 @@ func metadataToAttributes(metadata adapter.InboundContext) *attributes {
 		},
 	}
 	attrs.country.Store(ccNa)
+	attrs.asn.Store("")
+	ip := metadata.Source.IPAddr().IP
 	if metrics.countryLookupC != nil {
 		select {
-		case metrics.countryLookupC <- countryLookupRequest{
-			ip:      metadata.Source.IPAddr().IP,
-			country: &attrs.country,
-		}:
+		case metrics.countryLookupC <- countryLookupRequest{ip: ip, country: &attrs.country}:
+		default:
+		}
+	}
+	if metrics.asnLookupC != nil {
+		select {
+		case metrics.asnLookupC <- asnLookupRequest{ip: ip, asn: &attrs.asn}:
 		default:
 		}
 	}


### PR DESCRIPTION
Adds a client.asn attribute (e.g. "AS15169") to proxy.io samples when a GeoLite2-ASN database is configured. Follows the same async worker pattern as country lookup. Enable via --geo-asn-url at startup; omitting the flag leaves behaviour unchanged.