### PR TITLE
fix(metrics): remove 1MB goodput floor + emit track as queryable point attr

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,6 +58,9 @@ func preRun(cmd *cobra.Command, args []string) {
 	}
 
 	var attrs []attribute.KeyValue
+	// track is emitted both as a resource attr (below, via resourceAttrs) and,
+	// for the goodput histogram, as a queryable point attr (via SetupMetricsManager).
+	var track string
 	// Attempt to read proxy info, but this is merely informational,
 	// and may not be needed for every subcommand.
 	proxyInfoPath, _ := cmd.Flags().GetString("proxy-info")
@@ -66,6 +69,7 @@ func preRun(cmd *cobra.Command, args []string) {
 			log.Warn("could not read proxy info, skipping attribute addition: ", err)
 		} else {
 			attrs = info.resourceAttrs()
+			track = info.Track
 		}
 	} else {
 		log.Info("no proxy-info path provided, skipping attribute addition")
@@ -109,7 +113,7 @@ func preRun(cmd *cobra.Command, args []string) {
 			24*time.Hour, cityDatabaseName,
 			geo.CountryCode,
 		)
-		metrics.SetupMetricsManager(geolookup)
+		metrics.SetupMetricsManager(geolookup, track)
 	}
 	if otel.Enabled() {
 		log.Info("telemetry enabled")

--- a/test/e2e/telemetry_test.go
+++ b/test/e2e/telemetry_test.go
@@ -77,7 +77,7 @@ func TestTelemetryE2E(t *testing.T) {
 	shutdownTracer, err := otel.InitGlobalTracerProvider()
 	require.NoError(t, err)
 
-	metrics.SetupMetricsManager(geo.NoLookup{})
+	metrics.SetupMetricsManager(geo.NoLookup{}, "")
 
 	// --- Start upstream HTTP server ---
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tracker/metrics/metrics.go
+++ b/tracker/metrics/metrics.go
@@ -29,6 +29,13 @@ type metricsManager struct {
 	duration       metric.Int64Histogram
 	sessionGoodput metric.Float64Histogram
 
+	// track is the proxy's experiment track (from proxy-info). It is also an
+	// OTEL resource attribute (keyed "proxy.track"), but the metrics pipeline
+	// does not expose resource attrs as queryable labels, so it's re-emitted as
+	// a point attribute keyed "track" on the goodput sample, which is the key
+	// the bandit evaluator filters/groups by.
+	track string
+
 	countryLookup  geo.CountryLookup
 	countryLookupC chan countryLookupRequest
 }
@@ -41,7 +48,8 @@ var metrics = &metricsManager{
 	countryLookup:  geo.NoLookup{},
 }
 
-func SetupMetricsManager(countryLookup geo.CountryLookup) {
+func SetupMetricsManager(countryLookup geo.CountryLookup, track string) {
+	metrics.track = track
 	meter := otel.GetMeterProvider().Meter("lantern-box")
 	if pIO, err := meter.Int64Counter("proxy.io", metric.WithUnit("bytes")); err == nil {
 		metrics.ProxyIO = pIO
@@ -57,12 +65,17 @@ func SetupMetricsManager(countryLookup geo.CountryLookup) {
 		metrics.duration = duration
 	}
 	// Track per-session download goodput (received bytes per second of connection
-	// lifetime), recorded once at close for sessions that moved at least
-	// goodputMinBytes. Sliceable by track (resource attr) × cloud.region (resource
-	// attr) × geo.country.iso_code (point attr) so the bandit experiment evaluator
-	// can compare a challenger track's median goodput against the incumbent's. Unit
-	// "bytes/s" matches proxy.io's "bytes" spelling for consistency within this
-	// package's metrics.
+	// lifetime), recorded once at close for any session that moved >0 bytes over a
+	// >0 duration (see recordGoodput; no byte floor). The bandit experiment
+	// evaluator slices this by three QUERYABLE POINT attributes — "track"
+	// (the bare key, not the "proxy.track" resource attr), geo.country.iso_code,
+	// and network.io.direction='receive' — to compare a challenger track's
+	// median goodput against the incumbent's per (track, country). These must be
+	// point attributes, not OTEL resource attributes: the metrics pipeline does
+	// not expose resource attrs as queryable labels (this is why track is
+	// re-emitted as a "track" point attr in recordGoodput even though it is also
+	// a "proxy.track" resource attr). Unit "bytes/s" matches proxy.io's "bytes"
+	// spelling for consistency within this package's metrics.
 	goodput, err := meter.Float64Histogram("proxy.session.goodput",
 		metric.WithUnit("bytes/s"),
 		metric.WithDescription("Per-session download goodput: received bytes per second of connection lifetime"))

--- a/tracker/metrics/tracker.go
+++ b/tracker/metrics/tracker.go
@@ -20,12 +20,6 @@ const (
 	tx ioAttr = "transmit"
 
 	ccNa = "n/a"
-
-	// goodputMinBytes is the minimum received bytes a session must have moved
-	// before its goodput sample is recorded. Filters out idle/tiny connections
-	// whose bytes/duration is dominated by setup and idle time rather than
-	// actual transfer speed.
-	goodputMinBytes = 1_000_000
 )
 
 type ioAttr string
@@ -134,23 +128,50 @@ func (t *MetricsTracker) Leave(duration int64, attrs *attributes) {
 }
 
 // recordGoodput records a session's download goodput (received bytes per
-// second of connection lifetime) at close, for sessions that moved at least
-// goodputMinBytes. durationMs is the connection's open time; it includes idle
-// periods, so this is a floor on true transfer speed — but both arms of a
-// bandit experiment are measured identically, so it's a fair relative signal,
-// and the byte floor filters the worst idle-dominated noise.
+// second of connection lifetime) at close. It emits for every session that
+// moved any bytes over a non-zero duration — there is NO byte floor.
+//
+// The floor used to be 1 MB, but the floored direction is the small
+// client→proxy (upload / "receive") side, which averages ~22 KB/session in
+// prod — ~45× under the old 1 MB floor. Only ~0.04% of sessions ever cleared
+// it, so the floor erased the goodput signal for the ~99.96% of real (probe,
+// connectivity-check, blocked-then-retry, small-page) traffic that dominates
+// censored markets, and the bandit evaluator false-retired live challengers as
+// "starved". Very short/tiny sessions do produce noisy per-second rates, but
+// the evaluator compares per-(track, country) p50 medians, which are robust to
+// that tail — so we keep the sample rather than drop, cap, or weight it.
+//
+// durationMs is the connection's open time; it includes idle periods, so this
+// is a floor on true transfer speed — but both arms of a bandit experiment are
+// measured identically, so it's a fair relative signal.
+//
+// The sample carries the track (point-attr key "track", not the resource attr
+// "proxy.track") and network.io.direction='receive' as point (not resource)
+// attributes, plus geo.country.iso_code via attrs.AsSlice(), so the evaluator
+// can filter/group by track and country.
 func (t *MetricsTracker) recordGoodput(rxBytes, durationMs int64, attrs *attributes) {
-	if rxBytes < goodputMinBytes || durationMs <= 0 {
+	if rxBytes <= 0 || durationMs <= 0 {
 		return
 	}
 	goodput := float64(rxBytes) / (float64(durationMs) / 1000.0)
-	// Copy into a slice sized for the extra element rather than appending onto
+	// Copy into a slice sized for the extra elements rather than appending onto
 	// AsSlice()'s result in place, so we never share a backing array with a
 	// concurrent reporter.
 	base := attrs.AsSlice()
-	a := make([]attribute.KeyValue, 0, len(base)+1)
+	a := make([]attribute.KeyValue, 0, len(base)+2)
 	a = append(a, base...)
-	a = append(a, semconv.NetworkIODirectionKey.String(string(rx)))
+	a = append(a,
+		semconv.NetworkIODirectionKey.String(string(rx)),
+		// The evaluator filters `track IN [...]` and groups by `track` on the
+		// bare, literal point-attribute key "track" (lantern-cloud
+		// GoodputByStratum: filter + queryScalar groupKeys{"track", ...} +
+		// series label s.labels["track"]). track is ALSO an OTEL resource attr,
+		// but keyed "proxy.track" (semconv.ProxyTrackKey) and the metrics
+		// pipeline doesn't expose resource attrs as queryable labels — so the
+		// point attr must use the bare "track" key, NOT semconv.ProxyTrackKey.
+		// (Mirrors http-proxy #675's attribute.String("track", ...).)
+		attribute.String("track", metrics.track),
+	)
 	metrics.sessionGoodput.Record(context.Background(), goodput, metric.WithAttributes(a...))
 }
 

--- a/tracker/metrics/tracker_test.go
+++ b/tracker/metrics/tracker_test.go
@@ -225,8 +225,8 @@ func TestDeviceConnectedSpanNoClientInfo(t *testing.T) {
 // TestSessionGoodput verifies the per-session download goodput histogram is
 // emitted once at close, with the value ~= received bytes / connection seconds
 // and — crucially for the bandit evaluator — the three queryable POINT
-// attributes it filters/groups by: network.io.direction='receive', proxy.track,
-// and geo.country.iso_code.
+// attributes it filters/groups by: network.io.direction='receive', the bare
+// "track" key (NOT the "proxy.track" resource attr), and geo.country.iso_code.
 func TestSessionGoodput(t *testing.T) {
 	synctest.Run(func() {
 		reader := metric.NewManualReader()

--- a/tracker/metrics/tracker_test.go
+++ b/tracker/metrics/tracker_test.go
@@ -31,7 +31,7 @@ func TestTracker(t *testing.T) {
 		provider := metric.NewMeterProvider(metric.WithReader(reader))
 		sdkotel.SetMeterProvider(provider)
 
-		SetupMetricsManager(geo.NoLookup{})
+		SetupMetricsManager(geo.NoLookup{}, "")
 
 		ctx := context.Background()
 		metricsTracker := NewTracker(ctx)
@@ -90,7 +90,7 @@ func TestTrackerWithClientInfo(t *testing.T) {
 		provider := metric.NewMeterProvider(metric.WithReader(reader))
 		sdkotel.SetMeterProvider(provider)
 
-		SetupMetricsManager(geo.NoLookup{})
+		SetupMetricsManager(geo.NoLookup{}, "")
 
 		info := clientcontext.ClientInfo{
 			DeviceID: "dev-42",
@@ -223,15 +223,17 @@ func TestDeviceConnectedSpanNoClientInfo(t *testing.T) {
 }
 
 // TestSessionGoodput verifies the per-session download goodput histogram is
-// emitted once at close for a session that moved >= goodputMinBytes, with the
-// value ~= received bytes / connection seconds and a receive direction tag.
+// emitted once at close, with the value ~= received bytes / connection seconds
+// and — crucially for the bandit evaluator — the three queryable POINT
+// attributes it filters/groups by: network.io.direction='receive', proxy.track,
+// and geo.country.iso_code.
 func TestSessionGoodput(t *testing.T) {
 	synctest.Run(func() {
 		reader := metric.NewManualReader()
 		provider := metric.NewMeterProvider(metric.WithReader(reader))
 		sdkotel.SetMeterProvider(provider)
 
-		SetupMetricsManager(geo.NoLookup{})
+		SetupMetricsManager(geo.NoLookup{}, "challenger-01")
 
 		ctx := context.Background()
 		mt := NewTracker(ctx)
@@ -242,7 +244,7 @@ func TestSessionGoodput(t *testing.T) {
 		defer server.Close()
 		serverTracked := mt.RoutedConnection(ctx, server, adapter.InboundContext{}, nil, nil)
 
-		const n = 1_100_000 // above the 1MB goodput threshold
+		const n = 1_100_000
 		done := make(chan int, 1)
 		go func() {
 			buf := make([]byte, n)
@@ -271,25 +273,37 @@ func TestSessionGoodput(t *testing.T) {
 		reader.Collect(ctx, &rm)
 
 		count, sum, found := histogramCountSum(rm, "proxy.session.goodput")
-		require.True(t, found, "goodput histogram should be emitted for a >=1MB session")
+		require.True(t, found, "goodput histogram should be emitted")
 		assert.Equal(t, uint64(1), count, "exactly one goodput sample")
 		// ~1s open duration → goodput ~= received bytes per second.
 		assert.InDelta(t, float64(n), sum, float64(n)*0.05)
 
+		// The evaluator filters `network.io.direction = 'receive'` and
+		// `track IN [...]`, and groups by `track, geo.country.iso_code`. All
+		// three must be present as POINT attributes on the sample, and track
+		// must use the bare "track" key (the "proxy.track" resource attr is not
+		// a queryable label). Keys/values verified against lantern-cloud
+		// GoodputByStratum (cmd/api/experiment/signoz.go).
 		attrs := extractAttrs(rm, "proxy.session.goodput")
-		assert.Equal(t, "receive", attrs["network.io.direction"])
+		assert.Equal(t, "receive", attrs["network.io.direction"], "direction point attr")
+		assert.Equal(t, "challenger-01", attrs["track"], "track point attr (bare 'track' key)")
+		assert.Nil(t, attrs["proxy.track"], "goodput must not rely on the proxy.track resource key")
+		assert.Equal(t, ccNa, attrs["geo.country.iso_code"], "country point attr")
 	})
 }
 
-// TestSessionGoodputBelowThreshold verifies a sub-threshold session emits no
-// goodput sample.
-func TestSessionGoodputBelowThreshold(t *testing.T) {
+// TestSessionGoodputSmallSession is the core regression test for the byte-floor
+// removal: a ~20 KB session (near the real per-session average, ~45× under the
+// old 1 MB floor) must now record a goodput sample. Before the fix this emitted
+// nothing, which is what blinded the evaluator's goodput axis for the sing-box
+// protocol fleet.
+func TestSessionGoodputSmallSession(t *testing.T) {
 	synctest.Run(func() {
 		reader := metric.NewManualReader()
 		provider := metric.NewMeterProvider(metric.WithReader(reader))
 		sdkotel.SetMeterProvider(provider)
 
-		SetupMetricsManager(geo.NoLookup{})
+		SetupMetricsManager(geo.NoLookup{}, "")
 
 		ctx := context.Background()
 		mt := NewTracker(ctx)
@@ -300,16 +314,61 @@ func TestSessionGoodputBelowThreshold(t *testing.T) {
 		defer server.Close()
 		serverTracked := mt.RoutedConnection(ctx, server, adapter.InboundContext{}, nil, nil)
 
-		small := []byte("only a few bytes, well under the threshold")
-		done := make(chan struct{})
+		const n = 20_000 // well under the removed 1 MB floor
+		done := make(chan int, 1)
 		go func() {
-			buf := make([]byte, len(small))
-			_, _ = serverTracked.Read(buf)
-			close(done)
+			buf := make([]byte, n)
+			got := 0
+			for got < n {
+				r, err := serverTracked.Read(buf[got:])
+				if err != nil {
+					break
+				}
+				got += r
+			}
+			done <- got
 		}()
-		_, err := client.Write(small)
+		_, err := client.Write(make([]byte, n))
 		require.NoError(t, err)
-		<-done
+		require.Equal(t, n, <-done)
+
+		// ~2s open duration → goodput ~= n/2 bytes/s.
+		time.Sleep(2 * time.Second)
+		synctest.Wait()
+
+		require.NoError(t, serverTracked.Close())
+		synctest.Wait()
+
+		var rm metricdata.ResourceMetrics
+		reader.Collect(ctx, &rm)
+
+		count, sum, found := histogramCountSum(rm, "proxy.session.goodput")
+		require.True(t, found, "a 20 KB session must record a goodput sample after floor removal")
+		assert.Equal(t, uint64(1), count, "exactly one goodput sample")
+		assert.InDelta(t, float64(n)/2.0, sum, float64(n)/2.0*0.05)
+	})
+}
+
+// TestSessionGoodputZeroBytes verifies the rxBytes > 0 guard: a session that
+// received no bytes records nothing even though it was open for a while.
+func TestSessionGoodputZeroBytes(t *testing.T) {
+	synctest.Run(func() {
+		reader := metric.NewManualReader()
+		provider := metric.NewMeterProvider(metric.WithReader(reader))
+		sdkotel.SetMeterProvider(provider)
+
+		SetupMetricsManager(geo.NoLookup{}, "")
+
+		ctx := context.Background()
+		mt := NewTracker(ctx)
+		defer mt.Close()
+
+		client, server := net.Pipe()
+		defer client.Close()
+		defer server.Close()
+		serverTracked := mt.RoutedConnection(ctx, server, adapter.InboundContext{}, nil, nil)
+
+		// No bytes received; only elapse time so the duration is non-zero.
 		time.Sleep(time.Second)
 		synctest.Wait()
 
@@ -319,8 +378,29 @@ func TestSessionGoodputBelowThreshold(t *testing.T) {
 		var rm metricdata.ResourceMetrics
 		reader.Collect(ctx, &rm)
 		_, _, found := histogramCountSum(rm, "proxy.session.goodput")
-		assert.False(t, found, "no goodput sample below the byte threshold")
+		assert.False(t, found, "no goodput sample when zero bytes were received")
 	})
+}
+
+// TestSessionGoodputZeroDuration verifies the durationMs > 0 guard directly.
+// recordGoodput doesn't touch its receiver, so a zero-value tracker is fine;
+// this keeps the divide-by-zero guard deterministic (a net.Pipe close can race
+// to a sub-millisecond, but never exactly-zero, virtual duration).
+func TestSessionGoodputZeroDuration(t *testing.T) {
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	sdkotel.SetMeterProvider(provider)
+
+	SetupMetricsManager(geo.NoLookup{}, "")
+
+	mt := &MetricsTracker{}
+	attrs := metadataToAttributes(adapter.InboundContext{})
+	mt.recordGoodput(1_000_000, 0, attrs)
+
+	var rm metricdata.ResourceMetrics
+	reader.Collect(context.Background(), &rm)
+	_, _, found := histogramCountSum(rm, "proxy.session.goodput")
+	assert.False(t, found, "no goodput sample for zero duration")
 }
 
 func histogramCountSum(rm metricdata.ResourceMetrics, name string) (uint64, float64, bool) {


### PR DESCRIPTION
## What & why

`proxy.session.goodput` is recorded once per session at connection close (in `tracker/metrics`), but only for sessions that moved **≥ 1 MB** in the `receive` direction:

```go
const goodputMinBytes = 1_000_000
func (t *MetricsTracker) recordGoodput(rxBytes, durationMs int64, attrs *attributes) {
    if rxBytes < goodputMinBytes || durationMs <= 0 { return }  // < 1 MB → no sample
    ...
}
```

The bandit experiment evaluator (lantern-cloud `cmd/api/experiment/experiment.go` via `GoodputByStratum`) compares per-session download **goodput** between a challenger config and the incumbent, and uses the per-`(track, country)` **sample count** as a starvation signal. On prod, challengers were serving huge real traffic (hundreds of thousands of client callbacks) but emitting ~0 goodput samples, so ~79% were false-retired as "starved."

**Root cause: the 1 MB per-session floor is applied to the `receive` direction — the *small* (client→proxy / upload) side of a session — which averages ~22 KB/session in prod, ~45× under the floor.** Only ~0.04% of sessions ever cleared it. Small-but-real sessions (probes, connectivity checks, blocked-then-retry, small pages — which dominate censored markets) recorded a `bandit.callback` but no goodput sample.

This is the **sing-box / lantern-box** binary (`service.name=vps-proxy`), which serves reflex, samizdat, meek, unbounded, wireguard, hysteria2, vless, trojan, amnezia, and sing-box-native shadowsocks/vmess. It has the **identical floor** that was already removed from the http-proxy binary in getlantern/http-proxy#678, which serves the other half of the fleet.

## Part 1 — remove the byte floor

`recordGoodput` now emits for **any session with `rxBytes > 0 && durationMs > 0`** (the `goodputMinBytes` const is gone). Both `Conn` (TCP) and `PacketConn` (UDP) close paths already call it, so all transports are covered.

Very short/tiny sessions produce noisy per-second rates, but the evaluator compares per-`(track, country)` **p50 medians** (robust to that tail), so we keep the sample rather than drop/cap/weight it. Mirrors http-proxy#678 exactly.

## Part 2 — CRITICAL: make goodput sliceable by the evaluator (verified against lantern-cloud, not assumed)

Removing the floor is necessary but not sufficient. I read the **actual evaluator** (`lantern-cloud/cmd/api/experiment/signoz.go`), not just the http-proxy PR:

```go
// GoodputByStratum
filter := "track IN [...] AND network.io.direction = 'receive'"   // line 69
// queryScalar
groupKeys: []string{"track", "geo.country.iso_code"}              // line 263
// parseGoodputGroups
track: s.labels["track"]                                          // line 454
```

So the histogram must carry all three as **queryable POINT attributes** (the metrics pipeline does not expose OTEL *resource* attributes as labels), and **track must use the bare key `"track"`**:

| attribute | evaluator key | lantern-box before | after |
|---|---|---|---|
| direction | `network.io.direction` = `receive` | ✅ point attr (in `recordGoodput`) | unchanged |
| country | `geo.country.iso_code` | ✅ point attr (via `attrs.AsSlice()`) | unchanged |
| track | `track` (bare key) | ❌ **resource-only, and only as `proxy.track`** | ✅ **added as `attribute.String("track", …)` point attr** |

**`track` was the gap.** It was set only as an OTEL *resource* attribute, and only under the key `proxy.track` (`semconv.ProxyTrackKey`, via `cmd`'s `resourceAttrs()` → `WithResource`). The evaluator filters/groups on the bare `track` label, which nothing emitted — so even with the floor gone, goodput would still be unsliceable for lantern-box. Fixed by plumbing the track value into the metrics manager and emitting `attribute.String("track", metrics.track)` on the goodput sample (matches http-proxy#675's `attribute.String("track", ins.track)`). The `proxy.track` resource attr is left in place for traces/other metrics.

> Note: the brief/PR#675 mention `semconv.ProxyTrackKey`, but that is the *resource* key (`proxy.track`). The evaluator reads the bare `track` label — confirmed in lantern-cloud source — so the point attr uses `"track"`, not `semconv.ProxyTrackKey`.

Country is emitted per session via `attrs.AsSlice()` as `geo.country.iso_code`; it resolves to `n/a` only when no geo lookup is configured or the async lookup hasn't completed (prod runs `geo.FromWeb`). Metric name is unchanged (`proxy.session.goodput`); SigNoz splits it into the `proxy.session.goodput.bucket` / `.count` streams the evaluator reads.

## Tests (`tracker/metrics/tracker_test.go`)

- **`TestSessionGoodputSmallSession`** (new, the core regression) — 20 KB over 2s now records exactly one sample. Fails pre-fix (20 KB < 1 MB floor).
- **`TestSessionGoodputZeroBytes`** (new) — a 0-byte session records nothing (`rxBytes > 0` guard).
- **`TestSessionGoodputZeroDuration`** (new) — `durationMs = 0` records nothing (`durationMs > 0` guard).
- **`TestSessionGoodput`** (updated) — asserts the sample carries `track` (bare key, **and not** `proxy.track`), `geo.country.iso_code`, and `network.io.direction='receive'` as point attrs — the exact keys `GoodputByStratum` uses.

No `sync.Once` test-isolation trap here (the one http-proxy#678 had to add `ResetForTest()` for): lantern-box's `SetupMetricsManager` re-creates the instruments on each call, so per-test in-memory meter providers are honored. `go build ./...` and `go test ./tracker/...` pass clean.

## Scope / rollout

- Emitter side for sing-box protocols only. Companions (already done, not here): http-proxy#678 (floor) and lantern-cloud#2993 (starvation re-gated on client attempts). Together they restore both the liveness gate and the goodput decision axis across the whole fleet.
- **Latent, flagged, out of scope:** goodput measures the `receive` = client→proxy **upload** side (~22 KB avg), described as "download". The direction is preserved (the reader filters `receive`); changing which direction is measured is a coordinated emitter+reader change.
- ⚠️ **Goodput drives real prod promote/retire decisions — coordinate before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
