### PR TITLE
fix(tracker): bound client-info OK exchange and fix short-read handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86
 	github.com/getlantern/geo v0.0.0-20241129152027-2fc88c10f91e
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395
-	github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf
+	github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb
 	github.com/gobwas/ws v1.4.0
 	github.com/pion/transport/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNi
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534/go.mod h1:ZsLfOY6gKQOTyEcPYNA9ws5/XHZQFroxqCOhHjGcs9Y=
 github.com/getlantern/quic-go-unbounded-fork v0.59.0-unbounded h1:1vTizA6U8YdyvZT0RIsEaY5fuhuZumnR8myyCF3qiZs=
 github.com/getlantern/quic-go-unbounded-fork v0.59.0-unbounded/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
-github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf h1:KxiMF+oG0rTtuBi7GiIaHfccYOf69rLJ/VnO5myoYc4=
-github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
+github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
+github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb/go.mod h1:GkPT5P9JoOTIRXRmFWxYgu1hhXgTFFTNc2hoG7WQc3g=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=

--- a/tracker/clientcontext/injector.go
+++ b/tracker/clientcontext/injector.go
@@ -174,7 +174,7 @@ func (c *writeConn) sendInfo(conn net.Conn) error {
 		return fmt.Errorf("reading response: %w", err)
 	}
 	if string(resp[:]) != "OK" {
-		return fmt.Errorf("invalid response: %s", resp)
+		return fmt.Errorf("invalid response: %q", resp[:])
 	}
 	return nil
 }
@@ -282,7 +282,7 @@ func (c *writePacketConn) sendInfo(conn net.PacketConn) error {
 		return fmt.Errorf("reading response: %w", err)
 	}
 	if n < 2 || string(resp[:2]) != "OK" {
-		return fmt.Errorf("invalid response: %s", resp[:n])
+		return fmt.Errorf("invalid response: %q", resp[:n])
 	}
 	return nil
 }

--- a/tracker/clientcontext/injector.go
+++ b/tracker/clientcontext/injector.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"sync"
+	"time"
 
 	lAdapter "github.com/getlantern/lantern-box/adapter"
 
@@ -13,6 +15,12 @@ import (
 	"github.com/sagernet/sing-box/protocol/group"
 	N "github.com/sagernet/sing/common/network"
 )
