### PR TITLE
feat(autoselect): persist hard-demote state on TagHistory

### DIFF
--- a/adapter/autoselect_history.go
+++ b/adapter/autoselect_history.go
@@ -29,7 +29,10 @@ type TagHistory struct {
 	// never enter this window; entries age out naturally on the next
 	// mutation older than the group's userFailureWindow.
 	UserFailures []time.Time `json:"user_failures,omitempty"`
-	UpdatedAt    time.Time   `json:"updated_at"`
+	// HardDemoted reports whether the member has reached the hard-demote
+	// tier from its own recorded probe and user-traffic failures.
+	HardDemoted bool      `json:"hard_demoted,omitempty"`
+	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 // AutoSelectHistoryStorage is the store the MutableAutoSelect group

--- a/protocol/group/mutableautoselect.go
+++ b/protocol/group/mutableautoselect.go
@@ -952,7 +952,7 @@ func (s *MutableAutoSelect) mutateHistory(tag string, fn func(*localHistory, tim
 		return false
 	}
 	if s.history != nil {
-		s.history.Store(tag, h.toTagHistory(now, s.hist.userFailureWindow))
+		s.history.Store(tag, h.toTagHistory(now, s.hist))
 	}
 	return true
 }

--- a/protocol/group/mutableautoselect_history.go
+++ b/protocol/group/mutableautoselect_history.go
@@ -134,14 +134,19 @@ func (h *localHistory) snapshot(now time.Time, window time.Duration) (lastDelay 
 // toTagHistory snapshots the localHistory into adapter.TagHistory form.
 // updatedAt is a parameter so a single mutation call uses one
 // timestamp across the in-memory entry and the persisted snapshot.
-func (h *localHistory) toTagHistory(updatedAt time.Time, window time.Duration) *adapter.TagHistory {
+// HardDemoted is the intrinsic tier: selfMs/bestAltMs are zeroed so the
+// switch-penalty boost can't apply, classifying the member from its own
+// failure history alone.
+func (h *localHistory) toTagHistory(updatedAt time.Time, p historyParams) *adapter.TagHistory {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.userFailures = pruneUserFailures(h.userFailures, updatedAt, window)
+	h.userFailures = pruneUserFailures(h.userFailures, updatedAt, p.userFailureWindow)
+	hard, _, _ := demoted(h.consecutiveFailures, uint32(len(h.userFailures)), 0, 0, p)
 	out := &adapter.TagHistory{
 		LastSuccessDelayMs:  h.lastSuccessDelayMs,
 		LastOutcomeAt:       h.lastOutcomeAt,
 		ConsecutiveFailures: h.consecutiveFailures,
+		HardDemoted:         hard,
 		UpdatedAt:           updatedAt,
 	}
 	if len(h.userFailures) > 0 {

--- a/protocol/group/mutableautoselect_test.go
+++ b/protocol/group/mutableautoselect_test.go
@@ -189,13 +189,17 @@ func TestToTagHistory_HardDemoted(t *testing.T) {
 	assert.False(t, newLocalHistory().toTagHistory(now, p).HardDemoted,
 		"fresh history is not hard demoted")
 
+	// Failures are injected in the recent past so the snapshot's updatedAt
+	// (now) is >= every recorded outcome, as it is in real usage where a
+	// mutation and its persisted snapshot share one timestamp.
+
 	// Consecutive probe failures at the limit are hard even alongside a
 	// healthy prior success delay: toTagHistory zeroes selfMs/bestAltMs,
 	// so the switch-penalty boost can never rescue the persisted tier.
 	consecHard := newLocalHistory()
-	consecHard.recordProbeSuccess(10, now)
+	consecHard.recordProbeSuccess(10, now.Add(-time.Hour))
 	for i := uint32(0); i < p.consecutiveFailLimit; i++ {
-		consecHard.recordProbeFailure(now.Add(time.Duration(i) * time.Second))
+		consecHard.recordProbeFailure(now.Add(-time.Duration(i) * time.Second))
 	}
 	got := consecHard.toTagHistory(now, p)
 	assert.True(t, got.HardDemoted, "consecutive failures at limit are hard demoted")
@@ -205,14 +209,14 @@ func TestToTagHistory_HardDemoted(t *testing.T) {
 	// are not hard demoted.
 	soft := newLocalHistory()
 	for i := uint32(0); i < p.softFailLimit; i++ {
-		soft.addUserFailure(now.Add(time.Duration(i)*time.Second), p.userFailureWindow, 0)
+		soft.addUserFailure(now.Add(-time.Duration(i)*time.Second), p.userFailureWindow, 0)
 	}
 	assert.False(t, soft.toTagHistory(now, p).HardDemoted,
 		"user failures below the hard limit are not hard demoted")
 
 	userHard := newLocalHistory()
 	for i := uint32(0); i < p.consecutiveFailLimit; i++ {
-		userHard.addUserFailure(now.Add(time.Duration(i)*time.Second), p.userFailureWindow, 0)
+		userHard.addUserFailure(now.Add(-time.Duration(i)*time.Second), p.userFailureWindow, 0)
 	}
 	assert.True(t, userHard.toTagHistory(now, p).HardDemoted,
 		"user failures at the hard limit are hard demoted")

--- a/protocol/group/mutableautoselect_test.go
+++ b/protocol/group/mutableautoselect_test.go
@@ -182,6 +182,42 @@ func TestLocalHistory_FailureDoesNotClearLastSuccessDelay(t *testing.T) {
 	assert.Equal(t, uint32(1), consec, "consecutive failures bump")
 }
 
+func TestToTagHistory_HardDemoted(t *testing.T) {
+	p := defaultHistoryParams()
+	now := time.Now()
+
+	assert.False(t, newLocalHistory().toTagHistory(now, p).HardDemoted,
+		"fresh history is not hard demoted")
+
+	// Consecutive probe failures at the limit are hard even alongside a
+	// healthy prior success delay: toTagHistory zeroes selfMs/bestAltMs,
+	// so the switch-penalty boost can never rescue the persisted tier.
+	consecHard := newLocalHistory()
+	consecHard.recordProbeSuccess(10, now)
+	for i := uint32(0); i < p.consecutiveFailLimit; i++ {
+		consecHard.recordProbeFailure(now.Add(time.Duration(i) * time.Second))
+	}
+	got := consecHard.toTagHistory(now, p)
+	assert.True(t, got.HardDemoted, "consecutive failures at limit are hard demoted")
+	assert.Equal(t, uint32(10), got.LastSuccessDelayMs, "a fast prior success must not clear the tier")
+
+	// User-traffic failures past the soft limit but below the hard limit
+	// are not hard demoted.
+	soft := newLocalHistory()
+	for i := uint32(0); i < p.softFailLimit; i++ {
+		soft.addUserFailure(now.Add(time.Duration(i)*time.Second), p.userFailureWindow, 0)
+	}
+	assert.False(t, soft.toTagHistory(now, p).HardDemoted,
+		"user failures below the hard limit are not hard demoted")
+
+	userHard := newLocalHistory()
+	for i := uint32(0); i < p.consecutiveFailLimit; i++ {
+		userHard.addUserFailure(now.Add(time.Duration(i)*time.Second), p.userFailureWindow, 0)
+	}
+	assert.True(t, userHard.toTagHistory(now, p).HardDemoted,
+		"user failures at the hard limit are hard demoted")
+}
+
 func TestLocalHistory_UserFailuresIndependentOfProbeOutcomes(t *testing.T) {
 	// A probe success must not clear user failures: probe and user
 	// destinations live behind different classifiers, and a censor that


### PR DESCRIPTION
This pull request introduces a new `HardDemoted` field to the `TagHistory` struct and ensures that the demotion status is accurately tracked and persisted based on probe and user-traffic failures. Additionally, comprehensive unit tests are added to validate the correct behavior of the new logic.

Key changes include:

**Feature Addition: Hard Demotion Tracking**
* Added a `HardDemoted` boolean field to the `TagHistory` struct in `adapter/autoselect_history.go` to indicate if a member has reached the hard-demote tier due to its own failure history.
* Updated the `toTagHistory` method in `protocol/group/mutableautoselect_history.go` to compute and set the `HardDemoted` status based on consecutive probe and user-traffic failures, using the new `historyParams` struct for configuration.
* Modified the call to `toTagHistory` in `protocol/group/mutableautoselect.go` to pass the full `historyParams` instead of just the user failure window, ensuring all necessary parameters are available for demotion logic.
