### PR TITLE
fix: treat removal from a closed group as success, not an error

### DIFF
--- a/adapter/group.go
+++ b/adapter/group.go
@@ -1,10 +1,15 @@
 package adapter
 
 import (
+	"errors"
 	"net"
 
 	"github.com/sagernet/sing-box/adapter"
 )
+
+// ErrGroupClosed is returned by MutableOutboundGroup Add/Remove when the
+// group has already been torn down.
+var ErrGroupClosed = errors.New("group is closed")
 
 type MutableOutboundGroup interface {
 	adapter.OutboundGroup

--- a/adapter/groups/manager.go
+++ b/adapter/groups/manager.go
@@ -220,12 +220,12 @@ func (m *MutableGroupManager) RemoveFromGroup(group, tag string) error {
 		// The group was torn down concurrently (e.g. servers-updated racing
 		// tunnel shutdown). The tag is vacuously no longer a member, so fall
 		// through and still queue the underlying outbound for cleanup.
-		m.removalQueue.logger.Debug("group already closed, skipping group removal", slog.String("group", group), slog.String("tag", tag))
+		m.removalQueue.logger.Debug("group already closed, treating tag as removed and continuing outbound cleanup", slog.String("group", group), slog.String("tag", tag))
 	case err != nil:
 		return fmt.Errorf("failed to remove %s from %s: %w", tag, group, err)
 	case n == 0:
 		// Tag wasn't a member; removal is idempotent.
-		m.removalQueue.logger.Debug("tag not in group, nothing to remove", slog.String("group", group), slog.String("tag", tag))
+		m.removalQueue.logger.Debug("tag not in group, continuing outbound cleanup", slog.String("group", group), slog.String("tag", tag))
 	}
 
 	outbound, exists := m.outboundMgr.Outbound(tag)

--- a/adapter/groups/manager.go
+++ b/adapter/groups/manager.go
@@ -215,11 +215,17 @@ func (m *MutableGroupManager) RemoveFromGroup(group, tag string) error {
 	}
 
 	n, err := groupObj.Remove(tag)
-	if err != nil || n == 0 {
-		if err == nil {
-			err = errors.New("unknown")
-		}
+	switch {
+	case errors.Is(err, adapter.ErrGroupClosed):
+		// The group was torn down concurrently (e.g. servers-updated racing
+		// tunnel shutdown). The tag is vacuously no longer a member, so fall
+		// through and still queue the underlying outbound for cleanup.
+		m.removalQueue.logger.Debug("group already closed, skipping group removal", slog.String("group", group), slog.String("tag", tag))
+	case err != nil:
 		return fmt.Errorf("failed to remove %s from %s: %w", tag, group, err)
+	case n == 0:
+		// Tag wasn't a member; removal is idempotent.
+		m.removalQueue.logger.Debug("tag not in group, nothing to remove", slog.String("group", group), slog.String("tag", tag))
 	}
 
 	outbound, exists := m.outboundMgr.Outbound(tag)

--- a/adapter/groups/manager_test.go
+++ b/adapter/groups/manager_test.go
@@ -1,6 +1,7 @@
 package groups
 
 import (
+	"errors"
 	"slices"
 	"sync"
 	"testing"
@@ -225,6 +226,65 @@ func TestCheckOutbounds(t *testing.T) {
 		assert.ErrorIs(t, err, ErrIsClosed)
 		assert.False(t, mock.checked)
 	})
+}
+
+func TestRemoveFromGroup(t *testing.T) {
+	logger := log.NewNOPFactory().Logger()
+	tag := "outbound"
+
+	newMgr := func(group lbAdapter.MutableOutboundGroup) *MutableGroupManager {
+		return &MutableGroupManager{
+			outboundMgr: &mockOutboundManager{tags: []string{tag}},
+			endpointMgr: &mockEndpointManager{},
+			groups:      map[string]lbAdapter.MutableOutboundGroup{"auto-test": group},
+			removalQueue: newRemovalQueue(
+				logger, &mockOutboundManager{}, &mockEndpointManager{}, &mockConnectionManager{},
+				pollInterval, forceAfter,
+			),
+		}
+	}
+
+	pendingContains := func(mgr *MutableGroupManager, tag string) bool {
+		mgr.removalQueue.mu.RLock()
+		defer mgr.removalQueue.mu.RUnlock()
+		_, found := mgr.removalQueue.pending[tag]
+		return found
+	}
+
+	t.Run("removes and enqueues outbound", func(t *testing.T) {
+		mgr := newMgr(&mockRemovableGroup{removeN: 1})
+		require.NoError(t, mgr.RemoveFromGroup("auto-test", tag))
+		assert.True(t, pendingContains(mgr, tag), "outbound should be queued for removal")
+	})
+
+	t.Run("closed group treated as removed", func(t *testing.T) {
+		mgr := newMgr(&mockRemovableGroup{removeErr: lbAdapter.ErrGroupClosed})
+		require.NoError(t, mgr.RemoveFromGroup("auto-test", tag),
+			"removal racing group teardown must not error")
+		assert.True(t, pendingContains(mgr, tag), "outbound should still be queued for cleanup")
+	})
+
+	t.Run("tag not in group is idempotent", func(t *testing.T) {
+		mgr := newMgr(&mockRemovableGroup{removeN: 0})
+		assert.NoError(t, mgr.RemoveFromGroup("auto-test", tag))
+	})
+
+	t.Run("other errors propagate", func(t *testing.T) {
+		mgr := newMgr(&mockRemovableGroup{removeErr: errors.New("boom")})
+		err := mgr.RemoveFromGroup("auto-test", tag)
+		assert.ErrorContains(t, err, "boom")
+	})
+}
+
+// mockRemovableGroup implements MutableOutboundGroup with a configurable Remove.
+type mockRemovableGroup struct {
+	lbAdapter.MutableOutboundGroup
+	removeN   int
+	removeErr error
+}
+
+func (m *mockRemovableGroup) Remove(tags ...string) (int, error) {
+	return m.removeN, m.removeErr
 }
 
 // mockCheckerGroup implements both MutableOutboundGroup and OutboundChecker.

--- a/adapter/groups/manager_test.go
+++ b/adapter/groups/manager_test.go
@@ -267,6 +267,7 @@ func TestRemoveFromGroup(t *testing.T) {
 	t.Run("tag not in group is idempotent", func(t *testing.T) {
 		mgr := newMgr(&mockRemovableGroup{removeN: 0})
 		assert.NoError(t, mgr.RemoveFromGroup("auto-test", tag))
+		assert.True(t, pendingContains(mgr, tag), "outbound should still be queued for cleanup")
 	})
 
 	t.Run("other errors propagate", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.6
 
 replace github.com/sagernet/sing => github.com/getlantern/sing v0.7.18-lantern
 
-replace github.com/sagernet/sing-box => github.com/getlantern/sing-box-minimal v1.12.22-lantern.0.20260529221144-439651539f38
+replace github.com/sagernet/sing-box => github.com/getlantern/sing-box-minimal v1.12.22-lantern.0.20260717223538-d0cc8eb0fb17
 
 replace github.com/sagernet/wireguard-go => github.com/getlantern/wireguard-go v0.0.1-beta.7.0.20251208214020-d78e69f1eff4
 

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,8 @@ github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb/go.mod h1:GkPT5P9JoOTIRXRmFWxYgu1hhXgTFFTNc2hoG7WQc3g=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=
 github.com/getlantern/sing v0.7.18-lantern/go.mod h1:ARkL0gM13/Iv5VCZmci/NuoOlePoIsW0m7BWfln/Hak=
-github.com/getlantern/sing-box-minimal v1.12.22-lantern.0.20260529221144-439651539f38 h1:OfT3vn+nXMM9/D3clpakm1no8Hby3CuSg39DpV09Shg=
-github.com/getlantern/sing-box-minimal v1.12.22-lantern.0.20260529221144-439651539f38/go.mod h1:LzlFRel9E92gX0HXWCdsxgeg+kuAEPzLR+Znixk9EI4=
+github.com/getlantern/sing-box-minimal v1.12.22-lantern.0.20260717223538-d0cc8eb0fb17 h1:0L34+GKrF2zc6IVwncnh7AIcNHD5mPnfFtKe6uk4NrM=
+github.com/getlantern/sing-box-minimal v1.12.22-lantern.0.20260717223538-d0cc8eb0fb17/go.mod h1:LzlFRel9E92gX0HXWCdsxgeg+kuAEPzLR+Znixk9EI4=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5 h1:6ITBYqNkLbVZ1tQNXwmH8N80rZtvyW6IZa8L6EAhBQo=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5/go.mod h1:gx3dPUhZtQszPX5C+TshhxPXQHlY5t4gMnOOMA+viPA=
 github.com/getlantern/water v0.7.1-alpha.0.20260309190745-bd547c14b4aa h1:goZee1cURbWPiqX1xyjfwLB/zByQ50hEwonnnyLmcJQ=

--- a/protocol/group/mutableautoselect.go
+++ b/protocol/group/mutableautoselect.go
@@ -304,7 +304,7 @@ func (s *MutableAutoSelect) Add(tags ...string) (n int, err error) {
 	s.access.Lock()
 	defer s.access.Unlock()
 	if s.isClosed() {
-		return 0, errors.New("group is closed")
+		return 0, adapter.ErrGroupClosed
 	}
 	var missing []string
 	for _, tag := range tags {
@@ -336,7 +336,7 @@ func (s *MutableAutoSelect) Remove(tags ...string) (n int, err error) {
 	s.access.Lock()
 	defer s.access.Unlock()
 	if s.isClosed() {
-		return 0, errors.New("group is closed")
+		return 0, adapter.ErrGroupClosed
 	}
 	removed := make(map[string]struct{}, len(tags))
 	for _, tag := range tags {

--- a/protocol/group/mutableurltest.go
+++ b/protocol/group/mutableurltest.go
@@ -416,7 +416,7 @@ func (g *urlTestGroup) Add(tags []string) (n int, err error) {
 	defer g.access.Unlock()
 
 	if g.isClosed() {
-		return 0, errors.New("group is closed")
+		return 0, adapter.ErrGroupClosed
 	}
 
 	var missing []string
@@ -457,7 +457,7 @@ func (g *urlTestGroup) Remove(tags []string) (n int, err error) {
 	defer g.access.Unlock()
 
 	if g.isClosed() {
-		return 0, errors.New("group is closed")
+		return 0, adapter.ErrGroupClosed
 	}
 	if len(g.tags) == 0 {
 		return 0, nil


### PR DESCRIPTION
## Problem

The second half of getlantern/engineering#3693 (companion to getlantern/sing-box-minimal#51).

When a `servers-updated` refresh races tunnel teardown, `MutableGroupManager.RemoveFromGroup` (`adapter/groups/manager.go:217-223`) calls `group.Remove(tag)` on a group whose context is already cancelled. The group returns `group is closed`, `RemoveFromGroup` wraps it as `failed to remove <tag> from auto-lantern: group is closed`, and radiance escalates the failed event-forward to a 500 → tunnel restart. With the config poll at 180s, that's the "VPN drops every 3 minutes" loop the issue documents.

The same code path also treated "tag wasn't in the group" (`n == 0`) as an error (`failed to remove ...: unknown`), so a re-delivered removal could fail spuriously too.

## Fix

- New sentinel `adapter.ErrGroupClosed`; the urltest and autoselect groups return it from `Add`/`Remove` instead of ad-hoc `errors.New`.
- `RemoveFromGroup` treats a closed group as vacuous success — the tag is no longer a member of anything — logs at debug, and still enqueues the underlying outbound for cleanup (safe post-Close thanks to sing-box-minimal#51).
- `n == 0` (tag not a member) is now an idempotent no-op instead of an error.

`Add` on a closed group still errors — adding to a torn-down group is a genuine failure.

## Testing

- New `TestRemoveFromGroup` covers: normal removal + cleanup enqueue, the closed-group race (must not error, must still enqueue), idempotent not-a-member removal, and that other errors still propagate.
- `go test ./adapter/... ./protocol/group/` and `go build ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
