### PR TITLE
deps: bump broflake for unbounded leak/retry fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ replace github.com/refraction-networking/water => github.com/getlantern/water v0
 require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52
-	github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc
+	github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86
 	github.com/getlantern/geo v0.0.0-20241129152027-2fc88c10f91e
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395
 	github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/gaukas/wazerofs v0.1.0 h1:wIkW1bAxSnpaaVkQ5LOb1tm1BXdVap3eKjJpVWIqt2E
 github.com/gaukas/wazerofs v0.1.0/go.mod h1:+JECB9Fwt0taPqSgHckG9lmT3tcoVK+9VJozTsq9UlI=
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 h1:w2/RqYPw7PbTYfUMS2aToD5DMKLBnQed+fkTEYTKAqQ=
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52/go.mod h1:PrNR8tMXO26YNs8K9653XCUH7u2Kv4OdfFC3Ke1GsX0=
-github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc h1:AVY56mzJHM4CBTrW9oBgpShB5S68gGunvk9GMvJrkzM=
-github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc/go.mod h1:bIxM6xon/ADgprn6tZXYdXGrUIMCzq6u8zO9rET50IE=
+github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86 h1:r7j54Ol1wak59OY0SK2Fw5lOI3YvrAEDW3QAQEj12mA=
+github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86/go.mod h1:bIxM6xon/ADgprn6tZXYdXGrUIMCzq6u8zO9rET50IE=
 github.com/getlantern/context v0.0.0-20190109183933-c447772a6520/go.mod h1:L+mq6/vvYHKjCX2oez0CgEAJmbq1fbb/oNJIWQkBybY=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=


### PR DESCRIPTION
## Why

The consumer-side unbounded memory-leak fixes (getlantern/engineering#3698) live in broflake. `protocol/unbounded` imports `broflake/clientcore` **directly**, so lantern-box is the correct home for the bump — downstream (radiance) then picks it up by bumping lantern-box, instead of overriding the transitive broflake version in its own go.mod (which is the fragile pattern that shipped stale code via gomobile on 2026-04-13).

## What

Bumps `github.com/getlantern/broflake` `c4d1516` → `f2cacf69`, pulling in:

- **#371** — engine teardown no longer leaks the bus observer, routers, UI ticker, or a live `PeerConnection` per connect/disconnect cycle.
- **#372** — consumer signaling backoff is context-aware (`sleepOrDone`), so a torn-down outbound exits its retry backoff immediately instead of lingering a full `ErrorBackoff` (stacked overlapping FSMs during network roaming).
- **#373** — `QUICLayer` initializes `ctx`/`cancel` in its constructor, fixing the `Close()` data race + lost-cancel leak.

## Verification

- `go build ./protocol/... ./option/...` passes.
- `go test ./protocol/unbounded/` passes.
- Confirmed the fixes are in the resolved broflake (`sleepOrDone` + the `QUICLayer` guard present).

## Follow-up

Once this merges and is tagged (next: `v0.0.103`), radiance#567 will be repointed to bump **lantern-box** to that release rather than overriding broflake directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)