### PR TITLE
log failure kind in mutableautoselect

### DIFF
--- a/protocol/group/mutableautoselect.go
+++ b/protocol/group/mutableautoselect.go
@@ -966,9 +966,13 @@ func (s *MutableAutoSelect) mutateHistory(tag string, fn func(*localHistory, tim
 // can suppress downstream side effects (e.g. ladder kicks) on collapsed
 // events.
 func (s *MutableAutoSelect) recordUserFailure(tag string, kind adapter.UserFailureKind) bool {
-	return s.mutateHistory(tag, func(h *localHistory, now time.Time) bool {
+	recorded := s.mutateHistory(tag, func(h *localHistory, now time.Time) bool {
 		return h.addUserFailure(adapter.UserFailure{At: now, Kind: kind}, s.hist.userFailureWindow, s.hist.userFailureDedupeWindow)
 	})
+	if recorded {
+		s.logger.Info("user failure: tag=", tag, " kind=", kind)
+	}
+	return recorded
 }
 
 func (s *MutableAutoSelect) recordProbeOutcome(tag string, success bool, delayMs uint32) {


### PR DESCRIPTION
This pull request adds logging to the user failure recording process in the `MutableAutoSelect` component. Now, when a user failure is successfully recorded, an informational log entry is generated with the failure tag and kind.

Logging improvements:

* Added an `Info` log statement in `MutableAutoSelect.recordUserFailure` to log the tag and kind whenever a user failure is recorded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure recording feedback by logging when a failure is successfully saved.
  * Preserved the existing success or failure result of the recording operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->