+
+// sendInfoTimeout bounds the client-info exchange. It runs on the connection's
+// critical path after the dial-layer timeouts no longer apply; without a
+// deadline, a server that stalls after the handshake (e.g. under DPI
+// throttling) holds the flow and its healthy-pool slot indefinitely.
+var sendInfoTimeout = 10 * time.Second
 
 var (
 	_ (adapter.ConnectionTracker)    = (*ClientContextInjector)(nil)
@@ -150,6 +158,11 @@ func (c *writeConn) sendInfo(conn net.Conn) error {
 	if err != nil {
 		return fmt.Errorf("marshaling client info: %w", err)
 	}
+	// Best effort: conns that don't support deadlines keep the old unbounded
+	// behavior rather than failing the exchange.
+	_ = conn.SetDeadline(time.Now().Add(sendInfoTimeout))
+	defer conn.SetDeadline(time.Time{})
+
 	packet := append([]byte(packetPrefix), buf...)
 	if _, err = conn.Write(packet); err != nil {
 		return fmt.Errorf("writing client info: %w", err)
@@ -157,7 +170,7 @@ func (c *writeConn) sendInfo(conn net.Conn) error {
 
 	// wait for `OK` response
 	var resp [2]byte
-	if _, err := conn.Read(resp[:]); err != nil {
+	if _, err := io.ReadFull(conn, resp[:]); err != nil {
 		return fmt.Errorf("reading response: %w", err)
 	}
 	if string(resp[:]) != "OK" {
@@ -250,18 +263,26 @@ func (c *writePacketConn) sendInfo(conn net.PacketConn) error {
 	} else if addr, err = net.ResolveUDPAddr("udp", dest.String()); err != nil {
 		return fmt.Errorf("resolving destination %s: %w", dest, err)
 	}
+	// Best effort: conns that don't support deadlines keep the old unbounded
+	// behavior rather than failing the exchange.
+	_ = conn.SetDeadline(time.Now().Add(sendInfoTimeout))
+	defer conn.SetDeadline(time.Time{})
+
 	packet := append([]byte(packetPrefix), buf...)
 	if _, err = conn.WriteTo(packet, addr); err != nil {
 		return fmt.Errorf("writing packet: %w", err)
 	}
 
-	// wait for `OK` response
-	var resp [2]byte
-	if _, _, err := conn.ReadFrom(resp[:]); err != nil {
+	// wait for `OK` response; the buffer must be able to hold a full datagram —
+	// wrapped conns return io.ErrShortBuffer instead of truncating, so a 2-byte
+	// buffer would reject any reply carrying transport overhead.
+	resp := make([]byte, 512)
+	n, _, err := conn.ReadFrom(resp)
+	if err != nil {
 		return fmt.Errorf("reading response: %w", err)
 	}
-	if string(resp[:]) != "OK" {
-		return fmt.Errorf("invalid response: %s", resp)
+	if n < 2 || string(resp[:2]) != "OK" {
+		return fmt.Errorf("invalid response: %s", resp[:n])
 	}
 	return nil
 }

--- a/tracker/clientcontext/injector_test.go
+++ b/tracker/clientcontext/injector_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/sagernet/sing-box/adapter"
 	M "github.com/sagernet/sing/common/metadata"
@@ -108,4 +109,129 @@ func TestSendInfoWithUnresolvableDomainFails(t *testing.T) {
 	err = wpc.sendInfo(conn)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "resolving destination")
+}
+
+func setSendInfoTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	old := sendInfoTimeout
+	sendInfoTimeout = d
+	t.Cleanup(func() { sendInfoTimeout = old })
+}
+
+func TestStreamSendInfoReadsSplitOK(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	go func() {
+		buf := make([]byte, 4096)
+		server.Read(buf)
+		// "OK" delivered across two reads; sendInfo must not treat a short
+		// read as an invalid response.
+		server.Write([]byte("O"))
+		server.Write([]byte("K"))
+	}()
+
+	wc := &writeConn{info: &ClientInfo{DeviceID: "test-device", Platform: "test"}}
+	assert.NoError(t, wc.sendInfo(client))
+}
+
+func TestStreamSendInfoTimesOutWithoutResponse(t *testing.T) {
+	setSendInfoTimeout(t, 100*time.Millisecond)
+
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	go func() {
+		buf := make([]byte, 4096)
+		server.Read(buf)
+		// never respond
+	}()
+
+	wc := &writeConn{info: &ClientInfo{DeviceID: "test-device", Platform: "test"}}
+	start := time.Now()
+	err := wc.sendInfo(client)
+	assert.Error(t, err)
+	assert.Less(t, time.Since(start), 5*time.Second)
+}
+
+func TestStreamSendInfoClearsDeadlineAfterSuccess(t *testing.T) {
+	setSendInfoTimeout(t, 100*time.Millisecond)
+
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	go func() {
+		buf := make([]byte, 4096)
+		server.Read(buf)
+		server.Write([]byte("OK"))
+	}()
+
+	wc := &writeConn{info: &ClientInfo{DeviceID: "test-device", Platform: "test"}}
+	require.NoError(t, wc.sendInfo(client))
+
+	// The conn is piped for the connection's lifetime after sendInfo; a
+	// leftover deadline would kill reads that outlast the timeout.
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		server.Write([]byte("data"))
+	}()
+	buf := make([]byte, 4)
+	_, err := client.Read(buf)
+	assert.NoError(t, err)
+}
+
+func TestPacketSendInfoAcceptsOversizedResponse(t *testing.T) {
+	server, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { server.Close() })
+
+	go func() {
+		buf := make([]byte, 4096)
+		_, addr, err := server.ReadFrom(buf)
+		if err != nil {
+			return
+		}
+		server.WriteTo([]byte("OK with trailing transport overhead"), addr)
+	}()
+
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer conn.Close()
+
+	serverAddr := server.LocalAddr().(*net.UDPAddr)
+	dest := M.SocksaddrFrom(netip.MustParseAddr(serverAddr.IP.String()), uint16(serverAddr.Port))
+
+	wpc := &writePacketConn{
+		metadata: adapter.InboundContext{Destination: dest},
+		info:     &ClientInfo{DeviceID: "test-device", Platform: "test"},
+	}
+	assert.NoError(t, wpc.sendInfo(conn))
+}
+
+func TestPacketSendInfoTimesOutWithoutResponse(t *testing.T) {
+	setSendInfoTimeout(t, 100*time.Millisecond)
+
+	// Server reads but never responds.
+	server, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { server.Close() })
+
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer conn.Close()
+
+	serverAddr := server.LocalAddr().(*net.UDPAddr)
+	dest := M.SocksaddrFrom(netip.MustParseAddr(serverAddr.IP.String()), uint16(serverAddr.Port))
+
+	wpc := &writePacketConn{
+		metadata: adapter.InboundContext{Destination: dest},
+		info:     &ClientInfo{DeviceID: "test-device", Platform: "test"},
+	}
+	start := time.Now()
+	err = wpc.sendInfo(conn)
+	assert.Error(t, err)
+	assert.Less(t, time.Since(start), 5*time.Second)
 }


### PR DESCRIPTION
## Problem

The post-handshake `CLIENTINFO`/`OK` exchange in `tracker/clientcontext/injector.go` runs on every connection's critical path: sing-box calls `ConnHandshakeSuccess` after the upstream dial but **before** starting the copy goroutines, and dial-layer timeouts no longer apply at that point. Three defects:

1. **Unbounded stall (TCP + UDP).** The `OK`-read has no deadline. A server that stalls after the handshake (e.g. under DPI throttling — the Rostelecom AS9009 behavior in Freshdesk [#180563](https://lantern.freshdesk.com/a/tickets/180563), tracked in getlantern/engineering#3726) holds the flow and its healthy-pool slot for 10+ minutes. That ticket's log showed 300+ `report handshake success: … reading response: … timed out` errors with durations up to 10m.
2. **TCP short-read teardown.** `conn.Read` into a 2-byte buffer can legally return 1 byte, making a valid `OK` fail as `invalid response` — which sing-box treats as fatal, tearing down a healthy connection.
3. **UDP short-buffer teardown.** The 2-byte `ReadFrom` buffer returns `io.ErrShortBuffer` on wrapped conns whenever the reply datagram carries transport overhead, killing successful QUIC/UDP handshakes. This is the root cause of getlantern/engineering#3718.

```mermaid
sequenceDiagram
    autonumber
    participant U as User flow<br/>tun inbound
    participant CM as ConnectionManager<br/>sing-box-minimal route/conn.go
    participant WC as writeConn<br/>lantern-box injector.go
    participant S as Lantern server<br/>DPI-degraded path

    U->>CM: NewConnection
    CM->>S: route/conn.go:65<br/>dial outbound — bounded by dial timeout ✅
    S-->>CM: handshake complete
    CM->>WC: route/conn.go:85<br/>ReportConnHandshakeSuccess
    WC->>S: injector.go:154<br/>write CLIENTINFO json
    rect rgba(255, 200, 200, 0.3)
        Note over WC: injector.go:160<br/>conn.Read waits for 2-byte OK<br/>no deadline 🐛
        Note over S: DPI blackholes stream after handshake ⚠️
    end
    Note over WC,S: read blocks 10+ minutes<br/>holding a healthy-pool slot
    WC-->>CM: error only when stall detector kills conn
    Note over CM: route/conn.go:86-92<br/>hook error is fatal — conn torn down
    Note over U,CM: route/conn.go:105-106<br/>copy goroutines never started —<br/>user flow never moves a byte
```

Line references: `injector.go` lines are this repo's `main` pre-fix; `route/conn.go` lines are `getlantern/sing-box-minimal` at the currently-pinned version.

## Fix

- Bound the whole exchange with a 10s `SetDeadline` in both `sendInfo` variants, cleared afterward (the conn becomes the long-lived piped data connection on success). Best-effort: conns without deadline support keep the previous behavior rather than failing.
- TCP: `io.ReadFull` for the 2-byte `OK`.
- UDP: read into a 512-byte buffer and compare the 2-byte prefix.

Net effect: a post-handshake blackhole now fails in 10s instead of parking the flow for minutes, so `MutableAutoSelect` moves to the next candidate an order of magnitude faster; and successful UDP/QUIC handshakes are no longer torn down by the broken `OK` check (partially addresses getlantern/engineering#3718 — the remaining design question there, whether a client-info hook failure should be non-fatal in `sing-box-minimal route/conn.go:86-92`, is intentionally out of scope).

## Testing

- 5 new tests: TCP split-`OK` across two writes, TCP stalled-server timeout, TCP deadline-cleared-after-success, UDP oversized reply accepted, UDP stalled-server timeout.
- `go test -race -count=1 ./tracker/...` clean; `go build ./...`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Client information exchanges now enforce a strict timeout when the expected acknowledgment isn’t received.
  * Stream-based exchanges correctly handle acknowledgments split across multiple reads.
  * Packet-based exchanges accept larger responses that contain a valid acknowledgment.
  * Successful exchanges now clear any applied deadlines to avoid affecting later reads.
* **Tests**
  * Added coverage for timeout behavior, split acknowledgment handling, deadline clearing, and packet response validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->