### PR TITLE
Add gcore image build + publish to the Packer pipeline

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -513,10 +513,9 @@ jobs:
           GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
           GCORE_PROJECT_ID: ${{ secrets.GCORE_PROJECT_ID }}
           QEMU_SSH_PASSWORD: ${{ secrets.QEMU_SSH_PASSWORD }}
-          GCORE_IMAGE_GCS_BUCKET: ${{ secrets.GCORE_IMAGE_GCS_BUCKET }}
         run: |
           missing=""
-          for var in GCORE_API_KEY GCORE_PROJECT_ID QEMU_SSH_PASSWORD GCORE_IMAGE_GCS_BUCKET; do
+          for var in GCORE_API_KEY GCORE_PROJECT_ID QEMU_SSH_PASSWORD; do
             [ -z "${!var}" ] && missing="$missing $var"
           done
           if [ -n "$missing" ]; then
@@ -549,34 +548,42 @@ jobs:
             -only="qemu.lantern-box-gcore" \
             .
 
-      - name: Authenticate to Google Cloud (gcore)
+      - name: Provision gcore object storage (gcore)
+        id: gstore
         if: matrix.builder == 'gcore'
-        uses: google-github-actions/auth@v2
-        with:
-          token_format: access_token
-          workload_identity_provider: projects/472305719257/locations/global/workloadIdentityPools/github-actions/providers/ghactions-provider
-          service_account: ghactions@lantern-cloud.iam.gserviceaccount.com
+        env:
+          GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
+        run: |
+          # Find-or-create the dedicated gcore S3 storage + bucket and mint an
+          # ephemeral access key (revoked in the cleanup step below). Emits
+          # storage_id/address/bucket/access_key/secret_key as step outputs.
+          bash deploy/packer/gcore-storage.sh provision | while IFS='=' read -r k v; do
+            case "$k" in access_key | secret_key) echo "::add-mask::$v" ;; esac
+            echo "$k=$v" >> "$GITHUB_OUTPUT"
+          done
 
-      - name: Set up gcloud (gcore)
-        if: matrix.builder == 'gcore'
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Upload qcow2 to GCS and sign URL (gcore)
+      - name: Upload qcow2 and presign URL (gcore)
         id: gcs
         if: matrix.builder == 'gcore'
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
-          BUCKET: ${{ secrets.GCORE_IMAGE_GCS_BUCKET }}
-          SIGNER_SA: ghactions@lantern-cloud.iam.gserviceaccount.com
+          AWS_ACCESS_KEY_ID: ${{ steps.gstore.outputs.access_key }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.gstore.outputs.secret_key }}
+          # gcore object storage is S3-compatible; the AWS CLI is used only as an
+          # S3 client pointed at gcore's endpoint (never AWS). SigV4 needs a region
+          # value and gcore doesn't validate it, so a placeholder is fine. If a
+          # live run rejects the request, the knobs to try are this region and
+          # path-style addressing: aws configure set default.s3.addressing_style path
+          AWS_DEFAULT_REGION: us-east-1
+          ADDRESS: ${{ steps.gstore.outputs.address }}
+          BUCKET: ${{ steps.gstore.outputs.bucket }}
         run: |
+          endpoint="https://${ADDRESS}"
+          key="lantern-box/lantern-box-${VERSION}-${GITHUB_RUN_ID}.qcow2"
           qcow2="deploy/packer/output-gcore/lantern-box-${VERSION}-amd64.qcow2"
-          obj="gs://${BUCKET}/lantern-box/lantern-box-${VERSION}-${GITHUB_RUN_ID}.qcow2"
-          echo "Uploading ${qcow2} -> ${obj}"
-          gcloud storage cp "$qcow2" "$obj"
-          url=$(gcloud storage sign-url "$obj" \
-            --duration=24h \
-            --impersonate-service-account="$SIGNER_SA" \
-            --format='value(signed_url)')
+          echo "Uploading ${qcow2} -> s3://${BUCKET}/${key} via ${endpoint}"
+          aws s3 cp "$qcow2" "s3://${BUCKET}/${key}" --endpoint-url "$endpoint"
+          url=$(aws s3 presign "s3://${BUCKET}/${key}" --endpoint-url "$endpoint" --expires-in 86400)
           echo "::add-mask::$url"
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
@@ -589,6 +596,14 @@ jobs:
           GCORE_REGIONS: ${{ needs.prepare.outputs.gcore_regions }}
           IMAGE_URL: ${{ steps.gcs.outputs.url }}
         run: bash deploy/packer/gcore-publish.sh
+
+      - name: Clean up gcore access key (gcore)
+        if: always() && matrix.builder == 'gcore' && steps.gstore.outputs.access_key != ''
+        env:
+          GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
+          STORAGE_ID: ${{ steps.gstore.outputs.storage_id }}
+          ACCESS_KEY: ${{ steps.gstore.outputs.access_key }}
+        run: bash deploy/packer/gcore-storage.sh cleanup
 
       - name: Clean up OCI key
         if: always() && matrix.builder == 'oracle-oci'

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -500,6 +500,24 @@ jobs:
             -only="$ONLY" \
             .
 
+      - name: Verify gcore secrets
+        if: matrix.builder == 'gcore'
+        env:
+          GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
+          GCORE_PROJECT_ID: ${{ secrets.GCORE_PROJECT_ID }}
+          QEMU_SSH_PASSWORD: ${{ secrets.QEMU_SSH_PASSWORD }}
+          GCORE_IMAGE_GCS_BUCKET: ${{ secrets.GCORE_IMAGE_GCS_BUCKET }}
+        run: |
+          missing=""
+          for var in GCORE_API_KEY GCORE_PROJECT_ID QEMU_SSH_PASSWORD GCORE_IMAGE_GCS_BUCKET; do
+            [ -z "${!var}" ] && missing="$missing $var"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::Missing gcore secrets:$missing"
+            exit 1
+          fi
+          echo "All gcore secrets present"
+
       - name: Enable KVM (gcore)
         if: matrix.builder == 'gcore'
         run: |

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -24,10 +24,13 @@ on:
         required: false
         default: "linode,oracle-oci,alicloud-ecs,gcore"
         type: string
+      # Deliberately NOT prefilled with the default list. The list lives in exactly one
+      # place — the "Resolve gcore regions and build timeout" step — because a prefilled
+      # default here would be a second copy that a push-triggered run never uses, and the
+      # two silently drifted apart once already.
       gcore_regions:
-        description: "Comma-separated Gcore numeric region IDs (gcore builder only)."
+        description: "Comma-separated Gcore numeric region IDs (gcore builder only). Blank = every region lantern-cloud provisions in."
         required: false
-        default: "196,184,180,176,164,152,148,140,136,128,124,116,108,104,100,92,88,84,80,76,68,64,50,46,34,30,26,18,14,6"
         type: string
 
 permissions:
@@ -117,7 +120,15 @@ jobs:
         env:
           INPUT_REGIONS: ${{ github.event.inputs.gcore_regions }}
         run: |
-          regions="${INPUT_REGIONS:-180}"
+          # THE gcore region list — the only copy. Every gcore region lantern-cloud can
+          # provision a VPS in, because its provider looks the boot image up per region
+          # and fails outright where one is missing. Publishing to a subset is what
+          # caused the "no gcore image matching prefix lantern-box- in region 180"
+          # failure this builder exists to fix, so the automatic push-to-main build
+          # covers all of them, exactly as oracle-oci (36) and alicloud (8) already do.
+          # A dispatch may narrow it for a scoped test; nothing else should.
+          default_regions="196,184,180,176,164,152,148,140,136,128,124,116,108,104,100,92,88,84,80,76,68,64,50,46,34,30,26,18,14,6"
+          regions="${INPUT_REGIONS:-$default_regions}"
           echo "regions=$regions" >> "$GITHUB_OUTPUT"
           echo "gcore regions: $regions"
           # The gcore build job's timeout is budgeted here because GitHub expressions have
@@ -583,10 +594,9 @@ jobs:
         env:
           GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
           GCORE_PROJECT_ID: ${{ secrets.GCORE_PROJECT_ID }}
-          QEMU_SSH_PASSWORD: ${{ secrets.QEMU_SSH_PASSWORD }}
         run: |
           missing=""
-          for var in GCORE_API_KEY GCORE_PROJECT_ID QEMU_SSH_PASSWORD; do
+          for var in GCORE_API_KEY GCORE_PROJECT_ID; do
             [ -z "${!var}" ] && missing="$missing $var"
           done
           if [ -n "$missing" ]; then
@@ -615,8 +625,19 @@ jobs:
         working-directory: deploy/packer
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
-          QEMU_SSH_PASSWORD: ${{ secrets.QEMU_SSH_PASSWORD }}
         run: |
+          # Mint the build-only SSH password here rather than reading a repo secret.
+          # Packer needs a password to reach the cloud image, and the generalize step
+          # locks the account afterwards — but the account's hash still ships in the
+          # qcow2's /etc/shadow, and that qcow2 is briefly world-readable while gcore
+          # imports it. A long-lived secret's hash would stay valid for every later
+          # build if that window were ever caught; a per-run value is worthless the
+          # moment this job ends. Hex, not base64: the value is interpolated into the
+          # cloud-init YAML and into shutdown_command's single-quoted shell string, and
+          # hex cannot carry a quote, a slash, or a YAML indicator.
+          QEMU_SSH_PASSWORD="$(openssl rand -hex 24)"
+          echo "::add-mask::$QEMU_SSH_PASSWORD"
+          export QEMU_SSH_PASSWORD
           packer build \
             -var "lantern_box_version=$VERSION" \
             -only="qemu.lantern-box-gcore" \

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -20,9 +20,14 @@ on:
         required: false
         type: string
       builders:
-        description: "Comma-separated builders (linode,oracle-oci,alicloud-ecs)"
+        description: "Comma-separated builders (linode,oracle-oci,alicloud-ecs,gcore)"
         required: false
-        default: "linode,oracle-oci,alicloud-ecs"
+        default: "linode,oracle-oci,alicloud-ecs,gcore"
+        type: string
+      gcore_regions:
+        description: "Comma-separated Gcore numeric region IDs (gcore builder only). Default 180 = Frankfurt-2."
+        required: false
+        default: "180"
         type: string
 
 permissions:
@@ -37,6 +42,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       matrix: ${{ steps.matrix.outputs.matrix }}
+      gcore_regions: ${{ steps.gcore.outputs.regions }}
     steps:
       - name: Checkout (full history — needed to find the latest tag)
         uses: actions/checkout@v6
@@ -87,11 +93,11 @@ jobs:
           INPUT_BUILDERS: ${{ github.event.inputs.builders }}
         run: |
           if [ "$EVENT_NAME" = "push" ]; then
-            builders="linode,oracle-oci,alicloud-ecs"
+            builders="linode,oracle-oci,alicloud-ecs,gcore"
           elif [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_BUILDERS" ]; then
             builders="$INPUT_BUILDERS"
           else
-            builders="linode,oracle-oci,alicloud-ecs"
+            builders="linode,oracle-oci,alicloud-ecs,gcore"
           fi
           # Validate that we have at least one builder
           if [ -z "$builders" ]; then
@@ -104,6 +110,15 @@ jobs:
           json_array=$(printf '%s\n' "$builders" | tr ',' '\n' | jq -R . | jq -sc .)
           echo "matrix={\"builder\":$json_array}" >> "$GITHUB_OUTPUT"
           echo "Matrix: $json_array"
+
+      - name: Resolve gcore regions
+        id: gcore
+        env:
+          INPUT_REGIONS: ${{ github.event.inputs.gcore_regions }}
+        run: |
+          regions="${INPUT_REGIONS:-180}"
+          echo "regions=$regions" >> "$GITHUB_OUTPUT"
+          echo "gcore regions: $regions"
 
   # Prune old images before building (avoids provider quota limits)
   prune:
@@ -144,6 +159,49 @@ jobs:
               echo "::error::$failures image(s) failed to delete"
               exit 1
             fi
+          fi
+
+      - name: Prune old gcore images
+        if: contains(needs.prepare.outputs.matrix, 'gcore')
+        env:
+          GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
+          GCORE_PROJECT_ID: ${{ secrets.GCORE_PROJECT_ID }}
+          GCORE_REGIONS: ${{ needs.prepare.outputs.gcore_regions }}
+        run: |
+          KEEP=3
+          API="https://api.gcore.com/cloud/v1"
+          AUTH="Authorization: APIKey ${GCORE_API_KEY}"
+          failures=0
+          IFS=',' read -ra regions <<< "$GCORE_REGIONS"
+          for region in "${regions[@]}"; do
+            region="${region//[[:space:]]/}"
+            [ -z "$region" ] && continue
+            echo "Fetching gcore private images in region ${region}..."
+            images=$(curl -sS -f -H "$AUTH" \
+              "${API}/images/${GCORE_PROJECT_ID}/${region}?private=true" \
+              | jq -r '.results[] | select(.name | startswith("lantern-box-")) | "\(.created_at)\t\(.id)\t\(.name)"' \
+              | sort -r)
+            total=$(echo "$images" | grep -c . || true)
+            echo "Region ${region}: found ${total} lantern-box images (keeping ${KEEP})"
+            if [ "$total" -le "$KEEP" ]; then
+              echo "Nothing to prune."
+              continue
+            fi
+            while IFS=$'\t' read -r created id name; do
+              echo "Deleting ${name} (${id}, created ${created}) in region ${region}..."
+              http_code=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE -H "$AUTH" \
+                "${API}/images/${GCORE_PROJECT_ID}/${region}/${id}")
+              if [ "$http_code" = "404" ]; then
+                echo "  Already gone (404), skipping."
+              elif [ "$http_code" -ge 400 ]; then
+                echo "::error::Failed to delete gcore image ${name} (${id}) in region ${region}: HTTP ${http_code}"
+                failures=$((failures + 1))
+              fi
+            done < <(echo "$images" | tail -n +$((KEEP + 1)))
+          done
+          if [ "$failures" -gt 0 ]; then
+            echo "::error::${failures} gcore image(s) failed to delete"
+            exit 1
           fi
 
   build-datacap:
@@ -188,6 +246,9 @@ jobs:
     name: Build ${{ matrix.builder }}
     runs-on: ubuntu-latest
     needs: [prepare, prune, build-datacap]
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
@@ -234,6 +295,9 @@ jobs:
               ;;
             linode|alicloud-ecs)
               echo "flag=${BUILDER}.lantern-box" >> "$GITHUB_OUTPUT"
+              ;;
+            gcore)
+              echo "flag=qemu.lantern-box-gcore" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "::error::Unsupported builder: $BUILDER"
@@ -337,6 +401,7 @@ jobs:
           echo "All OCI region secrets present"
 
       - name: Build
+        if: matrix.builder != 'gcore'
         working-directory: deploy/packer
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
@@ -427,6 +492,67 @@ jobs:
             -var "lantern_box_version=$VERSION" \
             -only="$ONLY" \
             .
+
+      - name: Enable KVM (gcore)
+        if: matrix.builder == 'gcore'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y -q qemu-system-x86 qemu-utils
+          sudo chmod 666 /dev/kvm
+          echo "KVM device:"; ls -l /dev/kvm
+
+      - name: Build gcore qcow2
+        if: matrix.builder == 'gcore'
+        working-directory: deploy/packer
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          QEMU_SSH_PASSWORD: ${{ secrets.QEMU_SSH_PASSWORD }}
+        run: |
+          packer build \
+            -var "lantern_box_version=$VERSION" \
+            -only="qemu.lantern-box-gcore" \
+            .
+
+      - name: Authenticate to Google Cloud (gcore)
+        if: matrix.builder == 'gcore'
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          workload_identity_provider: projects/472305719257/locations/global/workloadIdentityPools/github-actions/providers/ghactions-provider
+          service_account: ghactions@lantern-cloud.iam.gserviceaccount.com
+
+      - name: Set up gcloud (gcore)
+        if: matrix.builder == 'gcore'
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Upload qcow2 to GCS and sign URL (gcore)
+        id: gcs
+        if: matrix.builder == 'gcore'
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          BUCKET: ${{ secrets.GCORE_IMAGE_GCS_BUCKET }}
+          SIGNER_SA: ghactions@lantern-cloud.iam.gserviceaccount.com
+        run: |
+          qcow2="deploy/packer/output-gcore/lantern-box-${VERSION}-amd64.qcow2"
+          obj="gs://${BUCKET}/lantern-box/lantern-box-${VERSION}-${GITHUB_RUN_ID}.qcow2"
+          echo "Uploading ${qcow2} -> ${obj}"
+          gcloud storage cp "$qcow2" "$obj"
+          url=$(gcloud storage sign-url "$obj" \
+            --duration=24h \
+            --impersonate-service-account="$SIGNER_SA" \
+            --format='value(signed_url)')
+          echo "::add-mask::$url"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Publish gcore image to regions
+        if: matrix.builder == 'gcore'
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
+          GCORE_PROJECT_ID: ${{ secrets.GCORE_PROJECT_ID }}
+          GCORE_REGIONS: ${{ needs.prepare.outputs.gcore_regions }}
+          IMAGE_URL: ${{ steps.gcs.outputs.url }}
+        run: bash deploy/packer/gcore-publish.sh
 
       - name: Clean up OCI key
         if: always() && matrix.builder == 'oracle-oci'

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -192,8 +192,12 @@ jobs:
             fi
             while IFS=$'\t' read -r created id name; do
               echo "Deleting ${name} (${id}, created ${created}) in region ${region}..."
-              http_code=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE -H "$AUTH" \
-                "${API}/images/${GCORE_PROJECT_ID}/${region}/${id}")
+              if ! http_code=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE -H "$AUTH" \
+                "${API}/images/${GCORE_PROJECT_ID}/${region}/${id}"); then
+                echo "::error::Failed to reach gcore to delete ${name} (${id}) in region ${region}"
+                failures=$((failures + 1))
+                continue
+              fi
               if [ "$http_code" = "404" ]; then
                 echo "  Already gone (404), skipping."
               elif [ "$http_code" -ge 400 ]; then

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -177,10 +177,13 @@ jobs:
             region="${region//[[:space:]]/}"
             [ -z "$region" ] && continue
             echo "Fetching gcore private images in region ${region}..."
-            images=$(curl -sS -f -H "$AUTH" \
-              "${API}/images/${GCORE_PROJECT_ID}/${region}?private=true" \
-              | jq -r '.results[] | select(.name | startswith("lantern-box-")) | "\(.created_at)\t\(.id)\t\(.name)"' \
-              | sort -r)
+            if ! raw=$(curl -sS -f -H "$AUTH" \
+              "${API}/images/${GCORE_PROJECT_ID}/${region}?private=true"); then
+              echo "::error::Failed to list gcore images in region ${region}"
+              failures=$((failures + 1))
+              continue
+            fi
+            images=$(echo "$raw" | jq -r '.results[] | select(.name | startswith("lantern-box-")) | "\(.created_at)\t\(.id)\t\(.name)"' | sort -r)
             total=$(echo "$images" | grep -c . || true)
             echo "Region ${region}: found ${total} lantern-box images (keeping ${KEEP})"
             if [ "$total" -le "$KEEP" ]; then
@@ -498,6 +501,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y -q qemu-system-x86 qemu-utils
+          if [ ! -e /dev/kvm ]; then
+            echo "::error::/dev/kvm not available on this runner — QEMU build requires KVM"
+            exit 1
+          fi
           sudo chmod 666 /dev/kvm
           echo "KVM device:"; ls -l /dev/kvm
 

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -255,7 +255,6 @@ jobs:
     needs: [prepare, prune, build-datacap]
     permissions:
       contents: read
-      id-token: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
@@ -557,16 +556,19 @@ jobs:
         env:
           GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
         run: |
-          # Find-or-create the dedicated gcore S3 storage + bucket and mint an
-          # ephemeral access key (revoked in the cleanup step below). Emits
-          # storage_id/address/bucket/access_key/secret_key as step outputs.
+          # Find-or-create the dedicated gcore S3 storage instance, sweep any
+          # leftover stage buckets, create a fresh randomly-named bucket, and mint
+          # an ephemeral access key (all torn down in the cleanup steps below).
+          # Emits storage_id/region/endpoint/bucket/access_key/secret_key as step
+          # outputs. The bucket name is unguessable and the secret key is masked;
+          # the object goes public only briefly (see the next step).
           bash deploy/packer/gcore-storage.sh provision | while IFS='=' read -r k v; do
-            case "$k" in access_key | secret_key) echo "::add-mask::$v" ;; esac
+            case "$k" in access_key | secret_key | bucket) echo "::add-mask::$v" ;; esac
             echo "$k=$v" >> "$GITHUB_OUTPUT"
           done
 
-      - name: Upload qcow2 and presign URL (gcore)
-        id: gcs
+      - name: Upload qcow2 and expose it for gcore import (gcore)
+        id: stage
         if: matrix.builder == 'gcore'
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
@@ -580,11 +582,29 @@ jobs:
           ENDPOINT: ${{ steps.gstore.outputs.endpoint }}
           BUCKET: ${{ steps.gstore.outputs.bucket }}
         run: |
-          key="lantern-box/lantern-box-${VERSION}-${GITHUB_RUN_ID}.qcow2"
+          # gcore's importer fetches an UNAUTHENTICATED URL (HEAD then GET), so a
+          # presigned/method-bound URL can't satisfy it — the object must be
+          # anonymously readable. We upload it to the throwaway, randomly-named
+          # bucket from the previous step and grant anonymous s3:GetObject for the
+          # duration of the import; the whole bucket (policy included) is torn down
+          # in the cleanup steps below. The random bucket name is masked and the
+          # URL is not logged, so the short public window stays unguessable.
+          key="lantern-box-${VERSION}-${GITHUB_RUN_ID}.qcow2"
           qcow2="deploy/packer/output-gcore/lantern-box-${VERSION}-amd64.qcow2"
-          echo "Uploading ${qcow2} -> s3://${BUCKET}/${key} via ${ENDPOINT}"
+          echo "Uploading ${qcow2} to the staging bucket via ${ENDPOINT}"
           aws s3 cp "$qcow2" "s3://${BUCKET}/${key}" --endpoint-url "$ENDPOINT"
-          url=$(aws s3 presign "s3://${BUCKET}/${key}" --endpoint-url "$ENDPOINT" --expires-in 86400)
+          aws s3api put-bucket-policy --bucket "$BUCKET" --endpoint-url "$ENDPOINT" \
+            --policy "$(jq -n --arg b "$BUCKET" '{
+              Version: "2012-10-17",
+              Statement: [{
+                Sid: "PublicReadForGcoreImport",
+                Effect: "Allow",
+                Principal: "*",
+                Action: "s3:GetObject",
+                Resource: "arn:aws:s3:::\($b)/*"
+              }]
+            }')"
+          url="${ENDPOINT}/${BUCKET}/${key}"
           echo "::add-mask::$url"
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
@@ -595,14 +615,15 @@ jobs:
           GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
           GCORE_PROJECT_ID: ${{ secrets.GCORE_PROJECT_ID }}
           GCORE_REGIONS: ${{ needs.prepare.outputs.gcore_regions }}
-          IMAGE_URL: ${{ steps.gcs.outputs.url }}
+          IMAGE_URL: ${{ steps.stage.outputs.url }}
         run: bash deploy/packer/gcore-publish.sh
 
       - name: Delete staged qcow2 (gcore)
-        # Runs before the key revoke below because deleting the object needs the
-        # still-valid minted S3 credentials. The qcow2 is only needed during the
-        # import above, so remove it immediately rather than leaving a multi-GB
-        # object in the bucket. `|| true` so a missing object never fails the job.
+        # Runs before the bucket/key teardown below because emptying the object
+        # needs the still-valid minted S3 credentials, and the control-plane
+        # bucket delete needs the bucket empty. The qcow2 (and its public policy)
+        # is only needed during the import above, so remove it as soon as the
+        # import finishes. `|| true` so a missing object never fails the job.
         if: always() && matrix.builder == 'gcore' && steps.gstore.outputs.access_key != ''
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
@@ -612,14 +633,15 @@ jobs:
           ENDPOINT: ${{ steps.gstore.outputs.endpoint }}
           BUCKET: ${{ steps.gstore.outputs.bucket }}
         run: |
-          key="lantern-box/lantern-box-${VERSION}-${GITHUB_RUN_ID}.qcow2"
+          key="lantern-box-${VERSION}-${GITHUB_RUN_ID}.qcow2"
           aws s3 rm "s3://${BUCKET}/${key}" --endpoint-url "$ENDPOINT" || true
 
-      - name: Clean up gcore access key (gcore)
+      - name: Clean up gcore stage bucket and access key (gcore)
         if: always() && matrix.builder == 'gcore' && steps.gstore.outputs.access_key != ''
         env:
           GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
           STORAGE_ID: ${{ steps.gstore.outputs.storage_id }}
+          BUCKET: ${{ steps.gstore.outputs.bucket }}
           ACCESS_KEY: ${{ steps.gstore.outputs.access_key }}
         run: bash deploy/packer/gcore-storage.sh cleanup
 

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -261,6 +261,13 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     # Alicloud copies images to 8 regions (up to 2h). OCI builds 36 regions
     # in parallel — usually ~7min but a slow mirror can push past 45min.
+    # NOTE: gcore also fans out — gcore-publish.sh imports+polls each region
+    # SEQUENTIALLY (worst case ~30min/region: POLL_ATTEMPTS×POLL_INTERVAL_SECS)
+    # — but keeps the 60min default. That's fine for the current single-region
+    # default (gcore_regions=180); before expanding gcore_regions to many
+    # regions, scale this timeout with the region count (e.g. compute it in the
+    # prepare job) or parallelize the imports in gcore-publish.sh, else the job
+    # can be killed mid-import and leave orphaned gcore tasks. See PR #292.
     timeout-minutes: ${{ matrix.builder == 'alicloud-ecs' && 150 || 60 }}
 
     steps:

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -260,13 +260,11 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     # Alicloud copies images to 8 regions (up to 2h). OCI builds 36 regions
     # in parallel — usually ~7min but a slow mirror can push past 45min.
-    # NOTE: gcore also fans out — gcore-publish.sh imports+polls each region
-    # SEQUENTIALLY (worst case ~30min/region: POLL_ATTEMPTS×POLL_INTERVAL_SECS)
-    # — but keeps the 60min default. That's fine for the current single-region
-    # default (gcore_regions=180); before expanding gcore_regions to many
-    # regions, scale this timeout with the region count (e.g. compute it in the
-    # prepare job) or parallelize the imports in gcore-publish.sh, else the job
-    # can be killed mid-import and leave orphaned gcore tasks. See PR #292.
+    # NOTE: gcore-publish.sh imports+polls each region SEQUENTIALLY (worst case
+    # ~30min/region: POLL_ATTEMPTS×POLL_INTERVAL_SECS) on the 60min default. Fine
+    # for the single-region default; before expanding gcore_regions, scale this
+    # timeout with the region count or parallelize the imports, else the job can
+    # be killed mid-import and leave orphaned gcore tasks. See PR #292.
     timeout-minutes: ${{ matrix.builder == 'alicloud-ecs' && 150 || 60 }}
 
     steps:
@@ -528,8 +526,8 @@ jobs:
         run: |
           sudo apt-get update
           # xorriso builds the NoCloud cidata seed ISO from the qemu source's
-          # cd_content; it isn't preinstalled on the runner. qemu-system-x86 and
-          # qemu-utils provide the emulator and qcow2 tooling.
+          # cd_content and isn't preinstalled; qemu-system-x86 and qemu-utils
+          # provide the emulator and qcow2 tooling.
           sudo apt-get install -y -q qemu-system-x86 qemu-utils xorriso
           if [ ! -e /dev/kvm ]; then
             echo "::error::/dev/kvm not available on this runner — QEMU build requires KVM"
@@ -556,12 +554,10 @@ jobs:
         env:
           GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
         run: |
-          # Find-or-create the dedicated gcore S3 storage instance, sweep any
-          # leftover stage buckets, create a fresh randomly-named bucket, and mint
-          # an ephemeral access key (all torn down in the cleanup steps below).
-          # Emits storage_id/region/endpoint/bucket/access_key/secret_key as step
-          # outputs. The bucket name is unguessable and the secret key is masked;
-          # the object goes public only briefly (see the next step).
+          # Find-or-create the storage instance, sweep leftover stage buckets, make
+          # a fresh randomly-named bucket, and mint an ephemeral access key — all
+          # torn down in the cleanup steps below. Emits
+          # storage_id/region/endpoint/bucket/access_key/secret_key as step outputs.
           bash deploy/packer/gcore-storage.sh provision | while IFS='=' read -r k v; do
             case "$k" in access_key | secret_key | bucket) echo "::add-mask::$v" ;; esac
             echo "$k=$v" >> "$GITHUB_OUTPUT"
@@ -572,10 +568,9 @@ jobs:
         if: matrix.builder == 'gcore'
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
-          # gcore object storage is S3-compatible; the AWS CLI is used only as an
-          # S3 client pointed at gcore's regional S3 endpoint (never AWS). The
-          # endpoint + region come from gcore-storage.sh (the location's
-          # technical_name), e.g. https://s-ed1.cloud.gcore.lu with region s-ed1.
+          # The AWS CLI is used only as a generic S3 client pointed at gcore's
+          # regional endpoint (never AWS). Endpoint + region come from
+          # gcore-storage.sh, e.g. https://s-ed1.cloud.gcore.lu with region s-ed1.
           AWS_ACCESS_KEY_ID: ${{ steps.gstore.outputs.access_key }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.gstore.outputs.secret_key }}
           AWS_DEFAULT_REGION: ${{ steps.gstore.outputs.region }}
@@ -583,12 +578,11 @@ jobs:
           BUCKET: ${{ steps.gstore.outputs.bucket }}
         run: |
           # gcore's importer fetches an UNAUTHENTICATED URL (HEAD then GET), so a
-          # presigned/method-bound URL can't satisfy it — the object must be
-          # anonymously readable. We upload it to the throwaway, randomly-named
-          # bucket from the previous step and grant anonymous s3:GetObject for the
-          # duration of the import; the whole bucket (policy included) is torn down
-          # in the cleanup steps below. The random bucket name is masked and the
-          # URL is not logged, so the short public window stays unguessable.
+          # method-bound presigned URL can't satisfy it — the object must be
+          # anonymously readable. Upload to the throwaway bucket from the previous
+          # step and grant anonymous s3:GetObject for the import; the bucket and its
+          # policy are torn down below. The bucket name is masked and the URL never
+          # logged, so the short public window stays unguessable.
           key="lantern-box-${VERSION}-${GITHUB_RUN_ID}.qcow2"
           qcow2="deploy/packer/output-gcore/lantern-box-${VERSION}-amd64.qcow2"
           echo "Uploading ${qcow2} to the staging bucket via ${ENDPOINT}"
@@ -619,11 +613,9 @@ jobs:
         run: bash deploy/packer/gcore-publish.sh
 
       - name: Delete staged qcow2 (gcore)
-        # Runs before the bucket/key teardown below because emptying the object
-        # needs the still-valid minted S3 credentials, and the control-plane
-        # bucket delete needs the bucket empty. The qcow2 (and its public policy)
-        # is only needed during the import above, so remove it as soon as the
-        # import finishes. `|| true` so a missing object never fails the job.
+        # Before the bucket/key teardown below: deleting the object needs the
+        # still-valid S3 credentials, and the control-plane bucket delete needs an
+        # empty bucket. `|| true` so a missing object never fails the job.
         if: always() && matrix.builder == 'gcore' && steps.gstore.outputs.access_key != ''
         env:
           VERSION: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -570,23 +570,21 @@ jobs:
         if: matrix.builder == 'gcore'
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
+          # gcore object storage is S3-compatible; the AWS CLI is used only as an
+          # S3 client pointed at gcore's regional S3 endpoint (never AWS). The
+          # endpoint + region come from gcore-storage.sh (the location's
+          # technical_name), e.g. https://s-ed1.cloud.gcore.lu with region s-ed1.
           AWS_ACCESS_KEY_ID: ${{ steps.gstore.outputs.access_key }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.gstore.outputs.secret_key }}
-          # gcore object storage is S3-compatible; the AWS CLI is used only as an
-          # S3 client pointed at gcore's endpoint (never AWS). SigV4 needs a region
-          # value and gcore doesn't validate it, so a placeholder is fine. If a
-          # live run rejects the request, the knobs to try are this region and
-          # path-style addressing: aws configure set default.s3.addressing_style path
-          AWS_DEFAULT_REGION: us-east-1
-          ADDRESS: ${{ steps.gstore.outputs.address }}
+          AWS_DEFAULT_REGION: ${{ steps.gstore.outputs.region }}
+          ENDPOINT: ${{ steps.gstore.outputs.endpoint }}
           BUCKET: ${{ steps.gstore.outputs.bucket }}
         run: |
-          endpoint="https://${ADDRESS}"
           key="lantern-box/lantern-box-${VERSION}-${GITHUB_RUN_ID}.qcow2"
           qcow2="deploy/packer/output-gcore/lantern-box-${VERSION}-amd64.qcow2"
-          echo "Uploading ${qcow2} -> s3://${BUCKET}/${key} via ${endpoint}"
-          aws s3 cp "$qcow2" "s3://${BUCKET}/${key}" --endpoint-url "$endpoint"
-          url=$(aws s3 presign "s3://${BUCKET}/${key}" --endpoint-url "$endpoint" --expires-in 86400)
+          echo "Uploading ${qcow2} -> s3://${BUCKET}/${key} via ${ENDPOINT}"
+          aws s3 cp "$qcow2" "s3://${BUCKET}/${key}" --endpoint-url "$ENDPOINT"
+          url=$(aws s3 presign "s3://${BUCKET}/${key}" --endpoint-url "$ENDPOINT" --expires-in 86400)
           echo "::add-mask::$url"
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
@@ -610,12 +608,12 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.version }}
           AWS_ACCESS_KEY_ID: ${{ steps.gstore.outputs.access_key }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.gstore.outputs.secret_key }}
-          AWS_DEFAULT_REGION: us-east-1
-          ADDRESS: ${{ steps.gstore.outputs.address }}
+          AWS_DEFAULT_REGION: ${{ steps.gstore.outputs.region }}
+          ENDPOINT: ${{ steps.gstore.outputs.endpoint }}
           BUCKET: ${{ steps.gstore.outputs.bucket }}
         run: |
           key="lantern-box/lantern-box-${VERSION}-${GITHUB_RUN_ID}.qcow2"
-          aws s3 rm "s3://${BUCKET}/${key}" --endpoint-url "https://${ADDRESS}" || true
+          aws s3 rm "s3://${BUCKET}/${key}" --endpoint-url "$ENDPOINT" || true
 
       - name: Clean up gcore access key (gcore)
         if: always() && matrix.builder == 'gcore' && steps.gstore.outputs.access_key != ''

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -127,7 +127,8 @@ jobs:
           # failure this builder exists to fix, so the automatic push-to-main build
           # covers all of them, exactly as oracle-oci (36) and alicloud (8) already do.
           # A dispatch may narrow it for a scoped test; nothing else should.
-          default_regions="196,184,180,176,164,152,148,140,136,128,124,116,108,104,100,92,88,84,80,76,68,64,50,46,34,30,26,18,14,6"
+          # 6 not added because luxembourg is a "special" region
+          default_regions="196,184,180,176,164,152,148,140,136,128,124,116,108,104,100,92,88,84,80,76,68,64,50,46,34,30,26,18,14"
           regions="${INPUT_REGIONS:-$default_regions}"
           echo "regions=$regions" >> "$GITHUB_OUTPUT"
           echo "gcore regions: $regions"

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -597,6 +597,23 @@ jobs:
           IMAGE_URL: ${{ steps.gcs.outputs.url }}
         run: bash deploy/packer/gcore-publish.sh
 
+      - name: Delete staged qcow2 (gcore)
+        # Runs before the key revoke below because deleting the object needs the
+        # still-valid minted S3 credentials. The qcow2 is only needed during the
+        # import above, so remove it immediately rather than leaving a multi-GB
+        # object in the bucket. `|| true` so a missing object never fails the job.
+        if: always() && matrix.builder == 'gcore' && steps.gstore.outputs.access_key != ''
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          AWS_ACCESS_KEY_ID: ${{ steps.gstore.outputs.access_key }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.gstore.outputs.secret_key }}
+          AWS_DEFAULT_REGION: us-east-1
+          ADDRESS: ${{ steps.gstore.outputs.address }}
+          BUCKET: ${{ steps.gstore.outputs.bucket }}
+        run: |
+          key="lantern-box/lantern-box-${VERSION}-${GITHUB_RUN_ID}.qcow2"
+          aws s3 rm "s3://${BUCKET}/${key}" --endpoint-url "https://${ADDRESS}" || true
+
       - name: Clean up gcore access key (gcore)
         if: always() && matrix.builder == 'gcore' && steps.gstore.outputs.access_key != ''
         env:

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -9,8 +9,8 @@ on:
   push:
     branches: [main]
     paths:
-      - 'deploy/packer/**'
-      - '.github/workflows/build-images.yaml'
+      - "deploy/packer/**"
+      - ".github/workflows/build-images.yaml"
 
   # Allow manual trigger for ad-hoc rebuilds (base-image updates, etc.)
   workflow_dispatch:
@@ -25,9 +25,9 @@ on:
         default: "linode,oracle-oci,alicloud-ecs,gcore"
         type: string
       gcore_regions:
-        description: "Comma-separated Gcore numeric region IDs (gcore builder only). Default 180 = Frankfurt-2."
+        description: "Comma-separated Gcore numeric region IDs (gcore builder only)."
         required: false
-        default: "180"
+        default: "196,184,180,176,164,152,148,140,136,128,124,116,108,104,100,92,88,84,80,76,68,64,50,46,34,30,26,18,14,6"
         type: string
 
 permissions:
@@ -43,6 +43,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       matrix: ${{ steps.matrix.outputs.matrix }}
       gcore_regions: ${{ steps.gcore.outputs.regions }}
+      gcore_timeout: ${{ steps.gcore.outputs.timeout }}
     steps:
       - name: Checkout (full history — needed to find the latest tag)
         uses: actions/checkout@v6
@@ -111,7 +112,7 @@ jobs:
           echo "matrix={\"builder\":$json_array}" >> "$GITHUB_OUTPUT"
           echo "Matrix: $json_array"
 
-      - name: Resolve gcore regions
+      - name: Resolve gcore regions and build timeout
         id: gcore
         env:
           INPUT_REGIONS: ${{ github.event.inputs.gcore_regions }}
@@ -119,6 +120,34 @@ jobs:
           regions="${INPUT_REGIONS:-180}"
           echo "regions=$regions" >> "$GITHUB_OUTPUT"
           echo "gcore regions: $regions"
+          # The gcore build job's timeout is budgeted here because GitHub expressions have
+          # no arithmetic operators, so timeout-minutes cannot scale itself with the
+          # region count. gcore-publish.sh starts every import, then waits on them
+          # together, so the poll window is SHARED rather than per-region:
+          #   fixed 55min  qemu build (a slow apt mirror alone can approach 45min) +
+          #                storage provision + multi-GB upload + teardown
+          #   plus 35min   one shared poll window: POLL_ATTEMPTS(120) x
+          #                POLL_INTERVAL_SECS(15) = 30min, plus visibility/delete polling
+          #   plus 3/region the sequential import POSTs and visibility checks, and slack
+          #                for the fact that every region pulls the same object from one
+          #                bucket at once, so shared egress makes each import slower than
+          #                a solo one would be
+          # Keep these in step with gcore-publish.sh's poll defaults if those change. Note
+          # the real ceiling on many regions is not this timeout but POLL_ATTEMPTS: if
+          # shared egress pushes a single import past 30min, its task poll gives up no
+          # matter how long the job is allowed to run.
+          count=$(echo "$regions" | tr ',' '\n' | grep -c '[^[:space:]]' || true)
+          # Any failure above leaves count empty or 0; either way fall back to one
+          # region, so a miscount can never produce a nonsensical timeout.
+          [ "${count:-0}" -gt 0 ] 2>/dev/null || count=1
+          timeout=$((55 + 35 + count * 3))
+          # GitHub caps hosted-runner jobs at 360min.
+          if [ "$timeout" -gt 350 ]; then
+            timeout=350
+            echo "::warning::gcore build timeout capped at 350min for ${count} regions — raise POLL_ATTEMPTS or split the region list across runs rather than growing this further"
+          fi
+          echo "timeout=$timeout" >> "$GITHUB_OUTPUT"
+          echo "gcore build timeout: ${timeout}min (${count} region(s))"
 
   # Prune old images before building (avoids provider quota limits)
   prune:
@@ -163,6 +192,10 @@ jobs:
 
       - name: Prune old gcore images
         if: contains(needs.prepare.outputs.matrix, 'gcore')
+        # For `-eo pipefail`: without it a failing jq below leaves `sort` to report
+        # success, the image list comes back empty, and the step prints "Nothing to
+        # prune" instead of admitting it could not read the listing.
+        shell: bash
         env:
           GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
           GCORE_PROJECT_ID: ${{ secrets.GCORE_PROJECT_ID }}
@@ -176,22 +209,49 @@ jobs:
           for region in "${regions[@]}"; do
             region="${region//[[:space:]]/}"
             [ -z "$region" ] && continue
-            echo "Fetching gcore private images in region ${region}..."
-            if ! raw=$(curl -sS -f -H "$AUTH" \
+            echo "Fetching gcore lantern-box images in region ${region}..."
+            # Two passes, unioned by image ID. `?private=true` is the project's own
+            # images; the unfiltered list is the only place an import that landed
+            # "shared" or "public" shows up, and gcore has no API to change
+            # visibility after the fact. Listing only the private pass is how a
+            # non-private image becomes invisible here and is never collected.
+            # Both passes are kept rather than just the unfiltered one because
+            # gcore's default (whether it includes private images) is not something
+            # to bet the prune job on.
+            if ! priv=$(curl -sS -f -H "$AUTH" \
               "${API}/images/${GCORE_PROJECT_ID}/${region}?private=true"); then
+              echo "::error::Failed to list gcore private images in region ${region}"
+              failures=$((failures + 1))
+              continue
+            fi
+            if ! all=$(curl -sS -f -H "$AUTH" \
+              "${API}/images/${GCORE_PROJECT_ID}/${region}"); then
               echo "::error::Failed to list gcore images in region ${region}"
               failures=$((failures + 1))
               continue
             fi
-            images=$(echo "$raw" | jq -r '.results[] | select(.name | startswith("lantern-box-")) | "\(.created_at)\t\(.id)\t\(.name)"' | sort -r)
+            # The name filter is what keeps gcore's public catalog out of the union.
+            # Guarded because an empty result is indistinguishable from a parse failure
+            # once it reaches the keep-N check, and "no images" silently skips pruning.
+            if ! images=$(jq -rs '
+              ([.[0].results // [], .[1].results // []] | add)
+              | unique_by(.id)
+              | .[]
+              | select(.name | startswith("lantern-box-"))
+              | "\(.created_at)\t\(.id)\t\(.name)\t\(.visibility // "unknown")"' \
+              <<<"${priv}"$'\n'"${all}" | sort -r); then
+              echo "::error::Could not parse the gcore image listings for region ${region}"
+              failures=$((failures + 1))
+              continue
+            fi
             total=$(echo "$images" | grep -c . || true)
             echo "Region ${region}: found ${total} lantern-box images (keeping ${KEEP})"
             if [ "$total" -le "$KEEP" ]; then
               echo "Nothing to prune."
               continue
             fi
-            while IFS=$'\t' read -r created id name; do
-              echo "Deleting ${name} (${id}, created ${created}) in region ${region}..."
+            while IFS=$'\t' read -r created id name vis; do
+              echo "Deleting ${name} (${id}, created ${created}, visibility ${vis}) in region ${region}..."
               if ! http_code=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE -H "$AUTH" \
                 "${API}/images/${GCORE_PROJECT_ID}/${region}/${id}"); then
                 echo "::error::Failed to reach gcore to delete ${name} (${id}) in region ${region}"
@@ -200,6 +260,11 @@ jobs:
               fi
               if [ "$http_code" = "404" ]; then
                 echo "  Already gone (404), skipping."
+              elif [ "$http_code" = "403" ]; then
+                # The unfiltered pass can surface a public image belonging to another
+                # project that happens to match the name prefix. Not ours to delete,
+                # and not a failure.
+                echo "  Not ours to delete (403), skipping."
               elif [ "$http_code" -ge 400 ]; then
                 echo "::error::Failed to delete gcore image ${name} (${id}) in region ${region}: HTTP ${http_code}"
                 failures=$((failures + 1))
@@ -258,14 +323,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    # Serialize each builder against itself across runs. gcore needs this: the
+    # storage instance is shared, so gcore-storage.sh prunes ALL its access keys and
+    # sweeps ALL its stage buckets, and two overlapping runs would revoke each
+    # other's credentials mid-upload. Keyed on the builder so the builders still run
+    # in parallel with one another. Never cancel in flight — a cancelled gcore build
+    # is the one case that can strand a public stage bucket.
+    concurrency:
+      group: build-images-${{ matrix.builder }}
+      cancel-in-progress: false
     # Alicloud copies images to 8 regions (up to 2h). OCI builds 36 regions
     # in parallel — usually ~7min but a slow mirror can push past 45min.
-    # NOTE: gcore-publish.sh imports+polls each region SEQUENTIALLY (worst case
-    # ~30min/region: POLL_ATTEMPTS×POLL_INTERVAL_SECS) on the 60min default. Fine
-    # for the single-region default; before expanding gcore_regions, scale this
-    # timeout with the region count or parallelize the imports, else the job can
-    # be killed mid-import and leave orphaned gcore tasks. See PR #292.
-    timeout-minutes: ${{ matrix.builder == 'alicloud-ecs' && 150 || 60 }}
+    # gcore's is computed in prepare (see "Resolve gcore regions and build timeout"),
+    # because GitHub expressions cannot do arithmetic. 60min was not enough for even one
+    # region: a slow qemu build plus a multi-GB upload plus 30min of import polling
+    # overruns it, and being killed mid-import leaves orphaned gcore tasks behind. The
+    # imports themselves wait concurrently, so adding regions costs little wall-clock.
+    timeout-minutes: ${{ matrix.builder == 'alicloud-ecs' && 150 || (matrix.builder == 'gcore' && fromJSON(needs.prepare.outputs.gcore_timeout || '90') || 60) }}
 
     steps:
       - name: Checkout
@@ -551,17 +625,35 @@ jobs:
       - name: Provision gcore object storage (gcore)
         id: gstore
         if: matrix.builder == 'gcore'
+        # Explicit `shell: bash` for `-eo pipefail`; the default `bash -e {0}` has no
+        # pipefail, which is what let the old pipeline form below hide a failure.
+        shell: bash
         env:
           GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
         run: |
-          # Find-or-create the storage instance, sweep leftover stage buckets, make
-          # a fresh randomly-named bucket, and mint an ephemeral access key — all
-          # torn down in the cleanup steps below. Emits
+          # Find-or-create the storage instance, mint an ephemeral access key, sweep
+          # leftover stage buckets with it, and make a fresh randomly-named bucket with a
+          # 1-day expiry rule — all torn down in the cleanup steps below. Emits
           # storage_id/region/endpoint/bucket/access_key/secret_key as step outputs.
-          bash deploy/packer/gcore-storage.sh provision | while IFS='=' read -r k v; do
+          #
+          # Captured rather than piped into `while`: a pipeline takes the loop's exit
+          # status, so a failed provision reported success here and the real error only
+          # surfaced two steps later inside `aws s3 cp`. Every teardown step gates on
+          # these outputs, so this must fail loudly and in place. Provision's own
+          # diagnostics go to stderr, so its ::error:: annotations still reach the log.
+          out=$(bash deploy/packer/gcore-storage.sh provision)
+          # Guard the other direction too: a provision that exited 0 without emitting
+          # usable values would silently strand every teardown step, which all gate on
+          # access_key. grep rather than echo, so no secret is printed while validating.
+          for required in storage_id region endpoint bucket access_key secret_key; do
+            grep -q "^${required}=." <<<"$out" \
+              || { echo "::error::gcore provision succeeded but emitted no ${required}"; exit 1; }
+          done
+          while IFS='=' read -r k v; do
+            [ -n "$k" ] || continue
             case "$k" in access_key | secret_key | bucket) echo "::add-mask::$v" ;; esac
             echo "$k=$v" >> "$GITHUB_OUTPUT"
-          done
+          done <<<"$out"
 
       - name: Upload qcow2 and expose it for gcore import (gcore)
         id: stage
@@ -612,21 +704,68 @@ jobs:
           IMAGE_URL: ${{ steps.stage.outputs.url }}
         run: bash deploy/packer/gcore-publish.sh
 
-      - name: Delete staged qcow2 (gcore)
-        # Before the bucket/key teardown below: deleting the object needs the
-        # still-valid S3 credentials, and the control-plane bucket delete needs an
-        # empty bucket. `|| true` so a missing object never fails the job.
+      - name: Revoke public access to the stage bucket (gcore)
+        # FIRST teardown action, ahead of the object and bucket deletes below.
+        # Dropping the anonymous-read policy is what actually ends the public window,
+        # and unlike the deletes it succeeds even on a non-empty bucket — so the
+        # exposure closes regardless of how the rest of the cleanup goes. Everything
+        # after this step is reclaiming storage, not containing a leak.
         if: always() && matrix.builder == 'gcore' && steps.gstore.outputs.access_key != ''
+        # For `-eo pipefail`; also keeps this step's semantics identical to the scripts.
+        shell: bash
         env:
-          VERSION: ${{ needs.prepare.outputs.version }}
           AWS_ACCESS_KEY_ID: ${{ steps.gstore.outputs.access_key }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.gstore.outputs.secret_key }}
           AWS_DEFAULT_REGION: ${{ steps.gstore.outputs.region }}
           ENDPOINT: ${{ steps.gstore.outputs.endpoint }}
           BUCKET: ${{ steps.gstore.outputs.bucket }}
+          STORAGE_ID: ${{ steps.gstore.outputs.storage_id }}
         run: |
-          key="lantern-box-${VERSION}-${GITHUB_RUN_ID}.qcow2"
-          aws s3 rm "s3://${BUCKET}/${key}" --endpoint-url "$ENDPOINT" || true
+          # This step also runs when the build failed before the policy was ever
+          # applied, so "no policy" is a success — but ONLY when that is confirmed.
+          # An unreadable policy must never be reported as an absent one: this is the
+          # step that contains the exposure, so "could not tell" has to fail loudly.
+          # The bucket name is masked in the log, hence the prefix hint for a human.
+          if aws s3api delete-bucket-policy --bucket "$BUCKET" --endpoint-url "$ENDPOINT" 2>/tmp/revoke.err; then
+            echo "revoked the anonymous-read policy on the stage bucket"
+            exit 0
+          fi
+          # The delete failed. Reaching for get-bucket-policy distinguishes the benign
+          # case (there was never a policy) from the dangerous one (a policy is there
+          # and could not be removed) — and from not knowing, e.g. revoked credentials
+          # or a network blip, which fails both calls and must not look benign.
+          if get_err=$(aws s3api get-bucket-policy --bucket "$BUCKET" --endpoint-url "$ENDPOINT" 2>&1); then
+            echo "::error::the gcore stage bucket still carries a policy that could not be removed — the staged qcow2 may still be publicly readable. Delete the policy or the bucket by hand: it is a lantern-box-stage-* bucket on gcore storage instance ${STORAGE_ID}."
+            cat /tmp/revoke.err >&2
+            exit 1
+          fi
+          if grep -qi 'NoSuchBucketPolicy\|NoSuchBucket\|not *found\|404' <<<"$get_err"; then
+            echo "no bucket policy present (never applied, or already gone)"
+            exit 0
+          fi
+          echo "::error::could not remove the gcore stage bucket's policy AND could not read it back, so it is unknown whether the staged qcow2 is still publicly readable — treat it as exposed. Check the lantern-box-stage-* buckets on gcore storage instance ${STORAGE_ID} by hand."
+          cat /tmp/revoke.err >&2
+          printf '%s\n' "$get_err" >&2
+          exit 1
+
+      - name: Empty the stage bucket (gcore)
+        # Between the revoke above and the bucket delete below: emptying needs the
+        # still-valid S3 credentials, and the control-plane bucket delete refuses a
+        # non-empty bucket. Shares gcore-storage.sh's empty_bucket with the stale-bucket
+        # sweep, so both paths abort incomplete multipart uploads before removing
+        # objects — `s3 rm` alone leaves the parts of a killed upload behind, and those
+        # would block the bucket delete forever. Best-effort by design: this also runs
+        # when the build never got as far as uploading, and the bucket delete below is
+        # what reports a genuinely stuck bucket.
+        if: always() && matrix.builder == 'gcore' && steps.gstore.outputs.access_key != ''
+        env:
+          GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ steps.gstore.outputs.access_key }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.gstore.outputs.secret_key }}
+          AWS_DEFAULT_REGION: ${{ steps.gstore.outputs.region }}
+          ENDPOINT: ${{ steps.gstore.outputs.endpoint }}
+          BUCKET: ${{ steps.gstore.outputs.bucket }}
+        run: bash deploy/packer/gcore-storage.sh empty-bucket
 
       - name: Clean up gcore stage bucket and access key (gcore)
         if: always() && matrix.builder == 'gcore' && steps.gstore.outputs.access_key != ''

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -524,11 +524,14 @@ jobs:
           fi
           echo "All gcore secrets present"
 
-      - name: Enable KVM (gcore)
+      - name: Install QEMU deps and enable KVM (gcore)
         if: matrix.builder == 'gcore'
         run: |
           sudo apt-get update
-          sudo apt-get install -y -q qemu-system-x86 qemu-utils
+          # xorriso builds the NoCloud cidata seed ISO from the qemu source's
+          # cd_content; it isn't preinstalled on the runner. qemu-system-x86 and
+          # qemu-utils provide the emulator and qcow2 tooling.
+          sudo apt-get install -y -q qemu-system-x86 qemu-utils xorriso
           if [ ! -e /dev/kvm ]; then
             echo "::error::/dev/kvm not available on this runner — QEMU build requires KVM"
             exit 1

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -24,10 +24,8 @@ on:
         required: false
         default: "linode,oracle-oci,alicloud-ecs,gcore"
         type: string
-      # Deliberately NOT prefilled with the default list. The list lives in exactly one
-      # place — the "Resolve gcore regions and build timeout" step — because a prefilled
-      # default here would be a second copy that a push-triggered run never uses, and the
-      # two silently drifted apart once already.
+      # NOT prefilled: a default here would be a second copy of the list that
+      # push-triggered runs never use, and the two silently drifted apart once already.
       gcore_regions:
         description: "Comma-separated Gcore numeric region IDs (gcore builder only). Blank = every region lantern-cloud provisions in."
         required: false
@@ -120,37 +118,23 @@ jobs:
         env:
           INPUT_REGIONS: ${{ github.event.inputs.gcore_regions }}
         run: |
-          # THE gcore region list — the only copy. Every gcore region lantern-cloud can
-          # provision a VPS in, because its provider looks the boot image up per region
-          # and fails outright where one is missing. Publishing to a subset is what
-          # caused the "no gcore image matching prefix lantern-box- in region 180"
-          # failure this builder exists to fix, so the automatic push-to-main build
-          # covers all of them, exactly as oracle-oci (36) and alicloud (8) already do.
-          # A dispatch may narrow it for a scoped test; nothing else should.
+          # THE gcore region list — the only copy. Every region lantern-cloud provisions
+          # in, since its provider fails outright where the image is missing. A dispatch
+          # may narrow it for a scoped test; nothing else should.
           # 6 not added because luxembourg is a "special" region
           default_regions="196,184,180,176,164,152,148,140,136,128,124,116,108,104,100,92,88,84,80,76,68,64,50,46,34,30,26,18,14"
           regions="${INPUT_REGIONS:-$default_regions}"
           echo "regions=$regions" >> "$GITHUB_OUTPUT"
           echo "gcore regions: $regions"
-          # The gcore build job's timeout is budgeted here because GitHub expressions have
-          # no arithmetic operators, so timeout-minutes cannot scale itself with the
-          # region count. gcore-publish.sh starts every import, then waits on them
-          # together, so the poll window is SHARED rather than per-region:
-          #   fixed 55min  qemu build (a slow apt mirror alone can approach 45min) +
-          #                storage provision + multi-GB upload + teardown
-          #   plus 35min   one shared poll window: POLL_ATTEMPTS(120) x
-          #                POLL_INTERVAL_SECS(15) = 30min, plus visibility/delete polling
-          #   plus 3/region the sequential import POSTs and visibility checks, and slack
-          #                for the fact that every region pulls the same object from one
-          #                bucket at once, so shared egress makes each import slower than
-          #                a solo one would be
-          # Keep these in step with gcore-publish.sh's poll defaults if those change. Note
-          # the real ceiling on many regions is not this timeout but POLL_ATTEMPTS: if
-          # shared egress pushes a single import past 30min, its task poll gives up no
-          # matter how long the job is allowed to run.
+          # Budgeted here because GitHub expressions have no arithmetic, so
+          # timeout-minutes cannot scale with the region count. The poll window is
+          # SHARED, not per-region: 55min build/upload/teardown + 35min for
+          # POLL_ATTEMPTS(120) x POLL_INTERVAL_SECS(15) and visibility/delete polling
+          # + 3/region for the staggered POSTs and checks. Keep in step with
+          # gcore-publish.sh's poll defaults. The real ceiling on many regions is
+          # POLL_ATTEMPTS, not this timeout.
           count=$(echo "$regions" | tr ',' '\n' | grep -c '[^[:space:]]' || true)
-          # Any failure above leaves count empty or 0; either way fall back to one
-          # region, so a miscount can never produce a nonsensical timeout.
+          # Empty or 0 falls back to one region, never a nonsensical timeout.
           [ "${count:-0}" -gt 0 ] 2>/dev/null || count=1
           timeout=$((55 + 35 + count * 3))
           # GitHub caps hosted-runner jobs at 360min.
@@ -204,9 +188,8 @@ jobs:
 
       - name: Prune old gcore images
         if: contains(needs.prepare.outputs.matrix, 'gcore')
-        # For `-eo pipefail`: without it a failing jq below leaves `sort` to report
-        # success, the image list comes back empty, and the step prints "Nothing to
-        # prune" instead of admitting it could not read the listing.
+        # For `-eo pipefail`: without it a failing jq lets `sort` report success and the
+        # step prints "Nothing to prune" instead of admitting it could not read the list.
         shell: bash
         env:
           GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
@@ -222,14 +205,9 @@ jobs:
             region="${region//[[:space:]]/}"
             [ -z "$region" ] && continue
             echo "Fetching gcore lantern-box images in region ${region}..."
-            # Two passes, unioned by image ID. `?private=true` is the project's own
-            # images; the unfiltered list is the only place an import that landed
-            # "shared" or "public" shows up, and gcore has no API to change
-            # visibility after the fact. Listing only the private pass is how a
-            # non-private image becomes invisible here and is never collected.
-            # Both passes are kept rather than just the unfiltered one because
-            # gcore's default (whether it includes private images) is not something
-            # to bet the prune job on.
+            # Two passes, unioned by ID. The unfiltered list is the only place a
+            # "shared" or "public" import shows up; the private pass is kept because
+            # gcore's unfiltered default is not documented enough to bet prune on.
             if ! priv=$(curl -sS -f -H "$AUTH" \
               "${API}/images/${GCORE_PROJECT_ID}/${region}?private=true"); then
               echo "::error::Failed to list gcore private images in region ${region}"
@@ -242,9 +220,8 @@ jobs:
               failures=$((failures + 1))
               continue
             fi
-            # The name filter is what keeps gcore's public catalog out of the union.
-            # Guarded because an empty result is indistinguishable from a parse failure
-            # once it reaches the keep-N check, and "no images" silently skips pruning.
+            # The name filter keeps gcore's public catalog out of the union. Guarded
+            # because a parse failure looks like "no images" and silently skips pruning.
             if ! images=$(jq -rs '
               ([.[0].results // [], .[1].results // []] | add)
               | unique_by(.id)
@@ -273,9 +250,8 @@ jobs:
               if [ "$http_code" = "404" ]; then
                 echo "  Already gone (404), skipping."
               elif [ "$http_code" = "403" ]; then
-                # The unfiltered pass can surface a public image belonging to another
-                # project that happens to match the name prefix. Not ours to delete,
-                # and not a failure.
+                # The unfiltered pass can surface another project's public image that
+                # matches the prefix. Not ours to delete, not a failure.
                 echo "  Not ours to delete (403), skipping."
               elif [ "$http_code" -ge 400 ]; then
                 echo "::error::Failed to delete gcore image ${name} (${id}) in region ${region}: HTTP ${http_code}"
@@ -335,22 +311,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
-    # Serialize each builder against itself across runs. gcore needs this: the
-    # storage instance is shared, so gcore-storage.sh prunes ALL its access keys and
-    # sweeps ALL its stage buckets, and two overlapping runs would revoke each
-    # other's credentials mid-upload. Keyed on the builder so the builders still run
-    # in parallel with one another. Never cancel in flight — a cancelled gcore build
+    # Serialize each builder against itself across runs. gcore needs it: the storage
+    # instance is shared, so gcore-storage.sh prunes ALL access keys and sweeps ALL stage
+    # buckets, and overlapping runs would revoke each other's credentials mid-upload.
+    # Keyed per builder so builders still run in parallel. Never cancel in flight — that
     # is the one case that can strand a public stage bucket.
     concurrency:
       group: build-images-${{ matrix.builder }}
       cancel-in-progress: false
     # Alicloud copies images to 8 regions (up to 2h). OCI builds 36 regions
     # in parallel — usually ~7min but a slow mirror can push past 45min.
-    # gcore's is computed in prepare (see "Resolve gcore regions and build timeout"),
-    # because GitHub expressions cannot do arithmetic. 60min was not enough for even one
-    # region: a slow qemu build plus a multi-GB upload plus 30min of import polling
-    # overruns it, and being killed mid-import leaves orphaned gcore tasks behind. The
-    # imports themselves wait concurrently, so adding regions costs little wall-clock.
+    # gcore's is computed in prepare, since GitHub expressions cannot do arithmetic. 60min
+    # was not enough for even one region, and being killed mid-import strands gcore tasks.
     timeout-minutes: ${{ matrix.builder == 'alicloud-ecs' && 150 || (matrix.builder == 'gcore' && fromJSON(needs.prepare.outputs.gcore_timeout || '90') || 60) }}
 
     steps:
@@ -610,9 +582,7 @@ jobs:
         if: matrix.builder == 'gcore'
         run: |
           sudo apt-get update
-          # xorriso builds the NoCloud cidata seed ISO from the qemu source's
-          # cd_content and isn't preinstalled; qemu-system-x86 and qemu-utils
-          # provide the emulator and qcow2 tooling.
+          # xorriso builds the NoCloud cidata seed ISO and isn't preinstalled.
           sudo apt-get install -y -q qemu-system-x86 qemu-utils xorriso
           if [ ! -e /dev/kvm ]; then
             echo "::error::/dev/kvm not available on this runner — QEMU build requires KVM"
@@ -627,15 +597,12 @@ jobs:
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          # Mint the build-only SSH password here rather than reading a repo secret.
-          # Packer needs a password to reach the cloud image, and the generalize step
-          # locks the account afterwards — but the account's hash still ships in the
-          # qcow2's /etc/shadow, and that qcow2 is briefly world-readable while gcore
-          # imports it. A long-lived secret's hash would stay valid for every later
-          # build if that window were ever caught; a per-run value is worthless the
-          # moment this job ends. Hex, not base64: the value is interpolated into the
-          # cloud-init YAML and into shutdown_command's single-quoted shell string, and
-          # hex cannot carry a quote, a slash, or a YAML indicator.
+          # Per-run, not a repo secret: the account's hash ships in the qcow2's
+          # /etc/shadow, and that qcow2 is briefly world-readable during import. A
+          # long-lived hash would stay valid for every later build; this one dies with
+          # the job. Hex, not base64 — it is interpolated into cloud-init YAML and a
+          # single-quoted shell string, and hex cannot carry a quote, slash, or YAML
+          # indicator.
           QEMU_SSH_PASSWORD="$(openssl rand -hex 24)"
           echo "::add-mask::$QEMU_SSH_PASSWORD"
           export QEMU_SSH_PASSWORD
@@ -653,20 +620,17 @@ jobs:
         env:
           GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
         run: |
-          # Find-or-create the storage instance, mint an ephemeral access key, sweep
-          # leftover stage buckets with it, and make a fresh randomly-named bucket with a
-          # 1-day expiry rule — all torn down in the cleanup steps below. Emits
-          # storage_id/region/endpoint/bucket/access_key/secret_key as step outputs.
+          # Find-or-create the storage instance, mint an ephemeral key, sweep leftover
+          # stage buckets, and make a fresh randomly-named bucket with a 1-day expiry —
+          # all torn down below. Emits storage_id/region/endpoint/bucket/access_key/
+          # secret_key as step outputs.
           #
-          # Captured rather than piped into `while`: a pipeline takes the loop's exit
-          # status, so a failed provision reported success here and the real error only
-          # surfaced two steps later inside `aws s3 cp`. Every teardown step gates on
-          # these outputs, so this must fail loudly and in place. Provision's own
-          # diagnostics go to stderr, so its ::error:: annotations still reach the log.
+          # Captured, not piped into `while`: a pipeline takes the loop's exit status, so
+          # a failed provision reported success and surfaced two steps later in `aws s3
+          # cp`. Every teardown gates on these outputs, so this must fail in place.
           out=$(bash deploy/packer/gcore-storage.sh provision)
-          # Guard the other direction too: a provision that exited 0 without emitting
-          # usable values would silently strand every teardown step, which all gate on
-          # access_key. grep rather than echo, so no secret is printed while validating.
+          # A provision that exits 0 without usable values would strand every teardown.
+          # grep rather than echo, so no secret is printed while validating.
           for required in storage_id region endpoint bucket access_key secret_key; do
             grep -q "^${required}=." <<<"$out" \
               || { echo "::error::gcore provision succeeded but emitted no ${required}"; exit 1; }
@@ -682,9 +646,8 @@ jobs:
         if: matrix.builder == 'gcore'
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
-          # The AWS CLI is used only as a generic S3 client pointed at gcore's
-          # regional endpoint (never AWS). Endpoint + region come from
-          # gcore-storage.sh, e.g. https://s-ed1.cloud.gcore.lu with region s-ed1.
+          # The AWS CLI is only a generic S3 client here, pointed at gcore's regional
+          # endpoint (never AWS) — e.g. https://s-ed1.cloud.gcore.lu, region s-ed1.
           AWS_ACCESS_KEY_ID: ${{ steps.gstore.outputs.access_key }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.gstore.outputs.secret_key }}
           AWS_DEFAULT_REGION: ${{ steps.gstore.outputs.region }}
@@ -692,11 +655,9 @@ jobs:
           BUCKET: ${{ steps.gstore.outputs.bucket }}
         run: |
           # gcore's importer fetches an UNAUTHENTICATED URL (HEAD then GET), so a
-          # method-bound presigned URL can't satisfy it — the object must be
-          # anonymously readable. Upload to the throwaway bucket from the previous
-          # step and grant anonymous s3:GetObject for the import; the bucket and its
-          # policy are torn down below. The bucket name is masked and the URL never
-          # logged, so the short public window stays unguessable.
+          # method-bound presigned URL cannot satisfy it — the object must be anonymously
+          # readable. Grant anonymous s3:GetObject on the throwaway bucket; both are torn
+          # down below. Name masked and URL never logged, so the window is unguessable.
           key="lantern-box-${VERSION}-${GITHUB_RUN_ID}.qcow2"
           qcow2="deploy/packer/output-gcore/lantern-box-${VERSION}-amd64.qcow2"
           echo "Uploading ${qcow2} to the staging bucket via ${ENDPOINT}"
@@ -727,11 +688,9 @@ jobs:
         run: bash deploy/packer/gcore-publish.sh
 
       - name: Revoke public access to the stage bucket (gcore)
-        # FIRST teardown action, ahead of the object and bucket deletes below.
-        # Dropping the anonymous-read policy is what actually ends the public window,
-        # and unlike the deletes it succeeds even on a non-empty bucket — so the
-        # exposure closes regardless of how the rest of the cleanup goes. Everything
-        # after this step is reclaiming storage, not containing a leak.
+        # FIRST teardown action. Dropping the policy is what ends the public window, and
+        # unlike the deletes it succeeds on a non-empty bucket, so the exposure closes
+        # regardless of the rest. Everything after this reclaims storage, not a leak.
         if: always() && matrix.builder == 'gcore' && steps.gstore.outputs.access_key != ''
         # For `-eo pipefail`; also keeps this step's semantics identical to the scripts.
         shell: bash
@@ -743,19 +702,16 @@ jobs:
           BUCKET: ${{ steps.gstore.outputs.bucket }}
           STORAGE_ID: ${{ steps.gstore.outputs.storage_id }}
         run: |
-          # This step also runs when the build failed before the policy was ever
-          # applied, so "no policy" is a success — but ONLY when that is confirmed.
-          # An unreadable policy must never be reported as an absent one: this is the
-          # step that contains the exposure, so "could not tell" has to fail loudly.
-          # The bucket name is masked in the log, hence the prefix hint for a human.
+          # Also runs when the build failed before the policy was applied, so "no policy"
+          # is a success — but ONLY when confirmed. This step contains the exposure, so
+          # "could not tell" fails loudly. Bucket name is masked, hence the prefix hint.
           if aws s3api delete-bucket-policy --bucket "$BUCKET" --endpoint-url "$ENDPOINT" 2>/tmp/revoke.err; then
             echo "revoked the anonymous-read policy on the stage bucket"
             exit 0
           fi
-          # The delete failed. Reaching for get-bucket-policy distinguishes the benign
-          # case (there was never a policy) from the dangerous one (a policy is there
-          # and could not be removed) — and from not knowing, e.g. revoked credentials
-          # or a network blip, which fails both calls and must not look benign.
+          # The delete failed. get-bucket-policy separates the benign case (never a
+          # policy) from the dangerous one (present, unremovable) — and from not knowing,
+          # e.g. revoked credentials, which fails both calls and must not look benign.
           if get_err=$(aws s3api get-bucket-policy --bucket "$BUCKET" --endpoint-url "$ENDPOINT" 2>&1); then
             echo "::error::the gcore stage bucket still carries a policy that could not be removed — the staged qcow2 may still be publicly readable. Delete the policy or the bucket by hand: it is a lantern-box-stage-* bucket on gcore storage instance ${STORAGE_ID}."
             cat /tmp/revoke.err >&2
@@ -771,14 +727,11 @@ jobs:
           exit 1
 
       - name: Empty the stage bucket (gcore)
-        # Between the revoke above and the bucket delete below: emptying needs the
-        # still-valid S3 credentials, and the control-plane bucket delete refuses a
-        # non-empty bucket. Shares gcore-storage.sh's empty_bucket with the stale-bucket
-        # sweep, so both paths abort incomplete multipart uploads before removing
-        # objects — `s3 rm` alone leaves the parts of a killed upload behind, and those
-        # would block the bucket delete forever. Best-effort by design: this also runs
-        # when the build never got as far as uploading, and the bucket delete below is
-        # what reports a genuinely stuck bucket.
+        # Needs the still-valid S3 credentials, and the bucket delete below refuses a
+        # non-empty bucket. Shares empty_bucket with the stale sweep so both abort
+        # incomplete multipart uploads first — `s3 rm` alone leaves a killed upload's
+        # parts behind, blocking the delete forever. Best-effort: the delete reports a
+        # genuinely stuck bucket.
         if: always() && matrix.builder == 'gcore' && steps.gstore.outputs.access_key != ''
         env:
           GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}

--- a/deploy/packer/README.md
+++ b/deploy/packer/README.md
@@ -124,13 +124,30 @@ provider's image store) gcore uses a **build → host → import** pipeline:
    builder (so image contents match), then generalizes the disk (cloud-init
    clean, zero machine-id, drop SSH host keys, lock the build password) so the
    raw disk boots fresh on import.
-2. CI stages the qcow2 in **gcore's own S3-compatible object storage** and hands
-   gcore a short-lived presigned URL — no external cloud, no stored bucket/key
-   secret. `deploy/packer/gcore-storage.sh` (gcore control plane, via the API)
-   find-or-creates a dedicated storage instance (`lantern-box-images`, location
-   `luxembourg-2`) + bucket and mints an **ephemeral** access key; the AWS CLI —
-   as a generic S3 client pointed at gcore's endpoint, not AWS — uploads the
-   qcow2 and `presign`s a 24h URL; a cleanup step revokes the key.
+2. CI stages the qcow2 in **gcore's own S3-compatible object storage**, in a
+   throwaway, **randomly-named** bucket that is made briefly public-read for the
+   import and then torn down — no external cloud, no stored bucket/key secret.
+   This is required because gcore's importer fetches an **unauthenticated** URL
+   (it does a HEAD then a GET): the API has no field for source credentials, and
+   a presigned/SigV4 URL is bound to one HTTP method (its HEAD preflight 403s),
+   so the object has to be anonymously readable. `deploy/packer/gcore-storage.sh`
+   (gcore control plane, via the API) find-or-creates a dedicated storage
+   instance (`lantern-box-images`, location `luxembourg-2`), sweeps any leftover
+   stage buckets, creates a fresh `lantern-box-stage-<random>` bucket, and mints
+   an **ephemeral** access key; the AWS CLI — as a generic S3 client pointed at
+   gcore's endpoint, not AWS — uploads the qcow2 and applies an anonymous
+   `s3:GetObject` bucket policy. The plain
+   `https://<region>.cloud.gcore.lu/<bucket>/<key>` URL is handed to gcore. After
+   the imports, `always()` cleanup steps delete the object, then the bucket (with
+   its public policy) and the access key.
+
+   The image is world-readable only for the length of the imports, and this is a
+   deliberate tradeoff: the bucket name is unguessable, the bucket holds only
+   that one qcow2, the URL is masked out of the CI logs, and teardown runs even
+   on failure. A run hard-killed between exposing and tearing down could leave a
+   public bucket behind until the next run's sweep removes it (the sweep can only
+   delete an *empty* leftover via the control plane; one that still holds an
+   object must be emptied — S3 `rm` — and deleted by hand).
 3. `deploy/packer/gcore-publish.sh` imports that URL into each target region via
    `POST cloud/v1/downloadimage/{project}/{region}` (name `lantern-box-<version>`,
    `architecture=x86_64`, `os_type=linux`) and polls each task to `FINISHED`.
@@ -152,9 +169,10 @@ in CI, not on macOS. To validate the config anywhere:
 - Repo secrets: `GCORE_API_KEY` (must have **object-storage** permission, not just
   cloud/compute), `GCORE_PROJECT_ID`, `QEMU_SSH_PASSWORD`.
 
-That's it — the storage instance, bucket, and (ephemeral) access keys are created
-and torn down by the workflow itself (`gcore-storage.sh`), so there's no bucket to
-pre-create and no cloud IAM to configure.
+That's it — the storage instance, the per-run stage bucket, and the (ephemeral)
+access keys are created and torn down by the workflow itself
+(`gcore-storage.sh`), so there's no bucket to pre-create and no cloud IAM to
+configure.
 
 ## Adding a new cloud provider
 

--- a/deploy/packer/README.md
+++ b/deploy/packer/README.md
@@ -125,36 +125,43 @@ provider's image store) gcore uses a **build → host → import** pipeline:
    clean, zero machine-id, drop SSH host keys, lock the build password) so the
    raw disk boots fresh on import.
 2. CI stages the qcow2 in **gcore's own S3-compatible object storage**, in a
-   throwaway, **randomly-named** bucket that is made briefly public-read for the
-   import and then torn down — no external cloud, no stored bucket/key secret.
-   This is required because gcore's importer fetches an **unauthenticated** URL
-   (it does a HEAD then a GET): the API has no field for source credentials, and
-   a presigned/SigV4 URL is bound to one HTTP method (its HEAD preflight 403s),
-   so the object has to be anonymously readable. `deploy/packer/gcore-storage.sh`
-   (gcore control plane, via the API) find-or-creates a dedicated storage
-   instance (`lantern-box-images`, location `luxembourg-2`), sweeps any leftover
-   stage buckets, creates a fresh `lantern-box-stage-<random>` bucket, and mints
-   an **ephemeral** access key; the AWS CLI — as a generic S3 client pointed at
-   gcore's endpoint, not AWS — uploads the qcow2 and applies an anonymous
-   `s3:GetObject` bucket policy. The plain
-   `https://<region>.cloud.gcore.lu/<bucket>/<key>` URL is handed to gcore. After
-   the imports, `always()` cleanup steps delete the object, then the bucket (with
-   its public policy) and the access key.
+   throwaway, **randomly-named** bucket made briefly public-read for the import
+   and then torn down — no external cloud, no stored bucket/key secret. Public is
+   required: gcore's importer fetches an **unauthenticated** URL (HEAD then GET),
+   the API has no field for source credentials, and a presigned SigV4 URL is bound
+   to one method (its HEAD preflight 403s). `deploy/packer/gcore-storage.sh` drives
+   the gcore control plane — find-or-create a dedicated storage instance
+   (`lantern-box-images`, location `luxembourg-2`), sweep leftover stage buckets,
+   create a fresh `lantern-box-stage-<random>` bucket, mint an **ephemeral** access
+   key — and the AWS CLI, as a generic S3 client pointed at gcore's endpoint,
+   uploads the qcow2 and applies an anonymous `s3:GetObject` policy. gcore is
+   handed the plain `https://<region>.cloud.gcore.lu/<bucket>/<key>` URL. `always()`
+   cleanup steps then delete the object, the bucket, and the access key.
 
-   The image is world-readable only for the length of the imports, and this is a
-   deliberate tradeoff: the bucket name is unguessable, the bucket holds only
-   that one qcow2, the URL is masked out of the CI logs, and teardown runs even
-   on failure. A run hard-killed between exposing and tearing down could leave a
-   public bucket behind until the next run's sweep removes it (the sweep can only
-   delete an *empty* leftover via the control plane; one that still holds an
-   object must be emptied — S3 `rm` — and deleted by hand).
+   The tradeoff: world-readable for the length of the imports only, with an
+   unguessable bucket name holding just that one qcow2, the URL masked out of CI
+   logs, and teardown running even on failure. A hard-killed run can leave a public
+   bucket until the next run's sweep — and the sweep can only delete an *empty*
+   leftover, so one still holding an object must be emptied (S3 `rm`) by hand.
 3. `deploy/packer/gcore-publish.sh` imports that URL into each target region via
    `POST cloud/v1/downloadimage/{project}/{region}` (name `lantern-box-<version>`,
-   `architecture=x86_64`, `os_type=linux`) and polls each task to `FINISHED`.
+   `architecture=x86_64`, `os_type=linux`), polls each task to `FINISHED`, and reads
+   back the created image's `visibility`.
 
-lantern-cloud's gcore provider then resolves the boot image by listing private
-images per region, keeping names prefixed `lantern-box-`, and picking the newest
-(x86_64, no fallback).
+**Image visibility** is read-only in gcore's API: neither
+`POST cloud/v1/downloadimage/...` nor `PATCH cloud/v1/images/...` accepts the
+field, and `private`/`visibility` exist only as *list filters*. It is not a
+boolean — an image is exactly one of:
+
+- `private` — this project only.
+- `shared` — this project plus any project added as a member. Gcore exposes no
+  image-member API, so in practice this is also project-only. **Not** public.
+- `public` — every gcore customer; gcore's global catalog.
+
+So step 3 reports the value rather than setting it: `private` is logged, `public`
+fails the publish, and `shared` only warns. `shared` is safe but invisible to
+`?private=true` listings — including the prune job's — so old images stop being
+collected and any lookup filtering that way finds nothing.
 
 **Regions** are numeric gcore region IDs. The workflow's `gcore_regions` input
 (default `180` = Frankfurt-2) controls where the image is published; the prune

--- a/deploy/packer/README.md
+++ b/deploy/packer/README.md
@@ -186,7 +186,9 @@ provider's image store) gcore uses a **build → host → import** pipeline:
 3. `deploy/packer/gcore-publish.sh` imports that URL into each target region via
    `POST cloud/v1/downloadimage/{project}/{region}` (name `lantern-box-<version>`,
    `architecture=x86_64`, `os_type=linux`), polls each task to `FINISHED`, and checks
-   the created image's `visibility`.
+   the created image's `visibility`. POSTs are spaced by `IMPORT_STAGGER_SECS`
+   (default 30) because gcore reaps a task not *started* within 10min of its own
+   `created_on` — submitting ~30 at once gave them one deadline it could not meet.
 
 **Image visibility** is read-only in gcore's API: neither
 `POST cloud/v1/downloadimage/...` nor `PATCH cloud/v1/images/...` accepts the

--- a/deploy/packer/README.md
+++ b/deploy/packer/README.md
@@ -87,6 +87,10 @@ In CI, the `datacap` binary is built from `getlantern/lantern-cloud` and baked i
 | `OCI_AVAILABILITY_DOMAIN_BOM` | OCI AD — ap-mumbai-1 |
 | `OCI_SUBNET_OCID_GRU` | OCI subnet — sa-saopaulo-1 |
 | `OCI_AVAILABILITY_DOMAIN_GRU` | OCI AD — sa-saopaulo-1 |
+| `GCORE_API_KEY` | Gcore Cloud API token (sent as `Authorization: APIKey ...`) |
+| `GCORE_PROJECT_ID` | Gcore project ID (numeric); scopes every API call |
+| `QEMU_SSH_PASSWORD` | Build-time password for the ubuntu user in the QEMU (gcore) build |
+| `GCORE_IMAGE_GCS_BUCKET` | Private GCS bucket the built qcow2 is uploaded to for import |
 
 ## Deploy a VPS from the image
 
@@ -109,6 +113,46 @@ linode-cli linodes create \
 ## CI
 
 The `build-images.yaml` workflow runs automatically when a GitHub release is published. It can also be triggered manually via workflow_dispatch.
+
+## gcore
+
+gcore has **no Packer plugin** and **no cross-region image-copy API**, so unlike
+the other builders (whose plugins snapshot the built instance straight into the
+provider's image store) gcore uses a **build → host → import** pipeline:
+
+1. The `qemu.lantern-box-gcore` Packer source builds one qcow2 from the stock
+   Ubuntu 24.04 cloud image, reusing the **same** provisioners as every other
+   builder (so image contents match), then generalizes the disk (cloud-init
+   clean, zero machine-id, drop SSH host keys, lock the build password) so the
+   raw disk boots fresh on import.
+2. CI uploads the qcow2 to a private GCS bucket and mints a 24h V4 signed URL
+   (reusing the repo's existing Workload Identity Federation to the
+   `lantern-cloud` GCP project — no static key).
+3. `deploy/packer/gcore-publish.sh` imports that URL into each target region via
+   `POST cloud/v1/downloadimage/{project}/{region}` (name `lantern-box-<version>`,
+   `architecture=x86_64`, `os_type=linux`) and polls each task to `FINISHED`.
+
+lantern-cloud's gcore provider then resolves the boot image by listing private
+images per region, keeping names prefixed `lantern-box-`, and picking the newest
+(x86_64, no fallback).
+
+**Regions** are numeric gcore region IDs. The workflow's `gcore_regions` input
+(default `180` = Frankfurt-2) controls where the image is published; the prune
+job keeps the 3 newest `lantern-box-` images per region.
+
+**Local build:** the QEMU build requires **Linux + KVM** (`/dev/kvm`), so it runs
+in CI, not on macOS. To validate the config anywhere:
+`cd deploy/packer && packer init . && packer validate -only=qemu.lantern-box-gcore -var lantern_box_version=0.0.0 .`
+
+**Operator prerequisites (one-time):**
+
+- Repo secrets: `GCORE_API_KEY`, `GCORE_PROJECT_ID`, `QEMU_SSH_PASSWORD`,
+  `GCORE_IMAGE_GCS_BUCKET`.
+- GCP (lantern-cloud project): create the private GCS bucket (add a short
+  object-expiry lifecycle rule — the qcow2 in GCS is only needed transiently
+  during import); grant `ghactions@lantern-cloud.iam.gserviceaccount.com`
+  `roles/storage.objectAdmin` on the bucket and `roles/iam.serviceAccountTokenCreator`
+  **on itself** so `gcloud storage sign-url` can sign via IAM SignBlob under WIF.
 
 ## Adding a new cloud provider
 

--- a/deploy/packer/README.md
+++ b/deploy/packer/README.md
@@ -90,7 +90,6 @@ In CI, the `datacap` binary is built from `getlantern/lantern-cloud` and baked i
 | `GCORE_API_KEY` | Gcore Cloud API token (sent as `Authorization: APIKey ...`) |
 | `GCORE_PROJECT_ID` | Gcore project ID (numeric); scopes every API call |
 | `QEMU_SSH_PASSWORD` | Build-time password for the ubuntu user in the QEMU (gcore) build |
-| `GCORE_IMAGE_GCS_BUCKET` | Private GCS bucket the built qcow2 is uploaded to for import |
 
 ## Deploy a VPS from the image
 
@@ -125,9 +124,13 @@ provider's image store) gcore uses a **build → host → import** pipeline:
    builder (so image contents match), then generalizes the disk (cloud-init
    clean, zero machine-id, drop SSH host keys, lock the build password) so the
    raw disk boots fresh on import.
-2. CI uploads the qcow2 to a private GCS bucket and mints a 24h V4 signed URL
-   (reusing the repo's existing Workload Identity Federation to the
-   `lantern-cloud` GCP project — no static key).
+2. CI stages the qcow2 in **gcore's own S3-compatible object storage** and hands
+   gcore a short-lived presigned URL — no external cloud, no stored bucket/key
+   secret. `deploy/packer/gcore-storage.sh` (gcore control plane, via the API)
+   find-or-creates a dedicated storage instance (`lantern-box-images`, location
+   `luxembourg-2`) + bucket and mints an **ephemeral** access key; the AWS CLI —
+   as a generic S3 client pointed at gcore's endpoint, not AWS — uploads the
+   qcow2 and `presign`s a 24h URL; a cleanup step revokes the key.
 3. `deploy/packer/gcore-publish.sh` imports that URL into each target region via
    `POST cloud/v1/downloadimage/{project}/{region}` (name `lantern-box-<version>`,
    `architecture=x86_64`, `os_type=linux`) and polls each task to `FINISHED`.
@@ -146,13 +149,12 @@ in CI, not on macOS. To validate the config anywhere:
 
 **Operator prerequisites (one-time):**
 
-- Repo secrets: `GCORE_API_KEY`, `GCORE_PROJECT_ID`, `QEMU_SSH_PASSWORD`,
-  `GCORE_IMAGE_GCS_BUCKET`.
-- GCP (lantern-cloud project): create the private GCS bucket (add a short
-  object-expiry lifecycle rule — the qcow2 in GCS is only needed transiently
-  during import); grant `ghactions@lantern-cloud.iam.gserviceaccount.com`
-  `roles/storage.objectAdmin` on the bucket and `roles/iam.serviceAccountTokenCreator`
-  **on itself** so `gcloud storage sign-url` can sign via IAM SignBlob under WIF.
+- Repo secrets: `GCORE_API_KEY` (must have **object-storage** permission, not just
+  cloud/compute), `GCORE_PROJECT_ID`, `QEMU_SSH_PASSWORD`.
+
+That's it — the storage instance, bucket, and (ephemeral) access keys are created
+and torn down by the workflow itself (`gcore-storage.sh`), so there's no bucket to
+pre-create and no cloud IAM to configure.
 
 ## Adding a new cloud provider
 

--- a/deploy/packer/README.md
+++ b/deploy/packer/README.md
@@ -60,36 +60,36 @@ In CI, the `datacap` binary is built from `getlantern/lantern-cloud` and baked i
 
 ## Environment variables
 
-| Variable | Description |
-|---|---|
-| `LINODE_TOKEN` | Linode/Akamai API token |
-| `FURY_TOKEN` | Gemfury token for .deb repo |
-| `OCI_TENANCY_OCID` | OCI tenancy OCID |
-| `OCI_USER_OCID` | OCI user OCID |
-| `OCI_FINGERPRINT` | OCI API key fingerprint |
-| `OCI_KEY_CONTENT` | OCI API private key (PEM) |
-| `OCI_COMPARTMENT_OCID` | OCI compartment for the image |
-| `OCI_SUBNET_OCID` | Legacy fallback subnet (used by IAD if `OCI_SUBNET_OCID_IAD` is empty) |
-| `OCI_AVAILABILITY_DOMAIN` | Legacy fallback AD (used by IAD if `OCI_AVAILABILITY_DOMAIN_IAD` is empty) |
-| `OCI_SUBNET_OCID_IAD` | OCI subnet — us-ashburn-1 |
-| `OCI_AVAILABILITY_DOMAIN_IAD` | OCI AD — us-ashburn-1 |
-| `OCI_SUBNET_OCID_FRA` | OCI subnet — eu-frankfurt-1 |
-| `OCI_AVAILABILITY_DOMAIN_FRA` | OCI AD — eu-frankfurt-1 |
-| `OCI_SUBNET_OCID_NRT` | OCI subnet — ap-tokyo-1 |
-| `OCI_AVAILABILITY_DOMAIN_NRT` | OCI AD — ap-tokyo-1 |
-| `OCI_SUBNET_OCID_SIN` | OCI subnet — ap-singapore-1 |
-| `OCI_AVAILABILITY_DOMAIN_SIN` | OCI AD — ap-singapore-1 |
-| `OCI_SUBNET_OCID_PHX` | OCI subnet — us-phoenix-1 |
-| `OCI_AVAILABILITY_DOMAIN_PHX` | OCI AD — us-phoenix-1 |
-| `OCI_SUBNET_OCID_AMS` | OCI subnet — eu-amsterdam-1 |
-| `OCI_AVAILABILITY_DOMAIN_AMS` | OCI AD — eu-amsterdam-1 |
-| `OCI_SUBNET_OCID_BOM` | OCI subnet — ap-mumbai-1 |
-| `OCI_AVAILABILITY_DOMAIN_BOM` | OCI AD — ap-mumbai-1 |
-| `OCI_SUBNET_OCID_GRU` | OCI subnet — sa-saopaulo-1 |
-| `OCI_AVAILABILITY_DOMAIN_GRU` | OCI AD — sa-saopaulo-1 |
-| `GCORE_API_KEY` | Gcore Cloud API token (sent as `Authorization: APIKey ...`) |
-| `GCORE_PROJECT_ID` | Gcore project ID (numeric); scopes every API call |
-| `QEMU_SSH_PASSWORD` | Build-time password for the ubuntu user in the QEMU (gcore) build |
+| Variable                      | Description                                                                |
+| ----------------------------- | -------------------------------------------------------------------------- |
+| `LINODE_TOKEN`                | Linode/Akamai API token                                                    |
+| `FURY_TOKEN`                  | Gemfury token for .deb repo                                                |
+| `OCI_TENANCY_OCID`            | OCI tenancy OCID                                                           |
+| `OCI_USER_OCID`               | OCI user OCID                                                              |
+| `OCI_FINGERPRINT`             | OCI API key fingerprint                                                    |
+| `OCI_KEY_CONTENT`             | OCI API private key (PEM)                                                  |
+| `OCI_COMPARTMENT_OCID`        | OCI compartment for the image                                              |
+| `OCI_SUBNET_OCID`             | Legacy fallback subnet (used by IAD if `OCI_SUBNET_OCID_IAD` is empty)     |
+| `OCI_AVAILABILITY_DOMAIN`     | Legacy fallback AD (used by IAD if `OCI_AVAILABILITY_DOMAIN_IAD` is empty) |
+| `OCI_SUBNET_OCID_IAD`         | OCI subnet — us-ashburn-1                                                  |
+| `OCI_AVAILABILITY_DOMAIN_IAD` | OCI AD — us-ashburn-1                                                      |
+| `OCI_SUBNET_OCID_FRA`         | OCI subnet — eu-frankfurt-1                                                |
+| `OCI_AVAILABILITY_DOMAIN_FRA` | OCI AD — eu-frankfurt-1                                                    |
+| `OCI_SUBNET_OCID_NRT`         | OCI subnet — ap-tokyo-1                                                    |
+| `OCI_AVAILABILITY_DOMAIN_NRT` | OCI AD — ap-tokyo-1                                                        |
+| `OCI_SUBNET_OCID_SIN`         | OCI subnet — ap-singapore-1                                                |
+| `OCI_AVAILABILITY_DOMAIN_SIN` | OCI AD — ap-singapore-1                                                    |
+| `OCI_SUBNET_OCID_PHX`         | OCI subnet — us-phoenix-1                                                  |
+| `OCI_AVAILABILITY_DOMAIN_PHX` | OCI AD — us-phoenix-1                                                      |
+| `OCI_SUBNET_OCID_AMS`         | OCI subnet — eu-amsterdam-1                                                |
+| `OCI_AVAILABILITY_DOMAIN_AMS` | OCI AD — eu-amsterdam-1                                                    |
+| `OCI_SUBNET_OCID_BOM`         | OCI subnet — ap-mumbai-1                                                   |
+| `OCI_AVAILABILITY_DOMAIN_BOM` | OCI AD — ap-mumbai-1                                                       |
+| `OCI_SUBNET_OCID_GRU`         | OCI subnet — sa-saopaulo-1                                                 |
+| `OCI_AVAILABILITY_DOMAIN_GRU` | OCI AD — sa-saopaulo-1                                                     |
+| `GCORE_API_KEY`               | Gcore Cloud API token (sent as `Authorization: APIKey ...`)                |
+| `GCORE_PROJECT_ID`            | Gcore project ID (numeric); scopes every API call                          |
+| `QEMU_SSH_PASSWORD`           | Build-time password for the ubuntu user in the QEMU (gcore) build          |
 
 ## Deploy a VPS from the image
 
@@ -113,7 +113,14 @@ linode-cli linodes create \
 
 The `build-images.yaml` workflow runs automatically when a GitHub release is published. It can also be triggered manually via workflow_dispatch.
 
-## gcore
+## Adding a new cloud provider
+
+1. Add a `required_plugins` block and `source` block in `lantern-box.pkr.hcl`
+2. Add the provider's API token as a variable
+3. Add the new source to the `build.sources` list
+4. Add the secret to the CI workflow
+
+## Gcore
 
 gcore has **no Packer plugin** and **no cross-region image-copy API**, so unlike
 the other builders (whose plugins snapshot the built instance straight into the
@@ -131,26 +138,60 @@ provider's image store) gcore uses a **build → host → import** pipeline:
    the API has no field for source credentials, and a presigned SigV4 URL is bound
    to one method (its HEAD preflight 403s). `deploy/packer/gcore-storage.sh` drives
    the gcore control plane — find-or-create a dedicated storage instance
-   (`lantern-box-images`, location `luxembourg-2`), sweep leftover stage buckets,
-   create a fresh `lantern-box-stage-<random>` bucket, mint an **ephemeral** access
-   key — and the AWS CLI, as a generic S3 client pointed at gcore's endpoint,
+   (`lantern-box-images`, location `luxembourg-2`), mint an **ephemeral** access key,
+   sweep leftover stage buckets with it, create a fresh `lantern-box-stage-<random>`
+   bucket — and the AWS CLI, as a generic S3 client pointed at gcore's endpoint,
    uploads the qcow2 and applies an anonymous `s3:GetObject` policy. gcore is
    handed the plain `https://<region>.cloud.gcore.lu/<bucket>/<key>` URL. `always()`
-   cleanup steps then delete the object, the bucket, and the access key.
+   cleanup steps then revoke the policy, delete the object, and delete the bucket
+   and the access key — in that order.
 
    The tradeoff: world-readable for the length of the imports only, with an
    unguessable bucket name holding just that one qcow2, the URL masked out of CI
-   logs, and teardown running even on failure. A hard-killed run can leave a public
-   bucket until the next run's sweep — and the sweep can only delete an *empty*
-   leftover, so one still holding an object must be emptied (S3 `rm`) by hand.
+   logs, and teardown running even on failure. Teardown revokes the bucket policy
+   **first**, before either delete, because that is the step that actually ends the
+   exposure and it works even on a bucket the deletes would refuse — so a failed or
+   cancelled run closes the public window regardless. Only a lost runner, where no
+   teardown runs at all, leaves a public bucket behind; the next run's sweep revokes
+   its policy, empties it, and deletes it.
+
+   Every one of those checks fails **loudly on an inconclusive result** rather than
+   reporting the reassuring one. If the revoke fails and the policy cannot be read
+   back either (revoked credentials, an endpoint blip), the step does not conclude
+   "no policy was set" — it fails the job and names the storage instance to check.
+   Likewise, if the bucket delete is refused and the bucket listing cannot be read,
+   cleanup does not report "already gone". Bucket names are masked in CI logs, so
+   these messages point at the `lantern-box-stage-*` prefix and the instance ID
+   instead of a name that would render as `***`.
+
+   Two backstops sit under that. The stage bucket is created with a **1-day object
+   expiry** lifecycle rule (gcore implements the legacy `put-bucket-lifecycle`), so
+   even a run that dies before any teardown has the qcow2 removed by gcore itself —
+   which also un-sticks the bucket, since the control-plane delete refuses a non-empty
+   one. Gcore's expiry pass runs around midnight UTC and lands a day later than `Days`
+   implies, so the worst case is ~48h: a floor under the exposure, not a substitute for
+   the revoke, which closes it in seconds. And because the multi-GB upload is
+   multipart, emptying a bucket **aborts incomplete multipart uploads first** — `s3 rm`
+   does not touch the parts left by a killed upload, and the expiry rule does not cover
+   them either (that needs `AbortIncompleteMultipartUpload`, which gcore does not
+   document), so without the abort such a bucket could never be emptied or deleted.
+   Both the teardown and the sweep go through `gcore-storage.sh empty-bucket`, so the
+   two paths empty a bucket identically.
+
+   Runs are serialized per builder (`concurrency: build-images-<builder>`). The
+   storage instance is shared, so provisioning prunes _all_ its access keys and
+   sweeps _all_ its stage buckets — two overlapping gcore runs would revoke each
+   other's credentials mid-upload. `cancel-in-progress` stays `false`: cancelling a
+   gcore build in flight is the one thing that can strand a public bucket.
+
 3. `deploy/packer/gcore-publish.sh` imports that URL into each target region via
    `POST cloud/v1/downloadimage/{project}/{region}` (name `lantern-box-<version>`,
-   `architecture=x86_64`, `os_type=linux`), polls each task to `FINISHED`, and reads
-   back the created image's `visibility`.
+   `architecture=x86_64`, `os_type=linux`), polls each task to `FINISHED`, and checks
+   the created image's `visibility`.
 
 **Image visibility** is read-only in gcore's API: neither
 `POST cloud/v1/downloadimage/...` nor `PATCH cloud/v1/images/...` accepts the
-field, and `private`/`visibility` exist only as *list filters*. It is not a
+field, and `private`/`visibility` exist only as _list filters_. It is not a
 boolean — an image is exactly one of:
 
 - `private` — this project only.
@@ -158,14 +199,55 @@ boolean — an image is exactly one of:
   image-member API, so in practice this is also project-only. **Not** public.
 - `public` — every gcore customer; gcore's global catalog.
 
-So step 3 reports the value rather than setting it: `private` is logged, `public`
-fails the publish, and `shared` only warns. `shared` is safe but invisible to
-`?private=true` listings — including the prune job's — so old images stop being
-collected and any lookup filtering that way finds nothing.
+Since the field cannot be set, step 3 acts on it instead. `private` is logged.
+`public` is an exposure and the only remediation gcore leaves is removal, so the
+image is **deleted** and the publish fails either way — the region ends up with no
+usable private image, and if the delete itself fails the log says so explicitly and
+names it as needing a human. `shared` only warns: it is not public, and it is still
+usable, so deleting it would cost an image for no security gain — and prune's
+two-pass listing (below) still collects it, so it does not escape retention either.
+
+The check **fails closed**. Both lookups behind it — the image ID from the import
+task, then that image's `visibility` — retry `VISIBILITY_ATTEMPTS` times (default 3)
+and then fail the publish for that region. An unreadable answer means nobody knows
+whether the image reached gcore's global catalog, and this is the only check that
+would catch it, so treating "could not tell" as a pass would turn the exposure into
+a green build. The bounded retry is what keeps one API blip from failing an
+otherwise good build; exhausting it names the image so a human can check it.
 
 **Regions** are numeric gcore region IDs. The workflow's `gcore_regions` input
 (default `180` = Frankfurt-2) controls where the image is published; the prune
 job keeps the 3 newest `lantern-box-` images per region.
+
+**Imports run concurrently.** There is one staged object and one URL, and each region's
+importer fetches it independently, so the transfers were never serial — only the waiting
+was. `gcore-publish.sh` starts every region's import first, then polls all outstanding
+tasks together, one sleep per round rather than per region. Wall-clock is the slowest
+single region instead of the sum, which also shortens the window the qcow2 spends
+publicly readable. A region whose import is rejected is counted as a failure without
+holding up the others.
+
+The build job's timeout is budgeted in the `prepare` job (55min fixed + a 35min shared
+poll window + 3min per region, capped at 350) rather than in `timeout-minutes`, which
+cannot do arithmetic. Adding regions therefore needs no timeout edit and costs little
+wall-clock. The per-region term is not the poll window — it covers the sequential import
+POSTs and visibility checks plus the fact that every region pulls the same object from one
+bucket at once, so shared egress makes each import slower than a solo one.
+
+With a long region list the binding constraint is **not** this timeout but `POLL_ATTEMPTS`
+(120 x 15s = 30min per task): if shared bucket egress pushes a single import past that,
+its poll gives up however long the job is allowed to run. That is the knob to raise
+first, and getting killed mid-import is worth avoiding since it leaves orphaned gcore
+tasks.
+
+Prune lists each region **twice** — `?private=true` plus unfiltered — and unions the
+results by image ID, because a `shared` or `public` image never appears in the
+private listing. Without the second pass such an image is invisible to prune and
+accumulates forever. Both passes are kept rather than only the unfiltered one, so
+pruning does not depend on whether gcore's default listing happens to include private
+images. The `lantern-box-` name prefix is what keeps gcore's own public catalog out
+of the union, and a `403` on delete is treated like `404` — another project's public
+image can match the prefix, and that is not ours to delete or to fail on.
 
 **Local build:** the QEMU build requires **Linux + KVM** (`/dev/kvm`), so it runs
 in CI, not on macOS. To validate the config anywhere:
@@ -180,10 +262,3 @@ That's it — the storage instance, the per-run stage bucket, and the (ephemeral
 access keys are created and torn down by the workflow itself
 (`gcore-storage.sh`), so there's no bucket to pre-create and no cloud IAM to
 configure.
-
-## Adding a new cloud provider
-
-1. Add a `required_plugins` block and `source` block in `lantern-box.pkr.hcl`
-2. Add the provider's API token as a variable
-3. Add the new source to the `build.sources` list
-4. Add the secret to the CI workflow

--- a/deploy/packer/README.md
+++ b/deploy/packer/README.md
@@ -89,7 +89,6 @@ In CI, the `datacap` binary is built from `getlantern/lantern-cloud` and baked i
 | `OCI_AVAILABILITY_DOMAIN_GRU` | OCI AD — sa-saopaulo-1                                                     |
 | `GCORE_API_KEY`               | Gcore Cloud API token (sent as `Authorization: APIKey ...`)                |
 | `GCORE_PROJECT_ID`            | Gcore project ID (numeric); scopes every API call                          |
-| `QEMU_SSH_PASSWORD`           | Build-time password for the ubuntu user in the QEMU (gcore) build          |
 
 ## Deploy a VPS from the image
 
@@ -215,9 +214,25 @@ would catch it, so treating "could not tell" as a pass would turn the exposure i
 a green build. The bounded retry is what keeps one API blip from failing an
 otherwise good build; exhausting it names the image so a human can check it.
 
-**Regions** are numeric gcore region IDs. The workflow's `gcore_regions` input
-(default `180` = Frankfurt-2) controls where the image is published; the prune
-job keeps the 3 newest `lantern-box-` images per region.
+**Regions** are numeric gcore region IDs. The default list — every region
+lantern-cloud provisions in — lives in exactly one place, the `prepare` job's
+"Resolve gcore regions and build timeout" step, and both push-to-main and
+default dispatches use it. lantern-cloud's provider resolves the boot image per
+region and fails where one is missing, so publishing to a subset is what caused
+the `no gcore image matching prefix "lantern-box-" in region 180` failure this
+builder fixes. The `gcore_regions` dispatch input overrides the list for a scoped
+test (e.g. a single region to verify a change) and is intentionally left blank
+rather than prefilled, so there is no second copy to drift. The prune job keeps
+the 3 newest `lantern-box-` images per region, over the same list.
+
+**The build-time SSH password is not a secret.** Packer needs a password to SSH
+into the stock cloud image; the generalize step locks the account, but its hash
+still ships in the qcow2 — and that qcow2 is briefly world-readable while gcore
+imports it. So the build job generates a fresh `openssl rand -hex 24` per run and
+masks it. A stored secret's hash would remain valid for every later build if that
+window were ever caught; a per-run value is worthless once the job ends. Keep any
+replacement hex or alphanumeric: it is interpolated into the cloud-init YAML and
+into `shutdown_command`'s single-quoted shell string.
 
 **Imports run concurrently.** There is one staged object and one URL, and each region's
 importer fetches it independently, so the transfers were never serial — only the waiting
@@ -256,7 +271,8 @@ in CI, not on macOS. To validate the config anywhere:
 **Operator prerequisites (one-time):**
 
 - Repo secrets: `GCORE_API_KEY` (must have **object-storage** permission, not just
-  cloud/compute), `GCORE_PROJECT_ID`, `QEMU_SSH_PASSWORD`.
+  cloud/compute) and `GCORE_PROJECT_ID`. There is no build-password secret: the
+  build job mints a random one per run (see below).
 
 That's it — the storage instance, the per-run stage bucket, and the (ephemeral)
 access keys are created and torn down by the workflow itself

--- a/deploy/packer/gcore-publish.sh
+++ b/deploy/packer/gcore-publish.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Publish the Gcore lantern-box image: import a hosted qcow2 into each target
+# Gcore region and poll each import task to completion. Gcore has no Packer
+# plugin and no cross-region image copy, so the same URL is imported into every
+# region individually. See deploy/packer/README.md.
+#
+# Required env:
+#   GCORE_API_KEY     Gcore Cloud API token (sent as "Authorization: APIKey ...")
+#   GCORE_PROJECT_ID  Gcore project ID (numeric); scopes every API call
+#   VERSION           Image version label; image is named "lantern-box-$VERSION"
+#   IMAGE_URL         URL Gcore's importer fetches the qcow2 from (a signed URL)
+#   GCORE_REGIONS     Comma-separated numeric region IDs (e.g. "180" or "180,68")
+#
+# Optional env (mainly for tests):
+#   CURL (default "curl"), SLEEP (default "sleep"),
+#   GCORE_API_BASE (default "https://api.gcore.com/cloud/v1"),
+#   POLL_ATTEMPTS (default 120), POLL_INTERVAL_SECS (default 15).
+set -euo pipefail
+
+: "${GCORE_API_KEY:?GCORE_API_KEY must be set}"
+: "${GCORE_PROJECT_ID:?GCORE_PROJECT_ID must be set}"
+: "${VERSION:?VERSION must be set}"
+: "${IMAGE_URL:?IMAGE_URL must be set}"
+: "${GCORE_REGIONS:?GCORE_REGIONS must be set (comma-separated region IDs)}"
+
+CURL="${CURL:-curl}"
+SLEEP="${SLEEP:-sleep}"
+API_BASE="${GCORE_API_BASE:-https://api.gcore.com/cloud/v1}"
+POLL_ATTEMPTS="${POLL_ATTEMPTS:-120}"
+POLL_INTERVAL_SECS="${POLL_INTERVAL_SECS:-15}"
+AUTH="Authorization: APIKey ${GCORE_API_KEY}"
+IMAGE_NAME="lantern-box-${VERSION}"
+
+# import_region REGION -> prints the created task ID on stdout.
+import_region() {
+  local region="$1" body resp task
+  body=$(jq -n \
+    --arg name "$IMAGE_NAME" \
+    --arg url "$IMAGE_URL" \
+    '{name: $name, url: $url, architecture: "x86_64", os_type: "linux", os_distro: "ubuntu", os_version: "24.04"}')
+  resp=$("$CURL" -sS -f -X POST \
+    -H "$AUTH" -H "Content-Type: application/json" \
+    -d "$body" \
+    "${API_BASE}/downloadimage/${GCORE_PROJECT_ID}/${region}")
+  task=$(printf '%s' "$resp" | jq -r '.tasks[0] // empty')
+  if [ -z "$task" ]; then
+    echo "::error::gcore import in region ${region} returned no task id: ${resp}" >&2
+    return 1
+  fi
+  printf '%s' "$task"
+}
+
+# poll_task REGION TASK_ID -> 0 on FINISHED, 1 on ERROR/timeout.
+poll_task() {
+  local region="$1" task="$2" attempt=0 state
+  while [ "$attempt" -lt "$POLL_ATTEMPTS" ]; do
+    state=$("$CURL" -sS -f -H "$AUTH" "${API_BASE}/tasks/${task}" | jq -r '.state')
+    case "$state" in
+      FINISHED)
+        echo "region ${region}: import task ${task} FINISHED"
+        return 0 ;;
+      ERROR)
+        echo "::error::region ${region}: import task ${task} state ERROR" >&2
+        return 1 ;;
+      *)
+        echo "region ${region}: task ${task} state=${state} (attempt $((attempt + 1))/${POLL_ATTEMPTS})"
+        "$SLEEP" "$POLL_INTERVAL_SECS" ;;
+    esac
+    attempt=$((attempt + 1))
+  done
+  echo "::error::region ${region}: import task ${task} did not finish after ${POLL_ATTEMPTS} attempts" >&2
+  return 1
+}
+
+main() {
+  echo "Publishing ${IMAGE_NAME} to Gcore regions: ${GCORE_REGIONS}"
+  local failures=0 region task
+  IFS=',' read -ra regions <<< "$GCORE_REGIONS"
+  for region in "${regions[@]}"; do
+    region="${region//[[:space:]]/}"
+    [ -z "$region" ] && continue
+    echo "==> Importing ${IMAGE_NAME} into region ${region}"
+    if ! task=$(import_region "$region"); then
+      failures=$((failures + 1))
+      continue
+    fi
+    if ! poll_task "$region" "$task"; then
+      failures=$((failures + 1))
+    fi
+  done
+  if [ "$failures" -gt 0 ]; then
+    echo "::error::${failures} gcore region import(s) failed" >&2
+    exit 1
+  fi
+  echo "All gcore region imports finished."
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main
+fi

--- a/deploy/packer/gcore-publish.sh
+++ b/deploy/packer/gcore-publish.sh
@@ -68,10 +68,9 @@ import_region() {
 }
 
 # poll_task REGION TASK_ID [WHAT] [MAX_ATTEMPTS] -> 0 on FINISHED, 1 on ERROR/timeout.
-# WHAT only labels the log lines. MAX_ATTEMPTS is an explicit parameter rather than an
-# env override in a subshell, so a caller wanting a shorter budget cannot accidentally
-# shadow POLL_ATTEMPTS for anyone else. Imports do not use this — main() waits on all of
-# them together — so in practice this is the delete path's poller.
+# MAX_ATTEMPTS is a parameter, not an env override, so a caller wanting a shorter budget
+# cannot shadow POLL_ATTEMPTS for everyone. In practice this is the delete path's poller;
+# main() waits on the imports together.
 poll_task() {
   local region="$1" task="$2" what="${3:-import}" max="${4:-$POLL_ATTEMPTS}" attempt=0 state
   while [ "$attempt" -lt "$max" ]; do
@@ -94,10 +93,8 @@ poll_task() {
 }
 
 # delete_image REGION IMAGE_ID -> remove an image we must not keep. Gcore deletes are
-# task-based, so issue the DELETE and poll the returned task: the request is what
-# matters, but polling is what lets the log state whether the image is actually gone
-# rather than merely accepted for deletion. Capture body AND status (not -f) so a
-# rejection is surfaced instead of an empty message.
+# task-based, so poll the returned task: that is what lets the log say the image is gone
+# rather than merely accepted. Capture body AND status (not -f) so a rejection surfaces.
 delete_image() {
   local region="$1" image="$2" resp http task
   resp=$("$CURL" -sS -w $'\n%{http_code}' -X DELETE -H "$AUTH" \
@@ -120,11 +117,10 @@ delete_image() {
   poll_task "$region" "$task" "delete" "$DELETE_POLL_ATTEMPTS"
 }
 
-# fetch_field URL JQ_FILTER WHAT -> print the extracted value, retrying an errored or
-# empty result up to VISIBILITY_ATTEMPTS times. Only the visibility check uses this,
-# and only because that check now fails closed: a bounded retry is what keeps one API
-# blip from failing an otherwise good build, without going back to assuming success.
-# Diagnostics go to stderr so the captured stdout stays just the value.
+# fetch_field URL JQ_FILTER WHAT -> print the value, retrying an errored or empty result
+# up to VISIBILITY_ATTEMPTS times. Used only by the visibility check, which fails closed:
+# the bounded retry keeps one API blip from failing a good build without going back to
+# assuming success. Diagnostics to stderr so stdout stays just the value.
 fetch_field() {
   local url="$1" filter="$2" what="$3" attempt=0 out
   while [ "$attempt" -lt "$VISIBILITY_ATTEMPTS" ]; do
@@ -141,21 +137,15 @@ fetch_field() {
   return 1
 }
 
-# report_visibility REGION TASK_ID -> check the imported image's visibility, which is
-# one of "private" (this project only), "shared" (this project plus member
-# projects, and gcore exposes no API to add members) or "public" (every gcore
-# customer). Only public is an exposure. Gcore has no API to *set* the field, so
-# deleting the image is the only remediation — and either way the publish failed,
-# because the region ends up with no usable private image, so public returns 1
-# whether or not the delete lands. "shared" is access-controlled too, so it only
-# warns; the prune job lists non-private images as well, so it still gets collected.
+# report_visibility REGION TASK_ID -> check the imported image's visibility: "private"
+# (this project), "shared" (plus member projects, which gcore has no API to add) or
+# "public" (every gcore customer). Only public is an exposure, and since gcore cannot
+# *set* the field, deleting is the only remediation — public returns 1 either way, since
+# the region ends up with no usable image. "shared" only warns; prune still collects it.
 #
-# Both lookups fail the publish once their retries are exhausted. This is the check
-# that catches an image landing in gcore's global catalog, so an unreadable answer
-# cannot be treated as a passing one: warning and returning 0 turned "we do not know
-# whether this image is public" into a green build that nobody would look at. The
-# import having already finished is not a reason to pass — the remediation is a human
-# checking the image, and the failure is what tells them to.
+# Both lookups fail the publish once retries are exhausted. This is the only check that
+# catches an image reaching gcore's global catalog, so "could not tell" must not pass as
+# "not public" — the failure is what tells a human to go look.
 report_visibility() {
   local region="$1" task="$2" image vis
   if ! image=$(fetch_field "${API_BASE}/tasks/${task}" \
@@ -184,14 +174,11 @@ report_visibility() {
   esac
 }
 
-# Imports run concurrently. There is one staged object and one URL, and every region's
-# importer fetches it independently — the transfers were never the serial part. What was
-# serial is the *waiting*: draining one region's task to FINISHED before starting the
-# next made wall-clock the SUM of the per-region imports. So start every import first,
-# then wait on all outstanding tasks together, checking each once per interval with a
-# single sleep per round. Wall-clock becomes the slowest single region rather than the
-# sum, which also shortens the window the staged qcow2 spends publicly readable.
-# Plain indexed arrays (no associative arrays) so this still runs under bash 3.2.
+# Imports run concurrently: the *waiting* was the serial part, since draining each task
+# before starting the next made wall-clock the SUM of the imports. Start them all, then
+# poll every outstanding task per round with one sleep. Wall-clock becomes the slowest
+# single region, which also shortens the qcow2's public window. Plain indexed arrays, no
+# associative ones, so this still runs under bash 3.2.
 main() {
   echo "Publishing ${IMAGE_NAME} to Gcore regions: ${GCORE_REGIONS}"
   local failures=0 region task attempt=0 pending i state

--- a/deploy/packer/gcore-publish.sh
+++ b/deploy/packer/gcore-publish.sh
@@ -34,18 +34,26 @@ IMAGE_NAME="lantern-box-${VERSION}"
 
 # import_region REGION -> prints the created task ID on stdout.
 import_region() {
-  local region="$1" body resp task
+  local region="$1" body resp http task
   body=$(jq -n \
     --arg name "$IMAGE_NAME" \
     --arg url "$IMAGE_URL" \
     '{name: $name, url: $url, architecture: "x86_64", os_type: "linux", os_distro: "ubuntu", os_version: "24.04"}')
-  resp=$("$CURL" -sS -f -X POST \
+  # Capture the response body AND HTTP status (NOT -f, which discards the error
+  # body) so a gcore rejection is surfaced instead of an empty message.
+  resp=$("$CURL" -sS -w $'\n%{http_code}' -X POST \
     -H "$AUTH" -H "Content-Type: application/json" \
     -d "$body" \
     "${API_BASE}/downloadimage/${GCORE_PROJECT_ID}/${region}")
+  http="${resp##*$'\n'}"
+  resp="${resp%$'\n'*}"
+  if [ "$http" -lt 200 ] || [ "$http" -ge 300 ]; then
+    echo "::error::gcore import in region ${region} failed: HTTP ${http}: ${resp}" >&2
+    return 1
+  fi
   task=$(printf '%s' "$resp" | jq -r '.tasks[0] // empty')
   if [ -z "$task" ]; then
-    echo "::error::gcore import in region ${region} returned no task id: ${resp}" >&2
+    echo "::error::gcore import in region ${region} returned no task id (HTTP ${http}): ${resp}" >&2
     return 1
   fi
   printf '%s' "$task"

--- a/deploy/packer/gcore-publish.sh
+++ b/deploy/packer/gcore-publish.sh
@@ -20,6 +20,7 @@
 #   already-failing public-image path, so it must not eat the whole job timeout.
 #   VISIBILITY_ATTEMPTS (default 3) — tries for each of the two visibility lookups,
 #   which fail the publish once exhausted (see report_visibility).
+#   IMPORT_STAGGER_SECS (default 30) — pause between import POSTs; 0 disables.
 set -euo pipefail
 
 : "${GCORE_API_KEY:?GCORE_API_KEY must be set}"
@@ -35,6 +36,7 @@ POLL_ATTEMPTS="${POLL_ATTEMPTS:-120}"
 POLL_INTERVAL_SECS="${POLL_INTERVAL_SECS:-15}"
 DELETE_POLL_ATTEMPTS="${DELETE_POLL_ATTEMPTS:-20}"
 VISIBILITY_ATTEMPTS="${VISIBILITY_ATTEMPTS:-3}"
+IMPORT_STAGGER_SECS="${IMPORT_STAGGER_SECS:-30}"
 AUTH="Authorization: APIKey ${GCORE_API_KEY}"
 IMAGE_NAME="lantern-box-${VERSION}"
 
@@ -202,6 +204,13 @@ main() {
   for region in "${raw[@]}"; do
     region="${region//[[:space:]]/}"
     [ -z "$region" ] && continue
+    # Gcore reaps a task not STARTED within 10min of its own created_on, so POSTing all
+    # ~30 imports in one window gives them a shared deadline the scheduler cannot meet.
+    # Before the POST, and only once a task exists: no trailing wait, and a rejected POST
+    # created nothing to space from.
+    if [ "${#tasks[@]}" -gt 0 ] && [ "$IMPORT_STAGGER_SECS" -gt 0 ]; then
+      "$SLEEP" "$IMPORT_STAGGER_SECS"
+    fi
     echo "==> Importing ${IMAGE_NAME} into region ${region}"
     if ! task=$(import_region "$region"); then
       failures=$((failures + 1))

--- a/deploy/packer/gcore-publish.sh
+++ b/deploy/packer/gcore-publish.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
 # Import a hosted qcow2 into each target Gcore region, poll each task to
-# completion, and report the resulting image's visibility. Gcore has no Packer
-# plugin and no cross-region image copy, so the same URL is imported per region.
-# See deploy/packer/README.md.
+# completion, and check the resulting image's visibility — deleting it if it landed
+# in gcore's public catalog. Gcore has no Packer plugin and no cross-region image
+# copy, so the same URL is imported per region. See deploy/packer/README.md.
 #
 # Required env:
 #   GCORE_API_KEY     Gcore Cloud API token ("Authorization: APIKey ...")
@@ -15,7 +15,11 @@
 # Optional env (mainly for tests):
 #   CURL (default "curl"), SLEEP (default "sleep"),
 #   GCORE_API_BASE (default "https://api.gcore.com/cloud/v1"),
-#   POLL_ATTEMPTS (default 120), POLL_INTERVAL_SECS (default 15).
+#   POLL_ATTEMPTS (default 120), POLL_INTERVAL_SECS (default 15),
+#   DELETE_POLL_ATTEMPTS (default 20) — deletes are quick, and this only runs on the
+#   already-failing public-image path, so it must not eat the whole job timeout.
+#   VISIBILITY_ATTEMPTS (default 3) — tries for each of the two visibility lookups,
+#   which fail the publish once exhausted (see report_visibility).
 set -euo pipefail
 
 : "${GCORE_API_KEY:?GCORE_API_KEY must be set}"
@@ -29,6 +33,8 @@ SLEEP="${SLEEP:-sleep}"
 API_BASE="${GCORE_API_BASE:-https://api.gcore.com/cloud/v1}"
 POLL_ATTEMPTS="${POLL_ATTEMPTS:-120}"
 POLL_INTERVAL_SECS="${POLL_INTERVAL_SECS:-15}"
+DELETE_POLL_ATTEMPTS="${DELETE_POLL_ATTEMPTS:-20}"
+VISIBILITY_ATTEMPTS="${VISIBILITY_ATTEMPTS:-3}"
 AUTH="Authorization: APIKey ${GCORE_API_KEY}"
 IMAGE_NAME="lantern-box-${VERSION}"
 
@@ -59,62 +65,141 @@ import_region() {
   printf '%s' "$task"
 }
 
-# poll_task REGION TASK_ID -> 0 on FINISHED, 1 on ERROR/timeout.
+# poll_task REGION TASK_ID [WHAT] [MAX_ATTEMPTS] -> 0 on FINISHED, 1 on ERROR/timeout.
+# WHAT only labels the log lines. MAX_ATTEMPTS is an explicit parameter rather than an
+# env override in a subshell, so a caller wanting a shorter budget cannot accidentally
+# shadow POLL_ATTEMPTS for anyone else. Imports do not use this — main() waits on all of
+# them together — so in practice this is the delete path's poller.
 poll_task() {
-  local region="$1" task="$2" attempt=0 state
-  while [ "$attempt" -lt "$POLL_ATTEMPTS" ]; do
+  local region="$1" task="$2" what="${3:-import}" max="${4:-$POLL_ATTEMPTS}" attempt=0 state
+  while [ "$attempt" -lt "$max" ]; do
     state=$("$CURL" -sS -f -H "$AUTH" "${API_BASE}/tasks/${task}" | jq -r '.state')
     case "$state" in
       FINISHED)
-        echo "region ${region}: import task ${task} FINISHED"
+        echo "region ${region}: ${what} task ${task} FINISHED"
         return 0 ;;
       ERROR)
-        echo "::error::region ${region}: import task ${task} state ERROR" >&2
+        echo "::error::region ${region}: ${what} task ${task} state ERROR" >&2
         return 1 ;;
       *)
-        echo "region ${region}: task ${task} state=${state} (attempt $((attempt + 1))/${POLL_ATTEMPTS})"
+        echo "region ${region}: task ${task} state=${state} (attempt $((attempt + 1))/${max})"
         "$SLEEP" "$POLL_INTERVAL_SECS" ;;
     esac
     attempt=$((attempt + 1))
   done
-  echo "::error::region ${region}: import task ${task} did not finish after ${POLL_ATTEMPTS} attempts" >&2
+  echo "::error::region ${region}: ${what} task ${task} did not finish after ${max} attempts" >&2
   return 1
 }
 
-# report_visibility REGION TASK_ID -> log the imported image's visibility, which is
-# one of "private" (this project only), "shared" (this project plus member
-# projects, and gcore exposes no API to add members) or "public" (every gcore
-# customer). Only public is an exposure, so only public returns 1. "shared" is
-# access-controlled too, but ?private=true listings skip it — including prune's —
-# so it only warns. Gcore has no API to *set* the field: this reports, not fixes.
-report_visibility() {
-  local region="$1" task="$2" image vis
-  if ! image=$("$CURL" -sS -f -H "$AUTH" "${API_BASE}/tasks/${task}" \
-      | jq -r '.created_resources.images[0] // empty') || [ -z "$image" ]; then
-    echo "::warning::region ${region}: could not resolve the imported image ID from task ${task}; skipping the visibility check" >&2
+# delete_image REGION IMAGE_ID -> remove an image we must not keep. Gcore deletes are
+# task-based, so issue the DELETE and poll the returned task: the request is what
+# matters, but polling is what lets the log state whether the image is actually gone
+# rather than merely accepted for deletion. Capture body AND status (not -f) so a
+# rejection is surfaced instead of an empty message.
+delete_image() {
+  local region="$1" image="$2" resp http task
+  resp=$("$CURL" -sS -w $'\n%{http_code}' -X DELETE -H "$AUTH" \
+    "${API_BASE}/images/${GCORE_PROJECT_ID}/${region}/${image}")
+  http="${resp##*$'\n'}"
+  resp="${resp%$'\n'*}"
+  if [ "$http" = "404" ]; then
+    echo "region ${region}: image ${image} already gone (404)"
     return 0
   fi
-  if ! vis=$("$CURL" -sS -f -H "$AUTH" "${API_BASE}/images/${GCORE_PROJECT_ID}/${region}/${image}" \
-      | jq -r '.visibility // empty') || [ -z "$vis" ]; then
-    echo "::warning::region ${region}: could not read visibility of image ${image}; skipping the check" >&2
+  if [ "$http" -lt 200 ] || [ "$http" -ge 300 ]; then
+    echo "::error::region ${region}: delete of image ${image} failed: HTTP ${http}: ${resp}" >&2
+    return 1
+  fi
+  task=$(printf '%s' "$resp" | jq -r '.tasks[0] // empty')
+  if [ -z "$task" ]; then
+    echo "::warning::region ${region}: delete of image ${image} returned no task id (HTTP ${http}) — accepted, but completion is unconfirmed" >&2
     return 0
+  fi
+  poll_task "$region" "$task" "delete" "$DELETE_POLL_ATTEMPTS"
+}
+
+# fetch_field URL JQ_FILTER WHAT -> print the extracted value, retrying an errored or
+# empty result up to VISIBILITY_ATTEMPTS times. Only the visibility check uses this,
+# and only because that check now fails closed: a bounded retry is what keeps one API
+# blip from failing an otherwise good build, without going back to assuming success.
+# Diagnostics go to stderr so the captured stdout stays just the value.
+fetch_field() {
+  local url="$1" filter="$2" what="$3" attempt=0 out
+  while [ "$attempt" -lt "$VISIBILITY_ATTEMPTS" ]; do
+    attempt=$((attempt + 1))
+    if out=$("$CURL" -sS -f -H "$AUTH" "$url" | jq -r "$filter") && [ -n "$out" ]; then
+      printf '%s' "$out"
+      return 0
+    fi
+    if [ "$attempt" -lt "$VISIBILITY_ATTEMPTS" ]; then
+      echo "  ${what} lookup failed (attempt ${attempt}/${VISIBILITY_ATTEMPTS}); retrying" >&2
+      "$SLEEP" "$POLL_INTERVAL_SECS"
+    fi
+  done
+  return 1
+}
+
+# report_visibility REGION TASK_ID -> check the imported image's visibility, which is
+# one of "private" (this project only), "shared" (this project plus member
+# projects, and gcore exposes no API to add members) or "public" (every gcore
+# customer). Only public is an exposure. Gcore has no API to *set* the field, so
+# deleting the image is the only remediation — and either way the publish failed,
+# because the region ends up with no usable private image, so public returns 1
+# whether or not the delete lands. "shared" is access-controlled too, so it only
+# warns; the prune job lists non-private images as well, so it still gets collected.
+#
+# Both lookups fail the publish once their retries are exhausted. This is the check
+# that catches an image landing in gcore's global catalog, so an unreadable answer
+# cannot be treated as a passing one: warning and returning 0 turned "we do not know
+# whether this image is public" into a green build that nobody would look at. The
+# import having already finished is not a reason to pass — the remediation is a human
+# checking the image, and the failure is what tells them to.
+report_visibility() {
+  local region="$1" task="$2" image vis
+  if ! image=$(fetch_field "${API_BASE}/tasks/${task}" \
+      '.created_resources.images[0] // empty' "imported image ID from task ${task}"); then
+    echo "::error::region ${region}: could not resolve the imported image ID from task ${task} after ${VISIBILITY_ATTEMPTS} attempts, so its visibility could not be checked. The import itself finished, so an image may exist and may be public — find it by name (${IMAGE_NAME}) in region ${region} and check it by hand." >&2
+    return 1
+  fi
+  if ! vis=$(fetch_field "${API_BASE}/images/${GCORE_PROJECT_ID}/${region}/${image}" \
+      '.visibility // empty' "visibility of image ${image}"); then
+    echo "::error::region ${region}: could not read visibility of image ${image} after ${VISIBILITY_ATTEMPTS} attempts, so it is unknown whether it landed in gcore's public catalog — treat it as exposed and check it by hand." >&2
+    return 1
   fi
   case "$vis" in
     private)
       echo "region ${region}: image ${image} visibility=private" ;;
     public)
-      echo "::error::region ${region}: image ${image} visibility=public — in gcore's global catalog, not private to project ${GCORE_PROJECT_ID}" >&2
+      echo "::error::region ${region}: image ${image} visibility=public — in gcore's global catalog, not private to project ${GCORE_PROJECT_ID}. Deleting it." >&2
+      if delete_image "$region" "$image"; then
+        echo "region ${region}: public image ${image} removed; nothing was published to this region"
+      else
+        echo "::error::region ${region}: public image ${image} could NOT be deleted and is still in gcore's global catalog — delete it by hand" >&2
+      fi
       return 1 ;;
     *)
-      echo "::warning::region ${region}: image ${image} visibility=${vis}, not private — gcore has no API to change it, and ?private=true listings will NOT return this image" >&2 ;;
+      echo "::warning::region ${region}: image ${image} visibility=${vis}, not private — gcore has no API to change it. It is not in the public catalog, and prune still collects it." >&2 ;;
   esac
 }
 
+# Imports run concurrently. There is one staged object and one URL, and every region's
+# importer fetches it independently — the transfers were never the serial part. What was
+# serial is the *waiting*: draining one region's task to FINISHED before starting the
+# next made wall-clock the SUM of the per-region imports. So start every import first,
+# then wait on all outstanding tasks together, checking each once per interval with a
+# single sleep per round. Wall-clock becomes the slowest single region rather than the
+# sum, which also shortens the window the staged qcow2 spends publicly readable.
+# Plain indexed arrays (no associative arrays) so this still runs under bash 3.2.
 main() {
   echo "Publishing ${IMAGE_NAME} to Gcore regions: ${GCORE_REGIONS}"
-  local failures=0 region task
-  IFS=',' read -ra regions <<< "$GCORE_REGIONS"
-  for region in "${regions[@]}"; do
+  local failures=0 region task attempt=0 pending i state
+  local raw=() regions=() tasks=() states=()
+  IFS=',' read -ra raw <<< "$GCORE_REGIONS"
+
+  # Phase 1 — start every import. downloadimage returns a task id immediately, so these
+  # POSTs are quick; issuing them sequentially also keeps them naturally spaced rather
+  # than arriving as one burst.
+  for region in "${raw[@]}"; do
     region="${region//[[:space:]]/}"
     [ -z "$region" ] && continue
     echo "==> Importing ${IMAGE_NAME} into region ${region}"
@@ -122,14 +207,52 @@ main() {
       failures=$((failures + 1))
       continue
     fi
-    if ! poll_task "$region" "$task"; then
-      failures=$((failures + 1))
-      continue
+    regions+=("$region")
+    tasks+=("$task")
+    states+=("PENDING")
+  done
+
+  # Phase 2 — wait on all of them at once. One sleep per round, not per region.
+  pending=${#regions[@]}
+  while [ "$pending" -gt 0 ] && [ "$attempt" -lt "$POLL_ATTEMPTS" ]; do
+    for i in "${!regions[@]}"; do
+      [ "${states[$i]}" = "PENDING" ] || continue
+      # A transient API error leaves state empty, which falls through to the retry
+      # branch — the same self-healing the sequential version had.
+      state=$("$CURL" -sS -f -H "$AUTH" "${API_BASE}/tasks/${tasks[$i]}" | jq -r '.state') || state=""
+      case "$state" in
+        FINISHED)
+          echo "region ${regions[$i]}: import task ${tasks[$i]} FINISHED"
+          states[i]=FINISHED
+          pending=$((pending - 1))
+          if ! report_visibility "${regions[$i]}" "${tasks[$i]}"; then
+            failures=$((failures + 1))
+          fi ;;
+        ERROR)
+          echo "::error::region ${regions[$i]}: import task ${tasks[$i]} state ERROR" >&2
+          states[i]=ERROR
+          pending=$((pending - 1))
+          failures=$((failures + 1)) ;;
+        *)
+          echo "region ${regions[$i]}: task ${tasks[$i]} state=${state:-unknown} (attempt $((attempt + 1))/${POLL_ATTEMPTS})" ;;
+      esac
+    done
+    attempt=$((attempt + 1))
+    # An explicit if, not a `&&` chain: a false chain here would be a failing last
+    # command in the loop body and `set -e` would kill the script.
+    if [ "$pending" -gt 0 ] && [ "$attempt" -lt "$POLL_ATTEMPTS" ]; then
+      "$SLEEP" "$POLL_INTERVAL_SECS"
     fi
-    if ! report_visibility "$region" "$task"; then
+  done
+
+  # Whatever is still PENDING ran out of attempts.
+  for i in "${!regions[@]}"; do
+    if [ "${states[$i]}" = "PENDING" ]; then
+      echo "::error::region ${regions[$i]}: import task ${tasks[$i]} did not finish after ${POLL_ATTEMPTS} attempts" >&2
       failures=$((failures + 1))
     fi
   done
+
   if [ "$failures" -gt 0 ]; then
     echo "::error::${failures} gcore region import(s) failed" >&2
     exit 1

--- a/deploy/packer/gcore-publish.sh
+++ b/deploy/packer/gcore-publish.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 #
-# Publish the Gcore lantern-box image: import a hosted qcow2 into each target
-# Gcore region and poll each import task to completion. Gcore has no Packer
-# plugin and no cross-region image copy, so the same URL is imported into every
-# region individually. See deploy/packer/README.md.
+# Import a hosted qcow2 into each target Gcore region, poll each task to
+# completion, and report the resulting image's visibility. Gcore has no Packer
+# plugin and no cross-region image copy, so the same URL is imported per region.
+# See deploy/packer/README.md.
 #
 # Required env:
-#   GCORE_API_KEY     Gcore Cloud API token (sent as "Authorization: APIKey ...")
+#   GCORE_API_KEY     Gcore Cloud API token ("Authorization: APIKey ...")
 #   GCORE_PROJECT_ID  Gcore project ID (numeric); scopes every API call
-#   VERSION           Image version label; image is named "lantern-box-$VERSION"
-#   IMAGE_URL         URL Gcore's importer fetches the qcow2 from (a signed URL)
-#   GCORE_REGIONS     Comma-separated numeric region IDs (e.g. "180" or "180,68")
+#   VERSION           Image is named "lantern-box-$VERSION"
+#   IMAGE_URL         URL Gcore's importer fetches the qcow2 from
+#   GCORE_REGIONS     Comma-separated numeric region IDs (e.g. "180,68")
 #
 # Optional env (mainly for tests):
 #   CURL (default "curl"), SLEEP (default "sleep"),
@@ -39,8 +39,8 @@ import_region() {
     --arg name "$IMAGE_NAME" \
     --arg url "$IMAGE_URL" \
     '{name: $name, url: $url, architecture: "x86_64", os_type: "linux", os_distro: "ubuntu", os_version: "24.04"}')
-  # Capture the response body AND HTTP status (NOT -f, which discards the error
-  # body) so a gcore rejection is surfaced instead of an empty message.
+  # Capture body AND status (not -f, which discards the error body) so a gcore
+  # rejection is surfaced instead of an empty message.
   resp=$("$CURL" -sS -w $'\n%{http_code}' -X POST \
     -H "$AUTH" -H "Content-Type: application/json" \
     -d "$body" \
@@ -81,6 +81,35 @@ poll_task() {
   return 1
 }
 
+# report_visibility REGION TASK_ID -> log the imported image's visibility, which is
+# one of "private" (this project only), "shared" (this project plus member
+# projects, and gcore exposes no API to add members) or "public" (every gcore
+# customer). Only public is an exposure, so only public returns 1. "shared" is
+# access-controlled too, but ?private=true listings skip it — including prune's —
+# so it only warns. Gcore has no API to *set* the field: this reports, not fixes.
+report_visibility() {
+  local region="$1" task="$2" image vis
+  if ! image=$("$CURL" -sS -f -H "$AUTH" "${API_BASE}/tasks/${task}" \
+      | jq -r '.created_resources.images[0] // empty') || [ -z "$image" ]; then
+    echo "::warning::region ${region}: could not resolve the imported image ID from task ${task}; skipping the visibility check" >&2
+    return 0
+  fi
+  if ! vis=$("$CURL" -sS -f -H "$AUTH" "${API_BASE}/images/${GCORE_PROJECT_ID}/${region}/${image}" \
+      | jq -r '.visibility // empty') || [ -z "$vis" ]; then
+    echo "::warning::region ${region}: could not read visibility of image ${image}; skipping the check" >&2
+    return 0
+  fi
+  case "$vis" in
+    private)
+      echo "region ${region}: image ${image} visibility=private" ;;
+    public)
+      echo "::error::region ${region}: image ${image} visibility=public — in gcore's global catalog, not private to project ${GCORE_PROJECT_ID}" >&2
+      return 1 ;;
+    *)
+      echo "::warning::region ${region}: image ${image} visibility=${vis}, not private — gcore has no API to change it, and ?private=true listings will NOT return this image" >&2 ;;
+  esac
+}
+
 main() {
   echo "Publishing ${IMAGE_NAME} to Gcore regions: ${GCORE_REGIONS}"
   local failures=0 region task
@@ -94,6 +123,10 @@ main() {
       continue
     fi
     if ! poll_task "$region" "$task"; then
+      failures=$((failures + 1))
+      continue
+    fi
+    if ! report_visibility "$region" "$task"; then
       failures=$((failures + 1))
     fi
   done

--- a/deploy/packer/gcore-publish.test.sh
+++ b/deploy/packer/gcore-publish.test.sh
@@ -32,15 +32,12 @@ trap cleanup EXIT
 #   mixed          downloadimage -> task named for the region in the URL (region
 #                  68 -> "task-68"); /tasks/ -> ERROR only for
 #                  FAKE_CURL_ERROR_REGION's task
-# FINISHED tasks report created_resources.images == ["img-1"] — unless
-# FAKE_CURL_NO_IMAGE_ID is set, which empties the list so report_visibility cannot
-# resolve the image at all. GET /images/... returns FAKE_CURL_VISIBILITY (default
-# "private") for report_visibility; FAKE_CURL_VISIBILITY_MISSING makes every such GET
-# unreadable, and FAKE_CURL_VISIBILITY_FLAKY=N makes only the first N unreadable so a
-# test can prove the bounded retry recovers.
-# DELETE /images/... (delete_image) answers FAKE_CURL_DELETE_HTTP (default 204) and
-# returns a "task-del" task, whose state comes from FAKE_CURL_DELETE_STATE
-# (default FINISHED).
+# FINISHED tasks report created_resources.images == ["img-1"]; FAKE_CURL_NO_IMAGE_ID
+# empties it so report_visibility cannot resolve the image. GET /images/... returns
+# FAKE_CURL_VISIBILITY (default "private"); _MISSING makes every such GET unreadable and
+# _FLAKY=N only the first N, to prove the bounded retry recovers. DELETE /images/...
+# answers FAKE_CURL_DELETE_HTTP (default 204) with a "task-del" task in
+# FAKE_CURL_DELETE_STATE (default FINISHED).
 make_fake_curl() {
   local dir
   dir=$(mktemp -d)
@@ -307,10 +304,8 @@ else
   echo "FAIL: shared image warns but succeeds (rc=$rc)"; echo "$out"; FAILED=1
 fi
 
-# Test 10: unreadable visibility -> FAIL the publish once the retries are exhausted.
-# This is the check that catches an image landing in gcore's public catalog, so "we
-# could not tell" must not read as "it is fine". Retries are bounded, so the failure
-# arrives after VISIBILITY_ATTEMPTS tries rather than hanging.
+# Test 10: unreadable visibility -> FAIL once retries are exhausted. "Could not tell"
+# must not read as "it is fine", and the bound means it fails rather than hangs.
 dir=$(make_fake_curl); TMP_DIRS+=("$dir")
 out=$(PATH="$dir:$PATH" FAKE_CURL_VISIBILITY_MISSING=1 \
   GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
@@ -358,11 +353,9 @@ else
   echo "FAIL: an unresolvable image ID fails the publish (rc=$rc)"; echo "$out"; FAILED=1
 fi
 
-# Test 11: every region's import is issued BEFORE any polling starts, and the wait costs
-# one sleep per round rather than one per region per round. That is the property making
-# wall-clock the slowest single region instead of the sum: draining regions one at a time
-# would cost regions x POLL_ATTEMPTS sleeps (6 here) and would not POST the later imports
-# until the earlier ones finished.
+# Test 11: every import is issued BEFORE polling starts, and the wait costs one sleep per
+# round, not per region per round — the property making wall-clock the slowest region
+# instead of the sum. Draining one at a time would cost 6 sleeps here.
 dir=$(make_fake_curl); TMP_DIRS+=("$dir")
 sleeplog="$dir/sleeps"
 printf '#!/usr/bin/env bash\necho s >> "%s"\n' "$sleeplog" > "$dir/fakesleep"

--- a/deploy/packer/gcore-publish.test.sh
+++ b/deploy/packer/gcore-publish.test.sh
@@ -29,8 +29,15 @@ trap cleanup EXIT
 #   mixed          downloadimage -> task named for the region in the URL (region
 #                  68 -> "task-68"); /tasks/ -> ERROR only for
 #                  FAKE_CURL_ERROR_REGION's task
-# FINISHED tasks report created_resources.images == ["img-1"], and /images/...
-# returns FAKE_CURL_VISIBILITY (default "private") for report_visibility.
+# FINISHED tasks report created_resources.images == ["img-1"] — unless
+# FAKE_CURL_NO_IMAGE_ID is set, which empties the list so report_visibility cannot
+# resolve the image at all. GET /images/... returns FAKE_CURL_VISIBILITY (default
+# "private") for report_visibility; FAKE_CURL_VISIBILITY_MISSING makes every such GET
+# unreadable, and FAKE_CURL_VISIBILITY_FLAKY=N makes only the first N unreadable so a
+# test can prove the bounded retry recovers.
+# DELETE /images/... (delete_image) answers FAKE_CURL_DELETE_HTTP (default 204) and
+# returns a "task-del" task, whose state comes from FAKE_CURL_DELETE_STATE
+# (default FINISHED).
 make_fake_curl() {
   local dir
   dir=$(mktemp -d)
@@ -39,6 +46,39 @@ make_fake_curl() {
 self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 mode="${FAKE_CURL_MODE:-ok}"
 finished='{"state":"FINISHED","created_resources":{"images":["img-1"]}}'
+if [ -n "${FAKE_CURL_NO_IMAGE_ID:-}" ]; then
+  finished='{"state":"FINISHED","created_resources":{"images":[]}}'
+fi
+# The image DELETE and the visibility GET share a URL shape, so the method has to be
+# read off the flags before any URL matching.
+method=GET prev=""
+for a in "$@"; do
+  [ "$prev" = "-X" ] && method="$a"
+  prev="$a"
+done
+if [ "$method" = DELETE ]; then
+  for a in "$@"; do
+    case "$a" in
+      */images/*)
+        http="${FAKE_CURL_DELETE_HTTP:-204}"
+        if [ "$http" != 204 ]; then
+          printf '%s\n%s' '{"detail":"delete refused"}' "$http"
+        else
+          printf '%s\n%s' '{"tasks":["task-del"]}' "$http"
+        fi
+        exit 0 ;;
+    esac
+  done
+fi
+for a in "$@"; do
+  # A delete task must resolve before the generic /tasks/ handling below, which is
+  # driven by the import-oriented modes.
+  case "$a" in
+    */tasks/task-del)
+      printf '{"state":"%s"}\n' "${FAKE_CURL_DELETE_STATE:-FINISHED}"
+      exit 0 ;;
+  esac
+done
 for a in "$@"; do
   case "$a" in
     *downloadimage*)
@@ -84,6 +124,17 @@ for a in "$@"; do
     */images/*)
       # report_visibility's GET /images/<project>/<region>/<image_id>. Deliberately
       # does not match the downloadimage URL ("downloadimage/" is not "/images/").
+      if [ -n "${FAKE_CURL_VISIBILITY_FLAKY:-}" ]; then
+        # Unreadable for the first N calls, then real: proves fetch_field's retry turns
+        # a transient blip back into a pass rather than failing the publish.
+        vcount_file="${self_dir}/vis_count"
+        [ -f "$vcount_file" ] || echo 0 > "$vcount_file"
+        vcount=$(cat "$vcount_file")
+        echo $((vcount + 1)) > "$vcount_file"
+        if [ "$vcount" -lt "$FAKE_CURL_VISIBILITY_FLAKY" ]; then
+          echo '{}'; exit 0
+        fi
+      fi
       if [ -n "${FAKE_CURL_VISIBILITY_MISSING:-}" ]; then
         echo '{}'
       else
@@ -190,8 +241,8 @@ else
   echo "FAIL: import HTTP error (rc=$rc)"; echo "$out"; FAILED=1
 fi
 
-# Test 8: image comes back public -> import succeeded, but exit non-zero, since
-# public means gcore's global catalog rather than private to the project.
+# Test 8: image comes back public -> the exposure is remediated by deleting it, and
+# the publish still fails, because the region ends up with no usable private image.
 dir=$(make_fake_curl); TMP_DIRS+=("$dir")
 out=$(PATH="$dir:$PATH" FAKE_CURL_VISIBILITY=public \
   GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
@@ -199,14 +250,46 @@ out=$(PATH="$dir:$PATH" FAKE_CURL_VISIBILITY=public \
   bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
 if [ "$rc" -ne 0 ] \
    && grep -q "import task task-abc FINISHED" <<<"$out" \
-   && grep -q "visibility=public" <<<"$out"; then
-  echo "PASS: public image fails the publish"
+   && grep -q "visibility=public" <<<"$out" \
+   && grep -q "region 180: delete task task-del FINISHED" <<<"$out" \
+   && grep -q "public image img-1 removed" <<<"$out"; then
+  echo "PASS: public image is deleted and fails the publish"
 else
-  echo "FAIL: public image fails the publish (rc=$rc)"; echo "$out"; FAILED=1
+  echo "FAIL: public image is deleted and fails the publish (rc=$rc)"; echo "$out"; FAILED=1
 fi
 
-# Test 9: image comes back "shared" -> owner-only, so a warning rather than a
-# failure, because ?private=true listings won't return it.
+# Test 8b: public image whose delete is refused -> say plainly that it is still in
+# the public catalog and needs a human, rather than implying it was cleaned up.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+out=$(PATH="$dir:$PATH" FAKE_CURL_VISIBILITY=public FAKE_CURL_DELETE_HTTP=409 \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180" POLL_INTERVAL_SECS=0 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -ne 0 ] \
+   && grep -q "HTTP 409" <<<"$out" && grep -q "delete refused" <<<"$out" \
+   && grep -q "could NOT be deleted" <<<"$out"; then
+  echo "PASS: refused delete of a public image is reported as still public"
+else
+  echo "FAIL: refused delete of a public image (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
+# Test 8c: delete accepted but its task ends in ERROR -> also "could NOT be deleted".
+# An accepted-then-failed delete leaves the image public just as a refusal does.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+out=$(PATH="$dir:$PATH" FAKE_CURL_VISIBILITY=public FAKE_CURL_DELETE_STATE=ERROR \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180" POLL_INTERVAL_SECS=0 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -ne 0 ] \
+   && grep -q "delete task task-del state ERROR" <<<"$out" \
+   && grep -q "could NOT be deleted" <<<"$out"; then
+  echo "PASS: failed delete task of a public image is reported as still public"
+else
+  echo "FAIL: failed delete task of a public image (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
+# Test 9: image comes back "shared" -> project-only in practice, so a warning rather
+# than a failure. It must NOT be deleted: it is usable and not an exposure.
 dir=$(make_fake_curl); TMP_DIRS+=("$dir")
 out=$(PATH="$dir:$PATH" FAKE_CURL_VISIBILITY=shared \
   GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
@@ -214,23 +297,105 @@ out=$(PATH="$dir:$PATH" FAKE_CURL_VISIBILITY=shared \
   bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
 if [ "$rc" -eq 0 ] \
    && grep -q "visibility=shared, not private" <<<"$out" \
-   && grep -q "will NOT return this image" <<<"$out"; then
-  echo "PASS: shared image warns but succeeds"
+   && grep -q "prune still collects it" <<<"$out" \
+   && ! grep -q "task-del" <<<"$out"; then
+  echo "PASS: shared image warns, is not deleted, and succeeds"
 else
   echo "FAIL: shared image warns but succeeds (rc=$rc)"; echo "$out"; FAILED=1
 fi
 
-# Test 10: unreadable visibility -> warn and succeed; the import already finished,
-# so a failed diagnostic must not fail the publish.
+# Test 10: unreadable visibility -> FAIL the publish once the retries are exhausted.
+# This is the check that catches an image landing in gcore's public catalog, so "we
+# could not tell" must not read as "it is fine". Retries are bounded, so the failure
+# arrives after VISIBILITY_ATTEMPTS tries rather than hanging.
 dir=$(make_fake_curl); TMP_DIRS+=("$dir")
 out=$(PATH="$dir:$PATH" FAKE_CURL_VISIBILITY_MISSING=1 \
   GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180" POLL_INTERVAL_SECS=0 VISIBILITY_ATTEMPTS=2 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -ne 0 ] \
+   && grep -q "could not read visibility of image img-1 after 2 attempts" <<<"$out" \
+   && grep -q "treat it as exposed" <<<"$out" \
+   && grep -q "visibility of image img-1 lookup failed (attempt 1/2)" <<<"$out" \
+   && grep -q "1 gcore region import(s) failed" <<<"$out"; then
+  echo "PASS: unverifiable visibility fails the publish after bounded retries"
+else
+  echo "FAIL: unverifiable visibility fails the publish (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
+# Test 10b: a visibility lookup that fails once and then succeeds must still pass. The
+# fail-closed behaviour above is only acceptable because one API blip does not sink an
+# otherwise good build.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+out=$(PATH="$dir:$PATH" FAKE_CURL_VISIBILITY_FLAKY=1 \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
   GCORE_REGIONS="180" POLL_INTERVAL_SECS=0 \
   bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
-if [ "$rc" -eq 0 ] && grep -q "could not read visibility of image img-1" <<<"$out"; then
-  echo "PASS: unreadable visibility warns but succeeds"
+if [ "$rc" -eq 0 ] \
+   && grep -q "visibility of image img-1 lookup failed (attempt 1/3); retrying" <<<"$out" \
+   && grep -q "region 180: image img-1 visibility=private" <<<"$out"; then
+  echo "PASS: a flaky visibility lookup recovers on retry"
 else
-  echo "FAIL: unreadable visibility warns but succeeds (rc=$rc)"; echo "$out"; FAILED=1
+  echo "FAIL: a flaky visibility lookup recovers on retry (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
+# Test 10c: the other half of the check — the task exposes no image ID, so visibility
+# cannot even be looked up. Same reasoning as test 10: fail rather than skip.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+out=$(PATH="$dir:$PATH" FAKE_CURL_NO_IMAGE_ID=1 \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180" POLL_INTERVAL_SECS=0 VISIBILITY_ATTEMPTS=2 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -ne 0 ] \
+   && grep -q "could not resolve the imported image ID from task task-abc after 2 attempts" <<<"$out" \
+   && grep -q "lantern-box-0.0.0" <<<"$out" \
+   && grep -q "1 gcore region import(s) failed" <<<"$out"; then
+  echo "PASS: an unresolvable image ID fails the publish"
+else
+  echo "FAIL: an unresolvable image ID fails the publish (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
+# Test 11: every region's import is issued BEFORE any polling starts, and the wait costs
+# one sleep per round rather than one per region per round. That is the property making
+# wall-clock the slowest single region instead of the sum: draining regions one at a time
+# would cost regions x POLL_ATTEMPTS sleeps (6 here) and would not POST the later imports
+# until the earlier ones finished.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+sleeplog="$dir/sleeps"
+printf '#!/usr/bin/env bash\necho s >> "%s"\n' "$sleeplog" > "$dir/fakesleep"
+chmod +x "$dir/fakesleep"
+out=$(PATH="$dir:$PATH" FAKE_CURL_MODE=always_running SLEEP="$dir/fakesleep" \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180,68,45" POLL_ATTEMPTS=2 POLL_INTERVAL_SECS=0 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+sleeps=$(grep -c . "$sleeplog" 2>/dev/null || echo 0)
+# sed rather than head, which would SIGPIPE the grep feeding it under pipefail.
+last_import=$(grep -n '==> Importing' <<<"$out" | sed -n '$p' | cut -d: -f1)
+first_poll=$(grep -n 'state=RUNNING' <<<"$out" | sed -n '1p' | cut -d: -f1)
+timeouts=$(grep -c 'did not finish after 2 attempts' <<<"$out")
+if [ "$rc" -ne 0 ] && [ "$timeouts" -eq 3 ] && [ "$sleeps" -le 2 ] \
+   && [ -n "$last_import" ] && [ -n "$first_poll" ] && [ "$last_import" -lt "$first_poll" ]; then
+  echo "PASS: imports all start before polling, ${sleeps} sleep(s) for 3 regions x 2 attempts"
+else
+  echo "FAIL: concurrent import/poll (rc=$rc timeouts=$timeouts sleeps=$sleeps import@$last_import poll@$first_poll)"
+  echo "$out"; FAILED=1
+fi
+
+# Test 12: a region whose import POST is rejected must not stop the others from being
+# started or waited on — the failure is counted and the rest still publish.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+out=$(PATH="$dir:$PATH" FAKE_CURL_MODE=mixed FAKE_CURL_ERROR_REGION=68 \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180,68,45" POLL_INTERVAL_SECS=0 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -ne 0 ] \
+   && grep -q "region 180: import task task-180 FINISHED" <<<"$out" \
+   && grep -q "region 45: import task task-45 FINISHED" <<<"$out" \
+   && grep -q "region 68: import task task-68 state ERROR" <<<"$out" \
+   && grep -q "1 gcore region import(s) failed" <<<"$out"; then
+  echo "PASS: one failing region does not block the others"
+else
+  echo "FAIL: one failing region does not block the others (rc=$rc)"; echo "$out"; FAILED=1
 fi
 
 if [ "$FAILED" -eq 0 ]; then echo "ALL TESTS PASSED"; else echo "SOME TESTS FAILED"; fi

--- a/deploy/packer/gcore-publish.test.sh
+++ b/deploy/packer/gcore-publish.test.sh
@@ -7,10 +7,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PUBLISH="${SCRIPT_DIR}/gcore-publish.sh"
 FAILED=0
 
-# Every make_fake_curl call's temp dir is recorded here and removed on exit so
-# no stray dirs are left behind. This runs after $FAILED is already decided by
-# the final `exit "$FAILED"`, so it never masks a test failure or changes the
-# script's exit code.
+# Temp dirs to remove on exit. Runs after $FAILED is already decided, so it can
+# never mask a failure or change the exit code.
 TMP_DIRS=()
 cleanup() {
   local d
@@ -20,21 +18,19 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Writes a fake `curl` into a fresh temp dir and prints the dir. Runs via
-# command substitution, i.e. in a subshell, so it cannot append to TMP_DIRS
-# itself; every call site below does `dir=$(make_fake_curl); TMP_DIRS+=("$dir")`
-# so the dir is still tracked for cleanup. The fake curl ignores flags and
-# responds based on the request URL and FAKE_CURL_MODE (default "ok"):
+# Writes a fake `curl` into a fresh temp dir and prints the dir. It runs in a
+# subshell, so callers do `dir=$(make_fake_curl); TMP_DIRS+=("$dir")` to track it.
+# The fake ignores flags and answers on URL plus FAKE_CURL_MODE (default "ok"):
 #   ok             downloadimage -> task "task-abc"; /tasks/ -> FINISHED
 #   import_error   /tasks/ -> ERROR
-#   retry          /tasks/ -> RUNNING until a per-invocation counter file
-#                  (next to the fake curl) reaches FAKE_CURL_RETRY_THRESHOLD
-#                  (default 2), then FINISHED
+#   retry          /tasks/ -> RUNNING until a counter file next to the fake curl
+#                  reaches FAKE_CURL_RETRY_THRESHOLD (default 2), then FINISHED
 #   always_running /tasks/ -> RUNNING, always (for the timeout test)
-#   mixed          downloadimage -> task named after the region in the URL
-#                  (e.g. region 68 -> "task-68"); /tasks/ -> ERROR for
-#                  FAKE_CURL_ERROR_REGION's task, FINISHED for every other
-#                  region's task
+#   mixed          downloadimage -> task named for the region in the URL (region
+#                  68 -> "task-68"); /tasks/ -> ERROR only for
+#                  FAKE_CURL_ERROR_REGION's task
+# FINISHED tasks report created_resources.images == ["img-1"], and /images/...
+# returns FAKE_CURL_VISIBILITY (default "private") for report_visibility.
 make_fake_curl() {
   local dir
   dir=$(mktemp -d)
@@ -42,6 +38,7 @@ make_fake_curl() {
 #!/usr/bin/env bash
 self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 mode="${FAKE_CURL_MODE:-ok}"
+finished='{"state":"FINISHED","created_resources":{"images":["img-1"]}}'
 for a in "$@"; do
   case "$a" in
     *downloadimage*)
@@ -68,7 +65,7 @@ for a in "$@"; do
           [ -f "$count_file" ] || echo 0 > "$count_file"
           count=$(cat "$count_file")
           if [ "$count" -ge "${FAKE_CURL_RETRY_THRESHOLD:-2}" ]; then
-            echo '{"state":"FINISHED"}'
+            echo "$finished"
           else
             echo $((count + 1)) > "$count_file"
             echo '{"state":"RUNNING"}'
@@ -78,11 +75,20 @@ for a in "$@"; do
           if [ "$region" = "${FAKE_CURL_ERROR_REGION:-}" ]; then
             echo '{"state":"ERROR"}'
           else
-            echo '{"state":"FINISHED"}'
+            echo "$finished"
           fi ;;
         *)
-          echo '{"state":"FINISHED"}' ;;
+          echo "$finished" ;;
       esac
+      exit 0 ;;
+    */images/*)
+      # report_visibility's GET /images/<project>/<region>/<image_id>. Deliberately
+      # does not match the downloadimage URL ("downloadimage/" is not "/images/").
+      if [ -n "${FAKE_CURL_VISIBILITY_MISSING:-}" ]; then
+        echo '{}'
+      else
+        printf '{"visibility":"%s"}\n' "${FAKE_CURL_VISIBILITY:-private}"
+      fi
       exit 0 ;;
   esac
 done
@@ -100,7 +106,9 @@ out=$(PATH="$dir:$PATH" \
   bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
 if [ "$rc" -eq 0 ] \
    && grep -q "region 180: import task task-abc FINISHED" <<<"$out" \
-   && grep -q "region 68: import task task-abc FINISHED" <<<"$out"; then
+   && grep -q "region 68: import task task-abc FINISHED" <<<"$out" \
+   && grep -q "region 180: image img-1 visibility=private" <<<"$out" \
+   && grep -q "region 68: image img-1 visibility=private" <<<"$out"; then
   echo "PASS: happy path (two regions)"
 else
   echo "FAIL: happy path (rc=$rc)"; echo "$out"; FAILED=1
@@ -126,9 +134,8 @@ else
   echo "FAIL: missing env path (rc=$rc)"; echo "$out"; FAILED=1
 fi
 
-# Test 4: poll retries on a non-terminal state, then succeeds -> the fake
-# curl returns RUNNING for the first two /tasks/ polls and FINISHED after,
-# exercising poll_task's sleep-and-retry branch; script still exits 0.
+# Test 4: RUNNING for the first two polls, then FINISHED -> exercises poll_task's
+# sleep-and-retry branch; still exits 0.
 dir=$(make_fake_curl); TMP_DIRS+=("$dir")
 out=$(PATH="$dir:$PATH" FAKE_CURL_MODE=retry FAKE_CURL_RETRY_THRESHOLD=2 \
   GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
@@ -142,9 +149,8 @@ else
   echo "FAIL: poll retry then success (rc=$rc, running_count=$running_count)"; echo "$out"; FAILED=1
 fi
 
-# Test 5: poll timeout -> the fake curl always returns RUNNING, so
-# poll_task exhausts POLL_ATTEMPTS and the script exits non-zero with the
-# "did not finish after" hard-failure message (no fallback).
+# Test 5: always RUNNING -> poll_task exhausts POLL_ATTEMPTS and hard-fails (no
+# fallback).
 dir=$(make_fake_curl); TMP_DIRS+=("$dir")
 out=$(PATH="$dir:$PATH" FAKE_CURL_MODE=always_running \
   GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
@@ -156,9 +162,8 @@ else
   echo "FAIL: poll timeout (rc=$rc)"; echo "$out"; FAILED=1
 fi
 
-# Test 6: mixed multi-region outcome -> region 180 FINISHED, region 68
-# ERROR; the failures counter aggregates across regions and the script
-# exits non-zero even though one region succeeded.
+# Test 6: region 180 FINISHED, region 68 ERROR -> failures aggregate across
+# regions, so the script exits non-zero even though one region succeeded.
 dir=$(make_fake_curl); TMP_DIRS+=("$dir")
 out=$(PATH="$dir:$PATH" FAKE_CURL_MODE=mixed FAKE_CURL_ERROR_REGION=68 \
   GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
@@ -172,8 +177,8 @@ else
   echo "FAIL: mixed multi-region outcome (rc=$rc)"; echo "$out"; FAILED=1
 fi
 
-# Test 7: downloadimage returns an HTTP error -> non-zero exit, status + body
-# surfaced (rather than the empty message the old `curl -f` produced).
+# Test 7: downloadimage HTTP error -> non-zero exit with status + body surfaced,
+# not the empty message `curl -f` used to produce.
 dir=$(make_fake_curl); TMP_DIRS+=("$dir")
 out=$(PATH="$dir:$PATH" FAKE_CURL_IMPORT_HTTP=422 \
   GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
@@ -185,9 +190,51 @@ else
   echo "FAIL: import HTTP error (rc=$rc)"; echo "$out"; FAILED=1
 fi
 
+# Test 8: image comes back public -> import succeeded, but exit non-zero, since
+# public means gcore's global catalog rather than private to the project.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+out=$(PATH="$dir:$PATH" FAKE_CURL_VISIBILITY=public \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180" POLL_INTERVAL_SECS=0 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -ne 0 ] \
+   && grep -q "import task task-abc FINISHED" <<<"$out" \
+   && grep -q "visibility=public" <<<"$out"; then
+  echo "PASS: public image fails the publish"
+else
+  echo "FAIL: public image fails the publish (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
+# Test 9: image comes back "shared" -> owner-only, so a warning rather than a
+# failure, because ?private=true listings won't return it.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+out=$(PATH="$dir:$PATH" FAKE_CURL_VISIBILITY=shared \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180" POLL_INTERVAL_SECS=0 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 0 ] \
+   && grep -q "visibility=shared, not private" <<<"$out" \
+   && grep -q "will NOT return this image" <<<"$out"; then
+  echo "PASS: shared image warns but succeeds"
+else
+  echo "FAIL: shared image warns but succeeds (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
+# Test 10: unreadable visibility -> warn and succeed; the import already finished,
+# so a failed diagnostic must not fail the publish.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+out=$(PATH="$dir:$PATH" FAKE_CURL_VISIBILITY_MISSING=1 \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180" POLL_INTERVAL_SECS=0 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 0 ] && grep -q "could not read visibility of image img-1" <<<"$out"; then
+  echo "PASS: unreadable visibility warns but succeeds"
+else
+  echo "FAIL: unreadable visibility warns but succeeds (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
 if [ "$FAILED" -eq 0 ]; then echo "ALL TESTS PASSED"; else echo "SOME TESTS FAILED"; fi
-# Explicit call (the EXIT trap above is a safety net for any other exit path);
-# cleanup is idempotent, and neither invocation touches $FAILED or calls exit,
-# so this cannot mask a test failure or change the exit code below.
+# The EXIT trap covers other exit paths; cleanup is idempotent and touches neither
+# $FAILED nor exit, so calling it twice is harmless.
 cleanup
 exit "$FAILED"

--- a/deploy/packer/gcore-publish.test.sh
+++ b/deploy/packer/gcore-publish.test.sh
@@ -7,6 +7,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PUBLISH="${SCRIPT_DIR}/gcore-publish.sh"
 FAILED=0
 
+# No real 30s waits between imports. Tests 13/14 set their own per-command value.
+export IMPORT_STAGGER_SECS=0
+
 # Temp dirs to remove on exit. Runs after $FAILED is already decided, so it can
 # never mask a failure or change the exit code.
 TMP_DIRS=()
@@ -364,9 +367,10 @@ dir=$(make_fake_curl); TMP_DIRS+=("$dir")
 sleeplog="$dir/sleeps"
 printf '#!/usr/bin/env bash\necho s >> "%s"\n' "$sleeplog" > "$dir/fakesleep"
 chmod +x "$dir/fakesleep"
+# Stagger off: this counts POLL sleeps, and test 13 covers the per-import ones.
 out=$(PATH="$dir:$PATH" FAKE_CURL_MODE=always_running SLEEP="$dir/fakesleep" \
   GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
-  GCORE_REGIONS="180,68,45" POLL_ATTEMPTS=2 POLL_INTERVAL_SECS=0 \
+  GCORE_REGIONS="180,68,45" POLL_ATTEMPTS=2 POLL_INTERVAL_SECS=0 IMPORT_STAGGER_SECS=0 \
   bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
 sleeps=$(grep -c . "$sleeplog" 2>/dev/null || echo 0)
 # sed rather than head, which would SIGPIPE the grep feeding it under pipefail.
@@ -396,6 +400,38 @@ if [ "$rc" -ne 0 ] \
   echo "PASS: one failing region does not block the others"
 else
   echo "FAIL: one failing region does not block the others (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
+# Test 13: N imports cost N-1 stagger sleeps — none before the first or after the last.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+sleeplog="$dir/sleeps"
+printf '#!/usr/bin/env bash\necho "$1" >> "%s"\n' "$sleeplog" > "$dir/fakesleep"
+chmod +x "$dir/fakesleep"
+out=$(PATH="$dir:$PATH" SLEEP="$dir/fakesleep" \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180,68,45" POLL_INTERVAL_SECS=0 IMPORT_STAGGER_SECS=7 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+staggers=$(grep -c '^7$' "$sleeplog" 2>/dev/null || echo 0)
+if [ "$rc" -eq 0 ] && [ "$staggers" -eq 2 ]; then
+  echo "PASS: 3 imports cost 2 stagger sleeps, none leading or trailing"
+else
+  echo "FAIL: import stagger (rc=$rc staggers=$staggers)"; echo "$out"; FAILED=1
+fi
+
+# Test 14: IMPORT_STAGGER_SECS=0 skips the stagger rather than sleeping 0.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+sleeplog="$dir/sleeps"
+printf '#!/usr/bin/env bash\necho "$1" >> "%s"\n' "$sleeplog" > "$dir/fakesleep"
+chmod +x "$dir/fakesleep"
+out=$(PATH="$dir:$PATH" SLEEP="$dir/fakesleep" \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180,68,45" POLL_INTERVAL_SECS=0 IMPORT_STAGGER_SECS=0 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+sleeps=$(grep -c . "$sleeplog" 2>/dev/null || echo 0)
+if [ "$rc" -eq 0 ] && [ "$sleeps" -eq 0 ]; then
+  echo "PASS: stagger of 0 issues no sleep at all"
+else
+  echo "FAIL: stagger disabled (rc=$rc sleeps=$sleeps)"; echo "$out"; FAILED=1
 fi
 
 if [ "$FAILED" -eq 0 ]; then echo "ALL TESTS PASSED"; else echo "SOME TESTS FAILED"; fi

--- a/deploy/packer/gcore-publish.test.sh
+++ b/deploy/packer/gcore-publish.test.sh
@@ -45,11 +45,15 @@ mode="${FAKE_CURL_MODE:-ok}"
 for a in "$@"; do
   case "$a" in
     *downloadimage*)
-      if [ "$mode" = mixed ]; then
+      # import_region uses `curl -w '\n%{http_code}'`, so append a status line.
+      http="${FAKE_CURL_IMPORT_HTTP:-200}"
+      if [ "$http" != 200 ]; then
+        printf '%s\n%s' '{"detail":"import rejected"}' "$http"
+      elif [ "$mode" = mixed ]; then
         region="${a##*/}"
-        echo "{\"tasks\":[\"task-${region}\"]}"
+        printf '%s\n%s' "{\"tasks\":[\"task-${region}\"]}" 200
       else
-        echo '{"tasks":["task-abc"]}'
+        printf '%s\n%s' '{"tasks":["task-abc"]}' 200
       fi
       exit 0 ;;
     */tasks/*)
@@ -166,6 +170,19 @@ if [ "$rc" -ne 0 ] \
   echo "PASS: mixed multi-region outcome"
 else
   echo "FAIL: mixed multi-region outcome (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
+# Test 7: downloadimage returns an HTTP error -> non-zero exit, status + body
+# surfaced (rather than the empty message the old `curl -f` produced).
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+out=$(PATH="$dir:$PATH" FAKE_CURL_IMPORT_HTTP=422 \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180" POLL_INTERVAL_SECS=0 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -ne 0 ] && grep -q "HTTP 422" <<<"$out" && grep -q "import rejected" <<<"$out"; then
+  echo "PASS: import HTTP error surfaces status + body"
+else
+  echo "FAIL: import HTTP error (rc=$rc)"; echo "$out"; FAILED=1
 fi
 
 if [ "$FAILED" -eq 0 ]; then echo "ALL TESTS PASSED"; else echo "SOME TESTS FAILED"; fi

--- a/deploy/packer/gcore-publish.test.sh
+++ b/deploy/packer/gcore-publish.test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Tests for gcore-publish.sh. Puts a fake `curl` on PATH so no network is used.
+# Run: bash deploy/packer/gcore-publish.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PUBLISH="${SCRIPT_DIR}/gcore-publish.sh"
+FAILED=0
+
+# Writes a fake `curl` into a fresh temp dir and prints the dir. The fake curl
+# ignores flags and responds based on the request URL: a downloadimage POST
+# returns a task id; a /tasks/ GET returns FINISHED (or ERROR when
+# FAKE_CURL_MODE=import_error).
+make_fake_curl() {
+  local dir
+  dir=$(mktemp -d)
+  cat > "$dir/curl" <<'FAKE'
+#!/usr/bin/env bash
+for a in "$@"; do
+  case "$a" in
+    *downloadimage*) echo '{"tasks":["task-abc"]}'; exit 0 ;;
+    */tasks/*)
+      if [ "${FAKE_CURL_MODE:-ok}" = "import_error" ]; then
+        echo '{"state":"ERROR"}'
+      else
+        echo '{"state":"FINISHED"}'
+      fi
+      exit 0 ;;
+  esac
+done
+echo '{}'; exit 0
+FAKE
+  chmod +x "$dir/curl"
+  echo "$dir"
+}
+
+# Test 1: happy path, two regions -> exit 0, both FINISHED.
+dir=$(make_fake_curl)
+out=$(PATH="$dir:$PATH" \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180,68" POLL_INTERVAL_SECS=0 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 0 ] \
+   && grep -q "region 180: import task task-abc FINISHED" <<<"$out" \
+   && grep -q "region 68: import task task-abc FINISHED" <<<"$out"; then
+  echo "PASS: happy path (two regions)"
+else
+  echo "FAIL: happy path (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
+# Test 2: import task ERROR -> non-zero exit, error surfaced.
+dir=$(make_fake_curl)
+out=$(PATH="$dir:$PATH" FAKE_CURL_MODE=import_error \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180" POLL_INTERVAL_SECS=0 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -ne 0 ] && grep -q "state ERROR" <<<"$out"; then
+  echo "PASS: import error path"
+else
+  echo "FAIL: import error path (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
+# Test 3: missing required env -> non-zero exit with a clear message.
+out=$(GCORE_API_KEY=k bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -ne 0 ] && grep -q "must be set" <<<"$out"; then
+  echo "PASS: missing env path"
+else
+  echo "FAIL: missing env path (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
+if [ "$FAILED" -eq 0 ]; then echo "ALL TESTS PASSED"; else echo "SOME TESTS FAILED"; fi
+exit "$FAILED"

--- a/deploy/packer/gcore-publish.test.sh
+++ b/deploy/packer/gcore-publish.test.sh
@@ -7,24 +7,78 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PUBLISH="${SCRIPT_DIR}/gcore-publish.sh"
 FAILED=0
 
-# Writes a fake `curl` into a fresh temp dir and prints the dir. The fake curl
-# ignores flags and responds based on the request URL: a downloadimage POST
-# returns a task id; a /tasks/ GET returns FINISHED (or ERROR when
-# FAKE_CURL_MODE=import_error).
+# Every make_fake_curl call's temp dir is recorded here and removed on exit so
+# no stray dirs are left behind. This runs after $FAILED is already decided by
+# the final `exit "$FAILED"`, so it never masks a test failure or changes the
+# script's exit code.
+TMP_DIRS=()
+cleanup() {
+  local d
+  for d in "${TMP_DIRS[@]:-}"; do
+    [ -n "$d" ] && rm -rf "$d"
+  done
+}
+trap cleanup EXIT
+
+# Writes a fake `curl` into a fresh temp dir and prints the dir. Runs via
+# command substitution, i.e. in a subshell, so it cannot append to TMP_DIRS
+# itself; every call site below does `dir=$(make_fake_curl); TMP_DIRS+=("$dir")`
+# so the dir is still tracked for cleanup. The fake curl ignores flags and
+# responds based on the request URL and FAKE_CURL_MODE (default "ok"):
+#   ok             downloadimage -> task "task-abc"; /tasks/ -> FINISHED
+#   import_error   /tasks/ -> ERROR
+#   retry          /tasks/ -> RUNNING until a per-invocation counter file
+#                  (next to the fake curl) reaches FAKE_CURL_RETRY_THRESHOLD
+#                  (default 2), then FINISHED
+#   always_running /tasks/ -> RUNNING, always (for the timeout test)
+#   mixed          downloadimage -> task named after the region in the URL
+#                  (e.g. region 68 -> "task-68"); /tasks/ -> ERROR for
+#                  FAKE_CURL_ERROR_REGION's task, FINISHED for every other
+#                  region's task
 make_fake_curl() {
   local dir
   dir=$(mktemp -d)
   cat > "$dir/curl" <<'FAKE'
 #!/usr/bin/env bash
+self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+mode="${FAKE_CURL_MODE:-ok}"
 for a in "$@"; do
   case "$a" in
-    *downloadimage*) echo '{"tasks":["task-abc"]}'; exit 0 ;;
-    */tasks/*)
-      if [ "${FAKE_CURL_MODE:-ok}" = "import_error" ]; then
-        echo '{"state":"ERROR"}'
+    *downloadimage*)
+      if [ "$mode" = mixed ]; then
+        region="${a##*/}"
+        echo "{\"tasks\":[\"task-${region}\"]}"
       else
-        echo '{"state":"FINISHED"}'
+        echo '{"tasks":["task-abc"]}'
       fi
+      exit 0 ;;
+    */tasks/*)
+      task="${a##*/tasks/}"
+      case "$mode" in
+        import_error)
+          echo '{"state":"ERROR"}' ;;
+        always_running)
+          echo '{"state":"RUNNING"}' ;;
+        retry)
+          count_file="${self_dir}/poll_count"
+          [ -f "$count_file" ] || echo 0 > "$count_file"
+          count=$(cat "$count_file")
+          if [ "$count" -ge "${FAKE_CURL_RETRY_THRESHOLD:-2}" ]; then
+            echo '{"state":"FINISHED"}'
+          else
+            echo $((count + 1)) > "$count_file"
+            echo '{"state":"RUNNING"}'
+          fi ;;
+        mixed)
+          region="${task#task-}"
+          if [ "$region" = "${FAKE_CURL_ERROR_REGION:-}" ]; then
+            echo '{"state":"ERROR"}'
+          else
+            echo '{"state":"FINISHED"}'
+          fi ;;
+        *)
+          echo '{"state":"FINISHED"}' ;;
+      esac
       exit 0 ;;
   esac
 done
@@ -35,7 +89,7 @@ FAKE
 }
 
 # Test 1: happy path, two regions -> exit 0, both FINISHED.
-dir=$(make_fake_curl)
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
 out=$(PATH="$dir:$PATH" \
   GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
   GCORE_REGIONS="180,68" POLL_INTERVAL_SECS=0 \
@@ -49,7 +103,7 @@ else
 fi
 
 # Test 2: import task ERROR -> non-zero exit, error surfaced.
-dir=$(make_fake_curl)
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
 out=$(PATH="$dir:$PATH" FAKE_CURL_MODE=import_error \
   GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
   GCORE_REGIONS="180" POLL_INTERVAL_SECS=0 \
@@ -68,5 +122,55 @@ else
   echo "FAIL: missing env path (rc=$rc)"; echo "$out"; FAILED=1
 fi
 
+# Test 4: poll retries on a non-terminal state, then succeeds -> the fake
+# curl returns RUNNING for the first two /tasks/ polls and FINISHED after,
+# exercising poll_task's sleep-and-retry branch; script still exits 0.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+out=$(PATH="$dir:$PATH" FAKE_CURL_MODE=retry FAKE_CURL_RETRY_THRESHOLD=2 \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180" POLL_INTERVAL_SECS=0 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+running_count=$(grep -c "state=RUNNING" <<<"$out")
+if [ "$rc" -eq 0 ] && [ "$running_count" -eq 2 ] \
+   && grep -q "region 180: import task task-abc FINISHED" <<<"$out"; then
+  echo "PASS: poll retry then success"
+else
+  echo "FAIL: poll retry then success (rc=$rc, running_count=$running_count)"; echo "$out"; FAILED=1
+fi
+
+# Test 5: poll timeout -> the fake curl always returns RUNNING, so
+# poll_task exhausts POLL_ATTEMPTS and the script exits non-zero with the
+# "did not finish after" hard-failure message (no fallback).
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+out=$(PATH="$dir:$PATH" FAKE_CURL_MODE=always_running \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180" POLL_ATTEMPTS=2 POLL_INTERVAL_SECS=0 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -ne 0 ] && grep -q "did not finish after 2 attempts" <<<"$out"; then
+  echo "PASS: poll timeout"
+else
+  echo "FAIL: poll timeout (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
+# Test 6: mixed multi-region outcome -> region 180 FINISHED, region 68
+# ERROR; the failures counter aggregates across regions and the script
+# exits non-zero even though one region succeeded.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+out=$(PATH="$dir:$PATH" FAKE_CURL_MODE=mixed FAKE_CURL_ERROR_REGION=68 \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180,68" POLL_INTERVAL_SECS=0 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -ne 0 ] \
+   && grep -q "region 180: import task task-180 FINISHED" <<<"$out" \
+   && grep -q "region 68: import task task-68 state ERROR" <<<"$out"; then
+  echo "PASS: mixed multi-region outcome"
+else
+  echo "FAIL: mixed multi-region outcome (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
 if [ "$FAILED" -eq 0 ]; then echo "ALL TESTS PASSED"; else echo "SOME TESTS FAILED"; fi
+# Explicit call (the EXIT trap above is a safety net for any other exit path);
+# cleanup is idempotent, and neither invocation touches $FAILED or calls exit,
+# so this cannot mask a test failure or change the exit code below.
+cleanup
 exit "$FAILED"

--- a/deploy/packer/gcore-storage.sh
+++ b/deploy/packer/gcore-storage.sh
@@ -1,25 +1,20 @@
 #!/usr/bin/env bash
 #
 # Manage the dedicated gcore object storage that stages the lantern-box qcow2 for
-# image import. gcore ingests images only by fetching from a URL, and its
-# importer does an *unauthenticated* HEAD then GET — there is no API field to
-# hand it credentials, and a presigned/SigV4 URL is bound to a single HTTP
-# method (its HEAD preflight would 403). So the qcow2 has to be reachable with no
-# credentials at all. We stage it in a throwaway, *randomly-named* bucket that is
-# made briefly public-read (the anonymous-read bucket policy is applied by the
-# AWS CLI in the workflow) for the duration of the import, then torn down. The
-# random name keeps the object unguessable during that short window, and the
-# bucket holds only that one qcow2.
+# image import. gcore ingests images only by URL, and its importer does an
+# *unauthenticated* HEAD then GET: there is no API field for source credentials,
+# and a presigned SigV4 URL is bound to one HTTP method (its HEAD preflight 403s).
+# So the qcow2 is staged in a throwaway, randomly-named bucket made briefly
+# public-read for the import, then torn down.
 #
 # This script owns the gcore *control plane* (storage instance + buckets + access
-# keys). The object upload, the public bucket policy, and the object delete are
-# done by the AWS CLI against gcore's S3 endpoint in the workflow.
+# keys); the upload, the public bucket policy, and the object delete are done by
+# the AWS CLI against gcore's S3 endpoint in the workflow.
 #
 # Subcommands:
-#   provision  Find-or-create the dedicated storage instance, sweep any leftover
-#              stage buckets from a crashed run, create a fresh randomly-named
-#              bucket, mint an ephemeral access key, and print these key=value
-#              lines to stdout:
+#   provision  Find-or-create the storage instance, sweep leftover stage buckets,
+#              create a fresh randomly-named bucket, mint an ephemeral access key,
+#              and print these key=value lines to stdout:
 #                storage_id=<int>
 #                region=<s3 region = location technical_name, e.g. s-ed1>
 #                endpoint=<s3 endpoint, e.g. https://s-ed1.cloud.gcore.lu>
@@ -45,31 +40,30 @@ API_BASE="${GCORE_STORAGE_API_BASE:-https://api.gcore.com/storage/v4}"
 AUTH="Authorization: APIKey ${GCORE_API_KEY}"
 STORAGE_NAME="${STORAGE_NAME:-lantern-box-images}"
 LOCATION_NAME="${LOCATION_NAME:-luxembourg-2}"
-# Each run stages into a fresh bucket named "<prefix><random>"; the prefix scopes
-# the stale-bucket sweep so the instance's other buckets are never touched.
+# Each run stages into a fresh "<prefix><random>" bucket; the prefix scopes the
+# stale-bucket sweep so the instance's other buckets are never touched.
 BUCKET_PREFIX="${BUCKET_PREFIX:-lantern-box-stage-}"
 POLL_ATTEMPTS="${POLL_ATTEMPTS:-60}"
 POLL_INTERVAL_SECS="${POLL_INTERVAL_SECS:-5}"
 # gcore's S3 API endpoint is https://<region>.<suffix>, where <region> is the
-# location's technical_name (luxembourg-2 -> s-ed1). NOTE: this is NOT the
-# object_storages `address` field — that host is not the S3 API endpoint.
+# location's technical_name (luxembourg-2 -> s-ed1). NOT the object_storages
+# `address` field — that host is not the S3 API endpoint.
 S3_ENDPOINT_SUFFIX="${GCORE_S3_ENDPOINT_SUFFIX:-cloud.gcore.lu}"
 
-# GET with fail-on-HTTP-error. A real API error propagates (pipefail); a valid
+# GET with fail-on-HTTP-error: a real API error propagates (pipefail), a valid
 # empty result does not.
 api_get() { "$CURL" -sS -f -H "$AUTH" "$@"; }
 
-# find_storage -> "<id>\t<provisioning_status>" for the instance named
-# STORAGE_NAME, or empty output if absent. Uses jq indexing (not `head`) so it
-# never triggers a SIGPIPE under `set -o pipefail`.
+# find_storage -> "<id>\t<provisioning_status>" for STORAGE_NAME, or empty if
+# absent. jq indexing rather than `head`, which would SIGPIPE under pipefail.
 find_storage() {
   api_get "${API_BASE}/object_storages?limit=1000" | jq -r --arg n "$STORAGE_NAME" '
     [.results[] | select(.name == $n)][0]
     | if . then "\(.id)\t\(.provisioning_status)" else empty end'
 }
 
-# resolve_region -> the S3 region code (the location's technical_name) for
-# LOCATION_NAME, e.g. luxembourg-2 -> s-ed1. Empty output if not found.
+# resolve_region -> the S3 region code (LOCATION_NAME's technical_name), e.g.
+# luxembourg-2 -> s-ed1. Empty if not found.
 resolve_region() {
   api_get "${API_BASE}/locations?limit=1000" | jq -r --arg n "$LOCATION_NAME" '
     [.results[] | select(.name == $n)][0].technical_name // empty'
@@ -80,8 +74,8 @@ storage_field() {
   api_get "${API_BASE}/object_storages/$1" | jq -r --arg f "$2" '.[$f]'
 }
 
-# wait_active ID -> returns when provisioning_status == active; fails on a
-# terminal state or timeout. Diagnostics go to stderr.
+# wait_active ID -> returns when provisioning_status == active; fails on a terminal
+# state or timeout.
 wait_active() {
   local id="$1" attempt=0 status
   while [ "$attempt" -lt "$POLL_ATTEMPTS" ]; do
@@ -97,8 +91,8 @@ wait_active() {
   return 1
 }
 
-# ensure_storage -> "<id>"; creates the instance and waits for active if it
-# doesn't already exist. Diagnostics go to stderr so stdout stays clean.
+# ensure_storage -> "<id>"; creates the instance and waits for active if absent.
+# Diagnostics go to stderr so stdout stays clean.
 ensure_storage() {
   local line id status resp
   line=$(find_storage)
@@ -116,15 +110,14 @@ ensure_storage() {
   printf '%s' "$id"
 }
 
-# rand_suffix -> 16 lowercase hex chars from /dev/urandom. Reads a fixed number
-# of bytes with `od` (no `head`) so it can't trip SIGPIPE under set -o pipefail.
+# rand_suffix -> 16 lowercase hex chars. Fixed-size `od` read rather than `head`,
+# which would SIGPIPE under pipefail.
 rand_suffix() { od -An -N8 -tx1 /dev/urandom | tr -d ' \n'; }
 
-# sweep_stale_buckets ID -> best-effort delete of any leftover stage buckets from
-# a crashed run whose cleanup never ran. Only touches buckets whose name starts
-# with BUCKET_PREFIX, so the dedicated instance's other buckets are untouched.
-# (Control-plane delete generally requires the bucket be empty; a leftover that
-# still holds an object is left for the next run / operator — see README.)
+# sweep_stale_buckets ID -> best-effort delete of stage buckets left by a crashed
+# run. Only BUCKET_PREFIX-named buckets, so the instance's others are untouched.
+# Control-plane delete needs an empty bucket, so a leftover still holding an
+# object is left for the operator — see README.
 sweep_stale_buckets() {
   local id="$1" b
   for b in $(api_get "${API_BASE}/object_storages/${id}/buckets?limit=1000" \
@@ -144,8 +137,7 @@ create_bucket() {
 }
 
 # prune_keys ID -> delete every existing access key. Safe because the instance is
-# dedicated to this pipeline; recovers the max-2-keys-per-storage cap after a run
-# whose cleanup didn't run.
+# dedicated to this pipeline; recovers the max-2-keys cap after a crashed run.
 prune_keys() {
   local id="$1" k
   for k in $(api_get "${API_BASE}/object_storages/${id}/access_keys?limit=1000" | jq -r '.results[].access_key'); do
@@ -184,8 +176,8 @@ provision() {
 cleanup() {
   : "${STORAGE_ID:?STORAGE_ID must be set for cleanup}"
   : "${ACCESS_KEY:?ACCESS_KEY must be set for cleanup}"
-  # Delete the stage bucket (and thus its public policy). The workflow removes the
-  # staged object just before calling this, so the bucket is empty by now.
+  # Deleting the bucket drops its public policy too. The workflow removes the
+  # staged object just before this, so the bucket is empty by now.
   if [ -n "${BUCKET:-}" ]; then
     "$CURL" -sS -f -X DELETE -H "$AUTH" \
       "${API_BASE}/object_storages/${STORAGE_ID}/buckets/${BUCKET}" >/dev/null 2>&1 \

--- a/deploy/packer/gcore-storage.sh
+++ b/deploy/packer/gcore-storage.sh
@@ -1,17 +1,13 @@
 #!/usr/bin/env bash
 #
-# Manage the dedicated gcore object storage that stages the lantern-box qcow2 for
-# image import. gcore ingests images only by URL, and its importer does an
-# *unauthenticated* HEAD then GET: there is no API field for source credentials,
-# and a presigned SigV4 URL is bound to one HTTP method (its HEAD preflight 403s).
-# So the qcow2 is staged in a throwaway, randomly-named bucket made briefly
-# public-read for the import, then torn down.
+# Manage the gcore object storage that stages the lantern-box qcow2 for image import.
+# gcore ingests only by URL and its importer does an *unauthenticated* HEAD then GET — no
+# source-credential field, and a presigned SigV4 URL is method-bound (the HEAD 403s). So
+# the qcow2 is staged in a throwaway randomly-named bucket, made briefly public-read.
 #
-# This script owns the gcore *control plane* (storage instance + buckets + access
-# keys); the upload, the public bucket policy, and the object delete are done by
-# the AWS CLI against gcore's S3 endpoint in the workflow. The one place this
-# script reaches for the S3 API too is the stale-bucket sweep, which has to revoke
-# the policy and empty a leftover before the control plane will delete it.
+# This script owns the gcore *control plane* (instance + buckets + access keys); the
+# workflow does the upload, policy, and object delete via the AWS CLI. The exception is
+# the stale-bucket sweep, which needs S3 to revoke and empty a leftover first.
 #
 # Subcommands:
 #   provision  Find-or-create the storage instance, mint an ephemeral access key,
@@ -124,13 +120,10 @@ ensure_storage() {
 # which would SIGPIPE under pipefail.
 rand_suffix() { od -An -N8 -tx1 /dev/urandom | tr -d ' \n'; }
 
-# sweep_stale_buckets ID ENDPOINT -> best-effort teardown of stage buckets left by
-# a run that died before its own cleanup (a lost runner; a cancelled job still runs
-# its always() teardown). Only BUCKET_PREFIX-named buckets, so the instance's
-# others are untouched. Order matters: revoke the anonymous-read policy FIRST —
-# that is what ends the exposure, and it works whether or not the rest succeeds —
-# then empty the bucket, because the control-plane delete refuses a non-empty one.
-# Expects AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_DEFAULT_REGION in the env.
+# sweep_stale_buckets ID ENDPOINT -> best-effort teardown of stage buckets left by a run
+# that died before its own cleanup. Only BUCKET_PREFIX-named ones. Order matters: revoke
+# the policy FIRST (that ends the exposure), then empty, since the control-plane delete
+# refuses a non-empty bucket. Expects AWS_* in the env.
 sweep_stale_buckets() {
   local id="$1" endpoint="$2" b
   for b in $(api_get "${API_BASE}/object_storages/${id}/buckets?limit=1000" \
@@ -147,13 +140,10 @@ sweep_stale_buckets() {
   done
 }
 
-# bucket_exists ID NAME -> 0 present, 1 absent, 2 could not tell. Lets cleanup tell
-# "the delete raced something that already removed it" apart from "the delete was
-# refused and the bucket is still there". The third state matters: folding an
-# unreadable listing into "absent" would report a stranded bucket as cleaned up,
-# which is the exact failure this check exists to catch. So the fetch and the parse
-# are separated — api_get uses curl -f, whose non-zero covers auth, 5xx and network
-# alike, and jq -e exits 1 only for a listing it read and found no match in.
+# bucket_exists ID NAME -> 0 present, 1 absent, 2 could not tell. The third state
+# matters: folding an unreadable listing into "absent" would report a stranded bucket as
+# cleaned up. Hence fetch and parse are separate — curl -f covers auth/5xx/network, and
+# jq -e exits 1 only for a listing it read and found no match in.
 bucket_exists() {
   local listing rc=0
   listing=$(api_get "${API_BASE}/object_storages/$1/buckets?limit=1000") || return 2
@@ -165,15 +155,11 @@ bucket_exists() {
   esac
 }
 
-# set_bucket_expiry BUCKET ENDPOINT -> attach a 1-day object-expiry lifecycle rule.
-# This is the last-resort backstop: if a run dies so hard that no teardown runs at all
-# (a lost runner — a cancelled job still runs its always() steps), gcore deletes the
-# staged qcow2 on its own. That also un-sticks the bucket, because the control-plane
-# delete refuses a non-empty one. Gcore's expiry pass runs around midnight UTC and
-# lands a day later than Days suggests, so the worst case is ~48h — a floor under the
-# exposure, never a substitute for the workflow's policy revoke, which closes the
-# window in seconds. Gcore implements the legacy put-bucket-lifecycle, not
-# put-bucket-lifecycle-configuration.
+# set_bucket_expiry BUCKET ENDPOINT -> 1-day object-expiry rule. Last-resort backstop for
+# a run that dies with no teardown at all: gcore removes the qcow2 itself, which also
+# un-sticks the bucket. Its expiry pass runs near midnight UTC, so worst case is ~48h — a
+# floor under the exposure, not a substitute for the policy revoke. Gcore implements the
+# legacy put-bucket-lifecycle, not put-bucket-lifecycle-configuration.
 set_bucket_expiry() {
   local bucket="$1" endpoint="$2"
   "$AWS" s3api put-bucket-lifecycle --bucket "$bucket" --endpoint-url "$endpoint" \
@@ -183,12 +169,9 @@ set_bucket_expiry() {
 }
 
 # empty_bucket BUCKET ENDPOINT -> remove everything the control-plane delete counts.
-# Incomplete multipart uploads come first: the qcow2 is multi-GB so `aws s3 cp` uploads
-# it in parts, and a run killed mid-upload leaves parts that `s3 rm` does NOT touch and
-# that the expiry rule does not cover either (that needs AbortIncompleteMultipartUpload,
-# which gcore does not document). Skipping them is how a bucket becomes permanently
-# un-deletable. Best-effort throughout: a bucket that was never written to has nothing
-# to remove, and that is not an error.
+# Multipart uploads first: a run killed mid-upload leaves parts that `s3 rm` does NOT
+# touch and the expiry rule does not cover, which is how a bucket becomes permanently
+# un-deletable. Best-effort: a bucket never written to has nothing to remove.
 empty_bucket() {
   local bucket="$1" endpoint="$2" mpu key uploadid
   mpu=$("$AWS" s3api list-multipart-uploads --bucket "$bucket" --endpoint-url "$endpoint" \
@@ -273,14 +256,10 @@ cleanup() {
   : "${STORAGE_ID:?STORAGE_ID must be set for cleanup}"
   : "${ACCESS_KEY:?ACCESS_KEY must be set for cleanup}"
   local stuck=0 exists=0
-  # The workflow revokes the bucket policy and deletes the staged object before
-  # calling this, so the bucket should be empty and already non-public. If the
-  # delete is refused and the bucket is still there, it is still holding the qcow2:
-  # report that instead of swallowing it, because a silently-ignored failure here is
-  # how a stage bucket gets stranded with nothing watching it.
-  #
-  # The bucket NAME is ::add-mask::ed in CI, so it renders as *** in these messages —
-  # hence the prefix-and-instance hint, which is what an operator can actually act on.
+  # The workflow already revoked the policy and deleted the object, so the bucket should
+  # be empty and non-public. A refused delete means it is still holding the qcow2 — report
+  # it rather than swallowing it. The bucket NAME is masked in CI and renders as ***,
+  # hence the prefix-and-instance hint.
   if [ -n "${BUCKET:-}" ]; then
     if "$CURL" -sS -f -X DELETE -H "$AUTH" \
       "${API_BASE}/object_storages/${STORAGE_ID}/buckets/${BUCKET}" >/dev/null 2>&1; then
@@ -301,9 +280,8 @@ cleanup() {
       esac
     fi
   fi
-  # Drop the key even when the bucket is stuck: it only grants write access to a
-  # bucket already being left behind, and the sweep that reclaims that bucket mints
-  # a fresh key of its own.
+  # Drop the key even when the bucket is stuck: it only grants write to a bucket already
+  # being left behind, and the sweep that reclaims it mints its own key.
   "$CURL" -sS -f -X DELETE -H "$AUTH" \
     "${API_BASE}/object_storages/${STORAGE_ID}/access_keys/${ACCESS_KEY}" >/dev/null 2>&1 \
     && echo "deleted gcore access key on storage ${STORAGE_ID}" \

--- a/deploy/packer/gcore-storage.sh
+++ b/deploy/packer/gcore-storage.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# Manage the dedicated gcore object storage that stages the lantern-box qcow2 for
+# image import. gcore ingests images only by fetching from a URL, so
+# build-images.yaml uploads the built qcow2 into this bucket (S3 protocol) and
+# hands gcore a short-lived presigned URL. This script owns the gcore *control
+# plane* (instance + bucket + access keys); the actual object upload/presign is
+# done by the AWS CLI against gcore's S3 endpoint in the workflow.
+#
+# Subcommands:
+#   provision  Find-or-create the dedicated S3 storage instance + bucket, mint a
+#              fresh access key, and print these key=value lines to stdout:
+#                storage_id=<int>
+#                address=<s3 host, e.g. luxembourg-2.storage.gcore.dev>
+#                bucket=<name>
+#                access_key=<key>
+#                secret_key=<secret>
+#   cleanup    Delete one access key (best-effort; never fails the job). Reads
+#              STORAGE_ID and ACCESS_KEY from the env.
+#
+# Required env: GCORE_API_KEY
+# Config env (defaults): STORAGE_NAME=lantern-box-images,
+#   LOCATION_NAME=luxembourg-2, BUCKET_NAME=lantern-box-images
+# Test/override env: CURL=curl, SLEEP=sleep,
+#   GCORE_STORAGE_API_BASE=https://api.gcore.com/storage/v4,
+#   POLL_ATTEMPTS=60, POLL_INTERVAL_SECS=5
+set -euo pipefail
+
+: "${GCORE_API_KEY:?GCORE_API_KEY must be set}"
+
+CURL="${CURL:-curl}"
+SLEEP="${SLEEP:-sleep}"
+API_BASE="${GCORE_STORAGE_API_BASE:-https://api.gcore.com/storage/v4}"
+AUTH="Authorization: APIKey ${GCORE_API_KEY}"
+STORAGE_NAME="${STORAGE_NAME:-lantern-box-images}"
+LOCATION_NAME="${LOCATION_NAME:-luxembourg-2}"
+BUCKET_NAME="${BUCKET_NAME:-lantern-box-images}"
+POLL_ATTEMPTS="${POLL_ATTEMPTS:-60}"
+POLL_INTERVAL_SECS="${POLL_INTERVAL_SECS:-5}"
+
+# GET with fail-on-HTTP-error. A real API error propagates (pipefail); a valid
+# empty result does not.
+api_get() { "$CURL" -sS -f -H "$AUTH" "$@"; }
+
+# find_storage -> "<id>\t<address>\t<provisioning_status>" for the instance named
+# STORAGE_NAME, or empty output if absent. Uses jq indexing (not `head`) so it
+# never triggers a SIGPIPE under `set -o pipefail`.
+find_storage() {
+  api_get "${API_BASE}/object_storages?limit=1000" | jq -r --arg n "$STORAGE_NAME" '
+    [.results[] | select(.name == $n)][0]
+    | if . then "\(.id)\t\(.address)\t\(.provisioning_status)" else empty end'
+}
+
+# storage_field ID FIELD -> a single field from the instance record.
+storage_field() {
+  api_get "${API_BASE}/object_storages/$1" | jq -r --arg f "$2" '.[$f]'
+}
+
+# wait_active ID -> returns when provisioning_status == active; fails on a
+# terminal state or timeout. Diagnostics go to stderr.
+wait_active() {
+  local id="$1" attempt=0 status
+  while [ "$attempt" -lt "$POLL_ATTEMPTS" ]; do
+    status=$(storage_field "$id" provisioning_status)
+    case "$status" in
+      active) return 0 ;;
+      deleting | deleted) echo "::error::gcore storage ${id} in terminal state ${status}" >&2; return 1 ;;
+      *) "$SLEEP" "$POLL_INTERVAL_SECS" ;;
+    esac
+    attempt=$((attempt + 1))
+  done
+  echo "::error::gcore storage ${id} not active after ${POLL_ATTEMPTS} attempts" >&2
+  return 1
+}
+
+# ensure_storage -> "<id>\t<address>"; creates the instance and waits for active
+# if it doesn't already exist. Diagnostics go to stderr so stdout stays clean.
+ensure_storage() {
+  local line id address status resp
+  line=$(find_storage)
+  if [ -n "$line" ]; then
+    IFS=$'\t' read -r id address status <<<"$line"
+    if [ "$status" != "active" ]; then
+      wait_active "$id" || return 1
+      address=$(storage_field "$id" address)
+    fi
+  else
+    echo "creating gcore storage ${STORAGE_NAME} in ${LOCATION_NAME}" >&2
+    resp=$("$CURL" -sS -f -X POST -H "$AUTH" -H 'Content-Type: application/json' \
+      -d "$(jq -n --arg n "$STORAGE_NAME" --arg loc "$LOCATION_NAME" '{name: $n, location_name: $loc}')" \
+      "${API_BASE}/object_storages")
+    id=$(printf '%s' "$resp" | jq -r '.id')
+    wait_active "$id" || return 1
+    address=$(storage_field "$id" address)
+  fi
+  printf '%s\t%s' "$id" "$address"
+}
+
+# ensure_bucket ID -> creates BUCKET_NAME if absent.
+ensure_bucket() {
+  local id="$1"
+  if api_get "${API_BASE}/object_storages/${id}/buckets?limit=1000" \
+    | jq -e --arg b "$BUCKET_NAME" 'any(.results[]; .name == $b)' >/dev/null; then
+    return 0
+  fi
+  "$CURL" -sS -f -X POST -H "$AUTH" -H 'Content-Type: application/json' \
+    -d "$(jq -n --arg b "$BUCKET_NAME" '{name: $b}')" \
+    "${API_BASE}/object_storages/${id}/buckets" >/dev/null
+}
+
+# prune_keys ID -> delete every existing access key. Safe because the instance is
+# dedicated to this pipeline; recovers the max-2-keys-per-storage cap after a run
+# whose cleanup didn't run.
+prune_keys() {
+  local id="$1" k
+  for k in $(api_get "${API_BASE}/object_storages/${id}/access_keys?limit=1000" | jq -r '.results[].access_key'); do
+    echo "pruning stale access key on storage ${id}" >&2
+    "$CURL" -sS -f -X DELETE -H "$AUTH" "${API_BASE}/object_storages/${id}/access_keys/${k}" >/dev/null || true
+  done
+}
+
+# mint_key ID -> "<access_key>\t<secret_key>"
+mint_key() {
+  local id="$1" resp
+  resp=$("$CURL" -sS -f -X POST -H "$AUTH" "${API_BASE}/object_storages/${id}/access_keys")
+  printf '%s\t%s' \
+    "$(printf '%s' "$resp" | jq -r '.access_key')" \
+    "$(printf '%s' "$resp" | jq -r '.secret_key')"
+}
+
+provision() {
+  local out id address ak sk
+  out=$(ensure_storage) || { echo "::error::failed to resolve gcore storage" >&2; exit 1; }
+  IFS=$'\t' read -r id address <<<"$out"
+  [ -n "$id" ] && [ -n "$address" ] || { echo "::error::empty gcore storage id/address" >&2; exit 1; }
+  ensure_bucket "$id"
+  prune_keys "$id"
+  out=$(mint_key "$id")
+  IFS=$'\t' read -r ak sk <<<"$out"
+  [ -n "$ak" ] && [ -n "$sk" ] || { echo "::error::failed to mint gcore access key" >&2; exit 1; }
+  printf 'storage_id=%s\naddress=%s\nbucket=%s\naccess_key=%s\nsecret_key=%s\n' \
+    "$id" "$address" "$BUCKET_NAME" "$ak" "$sk"
+}
+
+cleanup() {
+  : "${STORAGE_ID:?STORAGE_ID must be set for cleanup}"
+  : "${ACCESS_KEY:?ACCESS_KEY must be set for cleanup}"
+  "$CURL" -sS -f -X DELETE -H "$AUTH" \
+    "${API_BASE}/object_storages/${STORAGE_ID}/access_keys/${ACCESS_KEY}" >/dev/null 2>&1 \
+    && echo "deleted gcore access key on storage ${STORAGE_ID}" \
+    || echo "gcore access key already gone or delete failed (ignored)"
+}
+
+case "${1:-}" in
+  provision) provision ;;
+  cleanup) cleanup ;;
+  *)
+    echo "usage: $0 {provision|cleanup}" >&2
+    exit 2
+    ;;
+esac

--- a/deploy/packer/gcore-storage.sh
+++ b/deploy/packer/gcore-storage.sh
@@ -1,27 +1,37 @@
 #!/usr/bin/env bash
 #
 # Manage the dedicated gcore object storage that stages the lantern-box qcow2 for
-# image import. gcore ingests images only by fetching from a URL, so
-# build-images.yaml uploads the built qcow2 into this bucket (S3 protocol) and
-# hands gcore a short-lived presigned URL. This script owns the gcore *control
-# plane* (instance + bucket + access keys); the actual object upload/presign is
+# image import. gcore ingests images only by fetching from a URL, and its
+# importer does an *unauthenticated* HEAD then GET — there is no API field to
+# hand it credentials, and a presigned/SigV4 URL is bound to a single HTTP
+# method (its HEAD preflight would 403). So the qcow2 has to be reachable with no
+# credentials at all. We stage it in a throwaway, *randomly-named* bucket that is
+# made briefly public-read (the anonymous-read bucket policy is applied by the
+# AWS CLI in the workflow) for the duration of the import, then torn down. The
+# random name keeps the object unguessable during that short window, and the
+# bucket holds only that one qcow2.
+#
+# This script owns the gcore *control plane* (storage instance + buckets + access
+# keys). The object upload, the public bucket policy, and the object delete are
 # done by the AWS CLI against gcore's S3 endpoint in the workflow.
 #
 # Subcommands:
-#   provision  Find-or-create the dedicated S3 storage instance + bucket, mint a
-#              fresh access key, and print these key=value lines to stdout:
+#   provision  Find-or-create the dedicated storage instance, sweep any leftover
+#              stage buckets from a crashed run, create a fresh randomly-named
+#              bucket, mint an ephemeral access key, and print these key=value
+#              lines to stdout:
 #                storage_id=<int>
 #                region=<s3 region = location technical_name, e.g. s-ed1>
 #                endpoint=<s3 endpoint, e.g. https://s-ed1.cloud.gcore.lu>
-#                bucket=<name>
+#                bucket=<name, e.g. lantern-box-stage-ab12cd34ef56ab78>
 #                access_key=<key>
 #                secret_key=<secret>
-#   cleanup    Delete one access key (best-effort; never fails the job). Reads
-#              STORAGE_ID and ACCESS_KEY from the env.
+#   cleanup    Delete the stage bucket and the access key (best-effort; never
+#              fails the job). Reads STORAGE_ID, BUCKET, and ACCESS_KEY from env.
 #
 # Required env: GCORE_API_KEY
 # Config env (defaults): STORAGE_NAME=lantern-box-images,
-#   LOCATION_NAME=luxembourg-2, BUCKET_NAME=lantern-box-images
+#   LOCATION_NAME=luxembourg-2, BUCKET_PREFIX=lantern-box-stage-
 # Test/override env: CURL=curl, SLEEP=sleep,
 #   GCORE_STORAGE_API_BASE=https://api.gcore.com/storage/v4,
 #   POLL_ATTEMPTS=60, POLL_INTERVAL_SECS=5
@@ -35,7 +45,9 @@ API_BASE="${GCORE_STORAGE_API_BASE:-https://api.gcore.com/storage/v4}"
 AUTH="Authorization: APIKey ${GCORE_API_KEY}"
 STORAGE_NAME="${STORAGE_NAME:-lantern-box-images}"
 LOCATION_NAME="${LOCATION_NAME:-luxembourg-2}"
-BUCKET_NAME="${BUCKET_NAME:-lantern-box-images}"
+# Each run stages into a fresh bucket named "<prefix><random>"; the prefix scopes
+# the stale-bucket sweep so the instance's other buckets are never touched.
+BUCKET_PREFIX="${BUCKET_PREFIX:-lantern-box-stage-}"
 POLL_ATTEMPTS="${POLL_ATTEMPTS:-60}"
 POLL_INTERVAL_SECS="${POLL_INTERVAL_SECS:-5}"
 # gcore's S3 API endpoint is https://<region>.<suffix>, where <region> is the
@@ -104,15 +116,30 @@ ensure_storage() {
   printf '%s' "$id"
 }
 
-# ensure_bucket ID -> creates BUCKET_NAME if absent.
-ensure_bucket() {
-  local id="$1"
-  if api_get "${API_BASE}/object_storages/${id}/buckets?limit=1000" \
-    | jq -e --arg b "$BUCKET_NAME" 'any(.results[]; .name == $b)' >/dev/null; then
-    return 0
-  fi
+# rand_suffix -> 16 lowercase hex chars from /dev/urandom. Reads a fixed number
+# of bytes with `od` (no `head`) so it can't trip SIGPIPE under set -o pipefail.
+rand_suffix() { od -An -N8 -tx1 /dev/urandom | tr -d ' \n'; }
+
+# sweep_stale_buckets ID -> best-effort delete of any leftover stage buckets from
+# a crashed run whose cleanup never ran. Only touches buckets whose name starts
+# with BUCKET_PREFIX, so the dedicated instance's other buckets are untouched.
+# (Control-plane delete generally requires the bucket be empty; a leftover that
+# still holds an object is left for the next run / operator — see README.)
+sweep_stale_buckets() {
+  local id="$1" b
+  for b in $(api_get "${API_BASE}/object_storages/${id}/buckets?limit=1000" \
+    | jq -r --arg p "$BUCKET_PREFIX" '.results[] | select(.name | startswith($p)) | .name'); do
+    echo "sweeping stale stage bucket ${b} on storage ${id}" >&2
+    "$CURL" -sS -f -X DELETE -H "$AUTH" \
+      "${API_BASE}/object_storages/${id}/buckets/${b}" >/dev/null 2>&1 || true
+  done
+}
+
+# create_bucket ID NAME -> creates the named bucket.
+create_bucket() {
+  local id="$1" name="$2"
   "$CURL" -sS -f -X POST -H "$AUTH" -H 'Content-Type: application/json' \
-    -d "$(jq -n --arg b "$BUCKET_NAME" '{name: $b}')" \
+    -d "$(jq -n --arg b "$name" '{name: $b}')" \
     "${API_BASE}/object_storages/${id}/buckets" >/dev/null
 }
 
@@ -137,24 +164,34 @@ mint_key() {
 }
 
 provision() {
-  local id region endpoint out ak sk
+  local id region endpoint bucket out ak sk
   id=$(ensure_storage) || { echo "::error::failed to resolve gcore storage" >&2; exit 1; }
   [ -n "$id" ] || { echo "::error::empty gcore storage id" >&2; exit 1; }
   region=$(resolve_region || true)
   [ -n "$region" ] || { echo "::error::could not resolve S3 region (technical_name) for location ${LOCATION_NAME}" >&2; exit 1; }
   endpoint="https://${region}.${S3_ENDPOINT_SUFFIX}"
-  ensure_bucket "$id"
+  sweep_stale_buckets "$id"
+  bucket="${BUCKET_PREFIX}$(rand_suffix)"
+  create_bucket "$id" "$bucket"
   prune_keys "$id"
   out=$(mint_key "$id")
   IFS=$'\t' read -r ak sk <<<"$out"
   [ -n "$ak" ] && [ -n "$sk" ] || { echo "::error::failed to mint gcore access key" >&2; exit 1; }
   printf 'storage_id=%s\nregion=%s\nendpoint=%s\nbucket=%s\naccess_key=%s\nsecret_key=%s\n' \
-    "$id" "$region" "$endpoint" "$BUCKET_NAME" "$ak" "$sk"
+    "$id" "$region" "$endpoint" "$bucket" "$ak" "$sk"
 }
 
 cleanup() {
   : "${STORAGE_ID:?STORAGE_ID must be set for cleanup}"
   : "${ACCESS_KEY:?ACCESS_KEY must be set for cleanup}"
+  # Delete the stage bucket (and thus its public policy). The workflow removes the
+  # staged object just before calling this, so the bucket is empty by now.
+  if [ -n "${BUCKET:-}" ]; then
+    "$CURL" -sS -f -X DELETE -H "$AUTH" \
+      "${API_BASE}/object_storages/${STORAGE_ID}/buckets/${BUCKET}" >/dev/null 2>&1 \
+      && echo "deleted gcore stage bucket ${BUCKET} on storage ${STORAGE_ID}" \
+      || echo "gcore stage bucket ${BUCKET} already gone or delete failed (ignored)"
+  fi
   "$CURL" -sS -f -X DELETE -H "$AUTH" \
     "${API_BASE}/object_storages/${STORAGE_ID}/access_keys/${ACCESS_KEY}" >/dev/null 2>&1 \
     && echo "deleted gcore access key on storage ${STORAGE_ID}" \

--- a/deploy/packer/gcore-storage.sh
+++ b/deploy/packer/gcore-storage.sh
@@ -11,7 +11,8 @@
 #   provision  Find-or-create the dedicated S3 storage instance + bucket, mint a
 #              fresh access key, and print these key=value lines to stdout:
 #                storage_id=<int>
-#                address=<s3 host, e.g. luxembourg-2.storage.gcore.dev>
+#                region=<s3 region = location technical_name, e.g. s-ed1>
+#                endpoint=<s3 endpoint, e.g. https://s-ed1.cloud.gcore.lu>
 #                bucket=<name>
 #                access_key=<key>
 #                secret_key=<secret>
@@ -37,18 +38,29 @@ LOCATION_NAME="${LOCATION_NAME:-luxembourg-2}"
 BUCKET_NAME="${BUCKET_NAME:-lantern-box-images}"
 POLL_ATTEMPTS="${POLL_ATTEMPTS:-60}"
 POLL_INTERVAL_SECS="${POLL_INTERVAL_SECS:-5}"
+# gcore's S3 API endpoint is https://<region>.<suffix>, where <region> is the
+# location's technical_name (luxembourg-2 -> s-ed1). NOTE: this is NOT the
+# object_storages `address` field — that host is not the S3 API endpoint.
+S3_ENDPOINT_SUFFIX="${GCORE_S3_ENDPOINT_SUFFIX:-cloud.gcore.lu}"
 
 # GET with fail-on-HTTP-error. A real API error propagates (pipefail); a valid
 # empty result does not.
 api_get() { "$CURL" -sS -f -H "$AUTH" "$@"; }
 
-# find_storage -> "<id>\t<address>\t<provisioning_status>" for the instance named
+# find_storage -> "<id>\t<provisioning_status>" for the instance named
 # STORAGE_NAME, or empty output if absent. Uses jq indexing (not `head`) so it
 # never triggers a SIGPIPE under `set -o pipefail`.
 find_storage() {
   api_get "${API_BASE}/object_storages?limit=1000" | jq -r --arg n "$STORAGE_NAME" '
     [.results[] | select(.name == $n)][0]
-    | if . then "\(.id)\t\(.address)\t\(.provisioning_status)" else empty end'
+    | if . then "\(.id)\t\(.provisioning_status)" else empty end'
+}
+
+# resolve_region -> the S3 region code (the location's technical_name) for
+# LOCATION_NAME, e.g. luxembourg-2 -> s-ed1. Empty output if not found.
+resolve_region() {
+  api_get "${API_BASE}/locations?limit=1000" | jq -r --arg n "$LOCATION_NAME" '
+    [.results[] | select(.name == $n)][0].technical_name // empty'
 }
 
 # storage_field ID FIELD -> a single field from the instance record.
@@ -73,17 +85,14 @@ wait_active() {
   return 1
 }
 
-# ensure_storage -> "<id>\t<address>"; creates the instance and waits for active
-# if it doesn't already exist. Diagnostics go to stderr so stdout stays clean.
+# ensure_storage -> "<id>"; creates the instance and waits for active if it
+# doesn't already exist. Diagnostics go to stderr so stdout stays clean.
 ensure_storage() {
-  local line id address status resp
+  local line id status resp
   line=$(find_storage)
   if [ -n "$line" ]; then
-    IFS=$'\t' read -r id address status <<<"$line"
-    if [ "$status" != "active" ]; then
-      wait_active "$id" || return 1
-      address=$(storage_field "$id" address)
-    fi
+    IFS=$'\t' read -r id status <<<"$line"
+    [ "$status" = "active" ] || wait_active "$id" || return 1
   else
     echo "creating gcore storage ${STORAGE_NAME} in ${LOCATION_NAME}" >&2
     resp=$("$CURL" -sS -f -X POST -H "$AUTH" -H 'Content-Type: application/json' \
@@ -91,9 +100,8 @@ ensure_storage() {
       "${API_BASE}/object_storages")
     id=$(printf '%s' "$resp" | jq -r '.id')
     wait_active "$id" || return 1
-    address=$(storage_field "$id" address)
   fi
-  printf '%s\t%s' "$id" "$address"
+  printf '%s' "$id"
 }
 
 # ensure_bucket ID -> creates BUCKET_NAME if absent.
@@ -129,17 +137,19 @@ mint_key() {
 }
 
 provision() {
-  local out id address ak sk
-  out=$(ensure_storage) || { echo "::error::failed to resolve gcore storage" >&2; exit 1; }
-  IFS=$'\t' read -r id address <<<"$out"
-  [ -n "$id" ] && [ -n "$address" ] || { echo "::error::empty gcore storage id/address" >&2; exit 1; }
+  local id region endpoint out ak sk
+  id=$(ensure_storage) || { echo "::error::failed to resolve gcore storage" >&2; exit 1; }
+  [ -n "$id" ] || { echo "::error::empty gcore storage id" >&2; exit 1; }
+  region=$(resolve_region || true)
+  [ -n "$region" ] || { echo "::error::could not resolve S3 region (technical_name) for location ${LOCATION_NAME}" >&2; exit 1; }
+  endpoint="https://${region}.${S3_ENDPOINT_SUFFIX}"
   ensure_bucket "$id"
   prune_keys "$id"
   out=$(mint_key "$id")
   IFS=$'\t' read -r ak sk <<<"$out"
   [ -n "$ak" ] && [ -n "$sk" ] || { echo "::error::failed to mint gcore access key" >&2; exit 1; }
-  printf 'storage_id=%s\naddress=%s\nbucket=%s\naccess_key=%s\nsecret_key=%s\n' \
-    "$id" "$address" "$BUCKET_NAME" "$ak" "$sk"
+  printf 'storage_id=%s\nregion=%s\nendpoint=%s\nbucket=%s\naccess_key=%s\nsecret_key=%s\n' \
+    "$id" "$region" "$endpoint" "$BUCKET_NAME" "$ak" "$sk"
 }
 
 cleanup() {

--- a/deploy/packer/gcore-storage.sh
+++ b/deploy/packer/gcore-storage.sh
@@ -9,25 +9,34 @@
 #
 # This script owns the gcore *control plane* (storage instance + buckets + access
 # keys); the upload, the public bucket policy, and the object delete are done by
-# the AWS CLI against gcore's S3 endpoint in the workflow.
+# the AWS CLI against gcore's S3 endpoint in the workflow. The one place this
+# script reaches for the S3 API too is the stale-bucket sweep, which has to revoke
+# the policy and empty a leftover before the control plane will delete it.
 #
 # Subcommands:
-#   provision  Find-or-create the storage instance, sweep leftover stage buckets,
-#              create a fresh randomly-named bucket, mint an ephemeral access key,
-#              and print these key=value lines to stdout:
+#   provision  Find-or-create the storage instance, mint an ephemeral access key,
+#              sweep leftover stage buckets with it, create a fresh randomly-named
+#              bucket with a 1-day object-expiry rule, and print these key=value
+#              lines to stdout:
 #                storage_id=<int>
 #                region=<s3 region = location technical_name, e.g. s-ed1>
 #                endpoint=<s3 endpoint, e.g. https://s-ed1.cloud.gcore.lu>
 #                bucket=<name, e.g. lantern-box-stage-ab12cd34ef56ab78>
 #                access_key=<key>
 #                secret_key=<secret>
-#   cleanup    Delete the stage bucket and the access key (best-effort; never
-#              fails the job). Reads STORAGE_ID, BUCKET, and ACCESS_KEY from env.
+#   cleanup    Delete the stage bucket and the access key. Reads STORAGE_ID,
+#              BUCKET, and ACCESS_KEY from env. Fails if the bucket survives the
+#              delete, since that means the staged qcow2 is still sitting there.
+#   empty-bucket
+#              Abort incomplete multipart uploads, then remove every object. Reads
+#              BUCKET and ENDPOINT plus AWS_* credentials from env. Called by the
+#              workflow's teardown and reused by provision's stale-bucket sweep, so
+#              both paths empty a bucket the same way.
 #
 # Required env: GCORE_API_KEY
 # Config env (defaults): STORAGE_NAME=lantern-box-images,
 #   LOCATION_NAME=luxembourg-2, BUCKET_PREFIX=lantern-box-stage-
-# Test/override env: CURL=curl, SLEEP=sleep,
+# Test/override env: CURL=curl, AWS=aws, SLEEP=sleep,
 #   GCORE_STORAGE_API_BASE=https://api.gcore.com/storage/v4,
 #   POLL_ATTEMPTS=60, POLL_INTERVAL_SECS=5
 set -euo pipefail
@@ -35,6 +44,7 @@ set -euo pipefail
 : "${GCORE_API_KEY:?GCORE_API_KEY must be set}"
 
 CURL="${CURL:-curl}"
+AWS="${AWS:-aws}"
 SLEEP="${SLEEP:-sleep}"
 API_BASE="${GCORE_STORAGE_API_BASE:-https://api.gcore.com/storage/v4}"
 AUTH="Authorization: APIKey ${GCORE_API_KEY}"
@@ -114,18 +124,87 @@ ensure_storage() {
 # which would SIGPIPE under pipefail.
 rand_suffix() { od -An -N8 -tx1 /dev/urandom | tr -d ' \n'; }
 
-# sweep_stale_buckets ID -> best-effort delete of stage buckets left by a crashed
-# run. Only BUCKET_PREFIX-named buckets, so the instance's others are untouched.
-# Control-plane delete needs an empty bucket, so a leftover still holding an
-# object is left for the operator — see README.
+# sweep_stale_buckets ID ENDPOINT -> best-effort teardown of stage buckets left by
+# a run that died before its own cleanup (a lost runner; a cancelled job still runs
+# its always() teardown). Only BUCKET_PREFIX-named buckets, so the instance's
+# others are untouched. Order matters: revoke the anonymous-read policy FIRST —
+# that is what ends the exposure, and it works whether or not the rest succeeds —
+# then empty the bucket, because the control-plane delete refuses a non-empty one.
+# Expects AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_DEFAULT_REGION in the env.
 sweep_stale_buckets() {
-  local id="$1" b
+  local id="$1" endpoint="$2" b
   for b in $(api_get "${API_BASE}/object_storages/${id}/buckets?limit=1000" \
     | jq -r --arg p "$BUCKET_PREFIX" '.results[] | select(.name | startswith($p)) | .name'); do
     echo "sweeping stale stage bucket ${b} on storage ${id}" >&2
+    "$AWS" s3api delete-bucket-policy --bucket "$b" --endpoint-url "$endpoint" >/dev/null 2>&1 \
+      && echo "  revoked anonymous-read policy on ${b}" >&2 \
+      || echo "  no bucket policy to revoke on ${b} (or the revoke failed)" >&2
+    empty_bucket "$b" "$endpoint"
     "$CURL" -sS -f -X DELETE -H "$AUTH" \
-      "${API_BASE}/object_storages/${id}/buckets/${b}" >/dev/null 2>&1 || true
+      "${API_BASE}/object_storages/${id}/buckets/${b}" >/dev/null 2>&1 \
+      && echo "  deleted ${b}" >&2 \
+      || echo "::warning::stale stage bucket ${b} on storage ${id} could not be deleted; its public policy was revoked, so this is cost rather than exposure" >&2
   done
+}
+
+# bucket_exists ID NAME -> 0 present, 1 absent, 2 could not tell. Lets cleanup tell
+# "the delete raced something that already removed it" apart from "the delete was
+# refused and the bucket is still there". The third state matters: folding an
+# unreadable listing into "absent" would report a stranded bucket as cleaned up,
+# which is the exact failure this check exists to catch. So the fetch and the parse
+# are separated — api_get uses curl -f, whose non-zero covers auth, 5xx and network
+# alike, and jq -e exits 1 only for a listing it read and found no match in.
+bucket_exists() {
+  local listing rc=0
+  listing=$(api_get "${API_BASE}/object_storages/$1/buckets?limit=1000") || return 2
+  jq -e --arg b "$2" 'any(.results[]; .name == $b)' >/dev/null <<<"$listing" || rc=$?
+  case "$rc" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) return 2 ;;
+  esac
+}
+
+# set_bucket_expiry BUCKET ENDPOINT -> attach a 1-day object-expiry lifecycle rule.
+# This is the last-resort backstop: if a run dies so hard that no teardown runs at all
+# (a lost runner — a cancelled job still runs its always() steps), gcore deletes the
+# staged qcow2 on its own. That also un-sticks the bucket, because the control-plane
+# delete refuses a non-empty one. Gcore's expiry pass runs around midnight UTC and
+# lands a day later than Days suggests, so the worst case is ~48h — a floor under the
+# exposure, never a substitute for the workflow's policy revoke, which closes the
+# window in seconds. Gcore implements the legacy put-bucket-lifecycle, not
+# put-bucket-lifecycle-configuration.
+set_bucket_expiry() {
+  local bucket="$1" endpoint="$2"
+  "$AWS" s3api put-bucket-lifecycle --bucket "$bucket" --endpoint-url "$endpoint" \
+    --lifecycle-configuration "$(jq -nc '{Rules: [{
+      ID: "expire_stage_qcow2", Prefix: "", Status: "Enabled", Expiration: {Days: 1}
+    }]}')" >/dev/null
+}
+
+# empty_bucket BUCKET ENDPOINT -> remove everything the control-plane delete counts.
+# Incomplete multipart uploads come first: the qcow2 is multi-GB so `aws s3 cp` uploads
+# it in parts, and a run killed mid-upload leaves parts that `s3 rm` does NOT touch and
+# that the expiry rule does not cover either (that needs AbortIncompleteMultipartUpload,
+# which gcore does not document). Skipping them is how a bucket becomes permanently
+# un-deletable. Best-effort throughout: a bucket that was never written to has nothing
+# to remove, and that is not an error.
+empty_bucket() {
+  local bucket="$1" endpoint="$2" mpu key uploadid
+  mpu=$("$AWS" s3api list-multipart-uploads --bucket "$bucket" --endpoint-url "$endpoint" \
+    --query 'Uploads[].[Key,UploadId]' --output text 2>/dev/null || true)
+  if [ -n "$mpu" ]; then
+    while IFS=$'\t' read -r key uploadid; do
+      # An absent Uploads key renders as "None" with no second column; skip it.
+      [ -n "${uploadid:-}" ] || continue
+      echo "  aborting incomplete multipart upload ${uploadid} for ${key} in ${bucket}" >&2
+      "$AWS" s3api abort-multipart-upload --bucket "$bucket" --key "$key" \
+        --upload-id "$uploadid" --endpoint-url "$endpoint" >/dev/null 2>&1 \
+        || echo "::warning::could not abort multipart upload ${uploadid} for ${key} in ${bucket}" >&2
+    done <<<"$mpu"
+  fi
+  "$AWS" s3 rm "s3://${bucket}" --recursive --endpoint-url "$endpoint" >/dev/null 2>&1 \
+    || echo "  nothing to remove from ${bucket} (or the remove failed)" >&2
 }
 
 # create_bucket ID NAME -> creates the named bucket.
@@ -162,13 +241,30 @@ provision() {
   region=$(resolve_region || true)
   [ -n "$region" ] || { echo "::error::could not resolve S3 region (technical_name) for location ${LOCATION_NAME}" >&2; exit 1; }
   endpoint="https://${region}.${S3_ENDPOINT_SUFFIX}"
-  sweep_stale_buckets "$id"
-  bucket="${BUCKET_PREFIX}$(rand_suffix)"
-  create_bucket "$id" "$bucket"
   prune_keys "$id"
   out=$(mint_key "$id")
   IFS=$'\t' read -r ak sk <<<"$out"
   [ -n "$ak" ] && [ -n "$sk" ] || { echo "::error::failed to mint gcore access key" >&2; exit 1; }
+  # Sweep with the key in hand — emptying a leftover needs S3 credentials — and
+  # before creating this run's bucket, which shares BUCKET_PREFIX and would
+  # otherwise be a sweep target itself. Subshell so the credentials never leak into
+  # the rest of provision; best-effort so a sweep failure can't block the build.
+  (
+    # shellcheck disable=SC2030 # Subshell-local is the point: these must not outlive
+    # the block. Same below.
+    export AWS_ACCESS_KEY_ID="$ak" AWS_SECRET_ACCESS_KEY="$sk" AWS_DEFAULT_REGION="$region"
+    sweep_stale_buckets "$id" "$endpoint"
+  ) || echo "::warning::stale stage-bucket sweep did not complete" >&2
+  bucket="${BUCKET_PREFIX}$(rand_suffix)"
+  create_bucket "$id" "$bucket"
+  # Attach the expiry backstop before anything is uploaded, so it covers a run that
+  # dies at any later point. A warning rather than a failure: the primary controls
+  # (policy revoke, object delete, sweep) are what contain the exposure.
+  (
+    # shellcheck disable=SC2031 # Deliberately scoped to this subshell, as above.
+    export AWS_ACCESS_KEY_ID="$ak" AWS_SECRET_ACCESS_KEY="$sk" AWS_DEFAULT_REGION="$region"
+    set_bucket_expiry "$bucket" "$endpoint"
+  ) || echo "::warning::could not attach the 1-day expiry rule to ${bucket}; teardown is the only cleanup for this run" >&2
   printf 'storage_id=%s\nregion=%s\nendpoint=%s\nbucket=%s\naccess_key=%s\nsecret_key=%s\n' \
     "$id" "$region" "$endpoint" "$bucket" "$ak" "$sk"
 }
@@ -176,25 +272,55 @@ provision() {
 cleanup() {
   : "${STORAGE_ID:?STORAGE_ID must be set for cleanup}"
   : "${ACCESS_KEY:?ACCESS_KEY must be set for cleanup}"
-  # Deleting the bucket drops its public policy too. The workflow removes the
-  # staged object just before this, so the bucket is empty by now.
+  local stuck=0 exists=0
+  # The workflow revokes the bucket policy and deletes the staged object before
+  # calling this, so the bucket should be empty and already non-public. If the
+  # delete is refused and the bucket is still there, it is still holding the qcow2:
+  # report that instead of swallowing it, because a silently-ignored failure here is
+  # how a stage bucket gets stranded with nothing watching it.
+  #
+  # The bucket NAME is ::add-mask::ed in CI, so it renders as *** in these messages —
+  # hence the prefix-and-instance hint, which is what an operator can actually act on.
   if [ -n "${BUCKET:-}" ]; then
-    "$CURL" -sS -f -X DELETE -H "$AUTH" \
-      "${API_BASE}/object_storages/${STORAGE_ID}/buckets/${BUCKET}" >/dev/null 2>&1 \
-      && echo "deleted gcore stage bucket ${BUCKET} on storage ${STORAGE_ID}" \
-      || echo "gcore stage bucket ${BUCKET} already gone or delete failed (ignored)"
+    if "$CURL" -sS -f -X DELETE -H "$AUTH" \
+      "${API_BASE}/object_storages/${STORAGE_ID}/buckets/${BUCKET}" >/dev/null 2>&1; then
+      echo "deleted gcore stage bucket ${BUCKET} on storage ${STORAGE_ID}"
+    else
+      bucket_exists "$STORAGE_ID" "$BUCKET" || exists=$?
+      case "$exists" in
+        1)
+          echo "gcore stage bucket ${BUCKET} already gone" ;;
+        0)
+          stuck=1
+          echo "::error::gcore stage bucket ${BUCKET} on storage ${STORAGE_ID} could not be deleted and still exists — it is probably still holding the staged qcow2. Its public policy was revoked earlier in the job, so this is cost rather than exposure; the next run's sweep empties and deletes it. To find it by hand, list ${BUCKET_PREFIX}* buckets on storage instance ${STORAGE_ID}." >&2 ;;
+        *)
+          # Unknown, so assume the worst: the delete was refused and we cannot even
+          # read the listing to see whether the bucket survived it.
+          stuck=1
+          echo "::error::gcore stage bucket ${BUCKET} on storage ${STORAGE_ID} could not be deleted, and the bucket listing could not be read to confirm whether it survived — treat it as still present and holding the staged qcow2. Its public policy was revoked earlier in the job. Check ${BUCKET_PREFIX}* buckets on storage instance ${STORAGE_ID}; the next run's sweep also empties and deletes them." >&2 ;;
+      esac
+    fi
   fi
+  # Drop the key even when the bucket is stuck: it only grants write access to a
+  # bucket already being left behind, and the sweep that reclaims that bucket mints
+  # a fresh key of its own.
   "$CURL" -sS -f -X DELETE -H "$AUTH" \
     "${API_BASE}/object_storages/${STORAGE_ID}/access_keys/${ACCESS_KEY}" >/dev/null 2>&1 \
     && echo "deleted gcore access key on storage ${STORAGE_ID}" \
     || echo "gcore access key already gone or delete failed (ignored)"
+  return "$stuck"
 }
 
 case "${1:-}" in
   provision) provision ;;
   cleanup) cleanup ;;
+  empty-bucket)
+    : "${BUCKET:?BUCKET must be set for empty-bucket}"
+    : "${ENDPOINT:?ENDPOINT must be set for empty-bucket}"
+    empty_bucket "$BUCKET" "$ENDPOINT"
+    ;;
   *)
-    echo "usage: $0 {provision|cleanup}" >&2
+    echo "usage: $0 {provision|cleanup|empty-bucket}" >&2
     exit 2
     ;;
 esac

--- a/deploy/packer/gcore-storage.test.sh
+++ b/deploy/packer/gcore-storage.test.sh
@@ -194,10 +194,9 @@ out=$(PATH="$dir:$PATH" FAKE_BUCKET_DELETE_FAILS=1 GCORE_API_KEY=k \
 check "cleanup tolerates an already-gone bucket" 0 "$out" "$rc" \
   'already gone' 'deleted gcore access key'
 
-# Test 5c-2: the delete is refused AND the listing is unreadable, so cleanup cannot tell
-# whether the bucket survived. It must assume the worst and fail, never report the
-# reassuring "already gone" — folding unknown into absent is how a bucket still holding
-# the qcow2 gets signed off as cleaned up.
+# Test 5c-2: delete refused AND listing unreadable, so cleanup cannot tell whether the
+# bucket survived. It must fail, never report "already gone" — folding unknown into absent
+# is how a bucket still holding the qcow2 gets signed off as cleaned.
 dir=$(make_fake_curl)
 out=$(PATH="$dir:$PATH" FAKE_BUCKET_DELETE_FAILS=1 FAKE_BUCKET_LIST_FAILS=1 GCORE_API_KEY=k \
   STORAGE_ID=42 BUCKET=lantern-box-stage-abc ACCESS_KEY=NEWKEY \

--- a/deploy/packer/gcore-storage.test.sh
+++ b/deploy/packer/gcore-storage.test.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# Tests for gcore-storage.sh using a fake `curl` on PATH (no network). The fake
-# emulates the gcore object-storage control plane: list/create storages, get a
-# storage, list/create/delete buckets, and list/create/delete access keys.
+# Tests for gcore-storage.sh using fake `curl` and `aws` binaries on PATH (no
+# network). The curl fake emulates the gcore object-storage control plane:
+# list/create storages, get a storage, list/create/delete buckets, and
+# list/create/delete access keys. The aws fake records the S3 calls the stale-bucket
+# sweep makes, since the script redirects their output.
 # Run: bash deploy/packer/gcore-storage.test.sh
 set -uo pipefail
 
@@ -16,11 +18,15 @@ cleanup_tmp() {
 }
 trap cleanup_tmp EXIT
 
-# Writes a fake `curl` to a fresh temp dir (prepended to PATH) and prints the dir.
-# FAKE_MODE=create makes the storage list empty (forces the create path);
-# anything else returns an existing, active instance (id 42).
+# Writes fake `curl` and `aws` binaries to a fresh temp dir (prepended to PATH) and
+# prints the dir. FAKE_MODE=create makes the storage list empty (forces the create
+# path); anything else returns an existing, active instance (id 42).
 # FAKE_STALE=1 makes the bucket listing include a leftover stage bucket, so the
 # provision sweep has something to delete.
+# FAKE_BUCKET_DELETE_FAILS=1 makes the control-plane bucket DELETE fail the way a
+# non-empty bucket does, for the cleanup paths.
+# FAKE_BUCKET_LIST_FAILS=1 makes the bucket LISTING fail too, so cleanup cannot tell
+# whether a bucket that refused its delete actually survived.
 make_fake_curl() {
   local dir
   dir=$(mktemp -d)
@@ -38,9 +44,13 @@ case "$method $url" in
   "DELETE "*/access_keys/*)   echo '{}' ;;
   "POST "*/access_keys)        echo '{"access_key":"NEWKEY","secret_key":"NEWSECRET"}' ;;
   "GET "*/access_keys*)        echo '{"results":[{"access_key":"OLDKEY"}]}' ;;
-  "DELETE "*/buckets/*)        echo '{}' ;;
+  "DELETE "*/buckets/*)
+    # curl -f exits 22 on an HTTP error, which is how a non-empty bucket surfaces.
+    [ "${FAKE_BUCKET_DELETE_FAILS:-}" = "1" ] && exit 22
+    echo '{}' ;;
   "POST "*/buckets)            echo '{"name":"created"}' ;;
   "GET "*/buckets*)
+    [ "${FAKE_BUCKET_LIST_FAILS:-}" = "1" ] && exit 22
     if [ "${FAKE_STALE:-}" = "1" ]; then
       echo '{"results":[{"name":"lantern-box-stage-deadbeefdeadbeef"},{"name":"keep-me"}]}'
     else
@@ -60,6 +70,22 @@ esac
 exit 0
 FAKE
   chmod +x "$dir/curl"
+  cat > "$dir/aws" <<'FAKEAWS'
+#!/usr/bin/env bash
+# Append the invocation to FAKE_AWS_LOG. The sweep redirects aws stdout/stderr to
+# /dev/null, so a log file is the only way for a test to observe these calls.
+[ -n "${FAKE_AWS_LOG:-}" ] && echo "aws $*" >> "$FAKE_AWS_LOG"
+# FAKE_MPU=1 makes list-multipart-uploads report one orphaned upload, which is what
+# drives the abort path. Without it the listing is empty, as for a clean bucket.
+for a in "$@"; do
+  if [ "$a" = list-multipart-uploads ]; then
+    [ "${FAKE_MPU:-}" = "1" ] && printf 'stale-key.qcow2\tupload-123\n'
+    exit 0
+  fi
+done
+exit 0
+FAKEAWS
+  chmod +x "$dir/aws"
   echo "$dir"
 }
 
@@ -75,10 +101,19 @@ check() { # desc, expected-rc-zero(0/1), output, [grep patterns...]
 # Test 1: provision against an existing, active instance. The staged bucket is
 # randomly named, so assert only the "lantern-box-stage-" prefix.
 dir=$(make_fake_curl)
-out=$(PATH="$dir:$PATH" GCORE_API_KEY=k POLL_INTERVAL_SECS=0 bash "$SCRIPT" provision 2>/dev/null) && rc=0 || rc=$?
+awslog1="$dir/aws.log"
+out=$(PATH="$dir:$PATH" FAKE_AWS_LOG="$awslog1" GCORE_API_KEY=k POLL_INTERVAL_SECS=0 bash "$SCRIPT" provision 2>/dev/null) && rc=0 || rc=$?
 check "provision (existing instance)" 0 "$out" "$rc" \
   '^storage_id=42$' '^region=s-ed1$' '^endpoint=https://s-ed1.cloud.gcore.lu$' \
   '^bucket=lantern-box-stage-[0-9a-f]\{16\}$' '^access_key=NEWKEY$' '^secret_key=NEWSECRET$'
+
+# Test 1b: the fresh stage bucket gets the 1-day object-expiry rule — the last-resort
+# backstop for a run that dies before any teardown runs at all. Gcore implements the
+# legacy put-bucket-lifecycle, so assert that spelling specifically.
+logged=$(cat "$awslog1" 2>/dev/null || true)
+check "provision attaches the 1-day expiry rule" 0 "$logged" 0 \
+  's3api put-bucket-lifecycle --bucket lantern-box-stage-[0-9a-f]\{16\}' \
+  '"Expiration":{"Days":1}'
 
 # Test 2: provision when the instance must be created.
 dir=$(make_fake_curl)
@@ -88,9 +123,47 @@ check "provision (create instance)" 0 "$out" "$rc" '^storage_id=42$' '^region=s-
 
 # Test 3: provision sweeps a leftover stage bucket (diagnostics go to stderr).
 dir=$(make_fake_curl)
-out=$(PATH="$dir:$PATH" FAKE_STALE=1 GCORE_API_KEY=k POLL_INTERVAL_SECS=0 bash "$SCRIPT" provision 2>&1) && rc=0 || rc=$?
+awslog="$dir/aws.log"
+out=$(PATH="$dir:$PATH" FAKE_STALE=1 FAKE_AWS_LOG="$awslog" GCORE_API_KEY=k POLL_INTERVAL_SECS=0 bash "$SCRIPT" provision 2>&1) && rc=0 || rc=$?
 check "provision sweeps stale stage bucket" 0 "$out" "$rc" \
-  'sweeping stale stage bucket lantern-box-stage-deadbeefdeadbeef'
+  'sweeping stale stage bucket lantern-box-stage-deadbeefdeadbeef' \
+  'revoked anonymous-read policy on lantern-box-stage-deadbeefdeadbeef' \
+  'deleted lantern-box-stage-deadbeefdeadbeef'
+
+# Test 3b: the sweep revokes the public policy before emptying the bucket — the
+# control plane refuses a non-empty bucket, so without the empty it can't be deleted.
+logged=$(cat "$awslog" 2>/dev/null || true)
+check "sweep revokes policy then empties the stale bucket" 0 "$logged" 0 \
+  's3api delete-bucket-policy --bucket lantern-box-stage-deadbeefdeadbeef' \
+  's3 rm s3://lantern-box-stage-deadbeefdeadbeef --recursive'
+
+# Test 3c: the sweep must never touch a bucket outside BUCKET_PREFIX, and must not
+# touch the fresh bucket it is about to create for this run.
+if grep -q 'keep-me' "$awslog" 2>/dev/null; then
+  echo "FAIL: sweep touched the non-stage bucket keep-me"; FAILED=1
+else
+  echo "PASS: sweep leaves non-stage buckets alone"
+fi
+
+# Test 3d: a stale bucket holding an incomplete multipart upload. `s3 rm` does not
+# touch those parts and the expiry rule does not cover them, so unless the sweep aborts
+# them the control-plane delete can never succeed and the bucket is stranded forever.
+dir=$(make_fake_curl)
+awslog="$dir/aws.log"
+out=$(PATH="$dir:$PATH" FAKE_STALE=1 FAKE_MPU=1 FAKE_AWS_LOG="$awslog" GCORE_API_KEY=k \
+  POLL_INTERVAL_SECS=0 bash "$SCRIPT" provision 2>&1) && rc=0 || rc=$?
+logged=$(cat "$awslog" 2>/dev/null || true)
+check "sweep aborts an orphaned multipart upload" 0 "$logged" "$rc" \
+  'list-multipart-uploads --bucket lantern-box-stage-deadbeefdeadbeef' \
+  'abort-multipart-upload --bucket lantern-box-stage-deadbeefdeadbeef --key stale-key.qcow2 --upload-id upload-123'
+
+# Test 3e: and it must abort them BEFORE emptying — aborting after the `rm` would leave
+# the bucket non-empty at the moment the control-plane delete is attempted.
+if awk '/abort-multipart-upload/{a=NR} /s3 rm s3:\/\/lantern-box-stage-deadbeefdeadbeef/{r=NR} END{exit !(a && r && a < r)}' "$awslog"; then
+  echo "PASS: multipart abort precedes the object removal"
+else
+  echo "FAIL: multipart abort ordering"; cat "$awslog"; FAILED=1
+fi
 
 # Test 4: cleanup deletes the stage bucket and the access key.
 dir=$(make_fake_curl)
@@ -101,6 +174,75 @@ check "cleanup" 0 "$out" "$rc" 'deleted gcore stage bucket lantern-box-stage-abc
 dir=$(make_fake_curl)
 out=$(PATH="$dir:$PATH" GCORE_API_KEY=k STORAGE_ID=42 ACCESS_KEY=NEWKEY bash "$SCRIPT" cleanup 2>&1) && rc=0 || rc=$?
 check "cleanup (no bucket)" 0 "$out" "$rc" 'deleted gcore access key'
+
+# Test 5b: a bucket that survives its delete is still holding the qcow2 — cleanup
+# must say so and fail rather than quietly stranding it. The access key still goes.
+dir=$(make_fake_curl)
+out=$(PATH="$dir:$PATH" FAKE_STALE=1 FAKE_BUCKET_DELETE_FAILS=1 GCORE_API_KEY=k \
+  STORAGE_ID=42 BUCKET=lantern-box-stage-deadbeefdeadbeef ACCESS_KEY=NEWKEY \
+  bash "$SCRIPT" cleanup 2>&1) && rc=0 || rc=$?
+check "cleanup fails loudly on a stuck stage bucket" 1 "$out" "$rc" \
+  '::error::gcore stage bucket lantern-box-stage-deadbeefdeadbeef' \
+  'deleted gcore access key'
+
+# Test 5c: a bucket already gone (delete refused, and it is absent from the listing)
+# is not a failure — that is just a race with an earlier sweep.
+dir=$(make_fake_curl)
+out=$(PATH="$dir:$PATH" FAKE_BUCKET_DELETE_FAILS=1 GCORE_API_KEY=k \
+  STORAGE_ID=42 BUCKET=lantern-box-stage-abc ACCESS_KEY=NEWKEY \
+  bash "$SCRIPT" cleanup 2>&1) && rc=0 || rc=$?
+check "cleanup tolerates an already-gone bucket" 0 "$out" "$rc" \
+  'already gone' 'deleted gcore access key'
+
+# Test 5c-2: the delete is refused AND the listing is unreadable, so cleanup cannot tell
+# whether the bucket survived. It must assume the worst and fail, never report the
+# reassuring "already gone" — folding unknown into absent is how a bucket still holding
+# the qcow2 gets signed off as cleaned up.
+dir=$(make_fake_curl)
+out=$(PATH="$dir:$PATH" FAKE_BUCKET_DELETE_FAILS=1 FAKE_BUCKET_LIST_FAILS=1 GCORE_API_KEY=k \
+  STORAGE_ID=42 BUCKET=lantern-box-stage-abc ACCESS_KEY=NEWKEY \
+  bash "$SCRIPT" cleanup 2>&1) && rc=0 || rc=$?
+check "cleanup fails when it cannot confirm the bucket is gone" 1 "$out" "$rc" \
+  'could not be read to confirm' 'deleted gcore access key'
+if grep -q 'already gone' <<<"$out"; then
+  echo "FAIL: cleanup reported 'already gone' on an unreadable listing"; FAILED=1
+fi
+
+# Test 5d: the empty-bucket subcommand is what the workflow's teardown calls. It must do
+# the same multipart-then-objects removal as the sweep, since it shares empty_bucket.
+dir=$(make_fake_curl)
+awslog="$dir/aws.log"
+out=$(PATH="$dir:$PATH" FAKE_MPU=1 FAKE_AWS_LOG="$awslog" GCORE_API_KEY=k \
+  BUCKET=lantern-box-stage-abc ENDPOINT=https://s-ed1.cloud.gcore.lu \
+  bash "$SCRIPT" empty-bucket 2>&1) && rc=0 || rc=$?
+logged=$(cat "$awslog" 2>/dev/null || true)
+check "empty-bucket aborts multipart uploads and removes objects" 0 "$logged" "$rc" \
+  'abort-multipart-upload --bucket lantern-box-stage-abc --key stale-key.qcow2 --upload-id upload-123' \
+  's3 rm s3://lantern-box-stage-abc --recursive'
+# check() greps each pattern independently, so it cannot see ORDER — assert that
+# separately here rather than leaving it implied by the description above.
+if awk '/abort-multipart-upload/{a=NR} /s3 rm s3:\/\/lantern-box-stage-abc/{r=NR} END{exit !(a && r && a < r)}' "$awslog"; then
+  echo "PASS: empty-bucket aborts before it removes"
+else
+  echo "FAIL: empty-bucket ordering"; cat "$awslog"; FAILED=1
+fi
+
+# Test 5e: a clean bucket has no multipart uploads to abort, and that is not an error.
+dir=$(make_fake_curl)
+awslog="$dir/aws.log"
+out=$(PATH="$dir:$PATH" FAKE_AWS_LOG="$awslog" GCORE_API_KEY=k \
+  BUCKET=lantern-box-stage-abc ENDPOINT=https://s-ed1.cloud.gcore.lu \
+  bash "$SCRIPT" empty-bucket 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 0 ] && ! grep -q 'abort-multipart-upload' "$awslog"; then
+  echo "PASS: empty-bucket skips the abort when there are no orphaned uploads"
+else
+  echo "FAIL: empty-bucket on a clean bucket (rc=$rc)"; cat "$awslog"; FAILED=1
+fi
+
+# Test 5f: empty-bucket needs BUCKET and ENDPOINT, and says so rather than acting on an
+# empty bucket name.
+out=$(GCORE_API_KEY=k bash "$SCRIPT" empty-bucket 2>&1) && rc=0 || rc=$?
+check "empty-bucket requires BUCKET" 1 "$out" "$rc" 'BUCKET must be set'
 
 # Test 6: missing GCORE_API_KEY fails fast.
 out=$(bash "$SCRIPT" provision 2>&1) && rc=0 || rc=$?

--- a/deploy/packer/gcore-storage.test.sh
+++ b/deploy/packer/gcore-storage.test.sh
@@ -38,6 +38,7 @@ case "$method $url" in
   "GET "*/access_keys*)        echo '{"results":[{"access_key":"OLDKEY"}]}' ;;
   "POST "*/buckets)            echo '{"name":"lantern-box-images"}' ;;
   "GET "*/buckets*)            echo '{"results":[]}' ;;
+  "GET "*/locations*)          echo '{"results":[{"name":"luxembourg-2","technical_name":"s-ed1","type":"s3_compatible"}]}' ;;
   "POST "*/object_storages)    echo '{"id":42,"address":"lux.storage.example","provisioning_status":"active"}' ;;
   "GET "*/object_storages/42)  echo '{"id":42,"address":"lux.storage.example","provisioning_status":"active"}' ;;
   "GET "*/object_storages*)
@@ -67,13 +68,13 @@ check() { # desc, expected-rc-zero(0/1), output, [grep patterns...]
 dir=$(make_fake_curl)
 out=$(PATH="$dir:$PATH" GCORE_API_KEY=k POLL_INTERVAL_SECS=0 bash "$SCRIPT" provision 2>/dev/null) && rc=0 || rc=$?
 check "provision (existing instance)" 0 "$out" "$rc" \
-  '^storage_id=42$' '^address=lux.storage.example$' '^bucket=lantern-box-images$' \
-  '^access_key=NEWKEY$' '^secret_key=NEWSECRET$'
+  '^storage_id=42$' '^region=s-ed1$' '^endpoint=https://s-ed1.cloud.gcore.lu$' \
+  '^bucket=lantern-box-images$' '^access_key=NEWKEY$' '^secret_key=NEWSECRET$'
 
 # Test 2: provision when the instance must be created.
 dir=$(make_fake_curl)
 out=$(PATH="$dir:$PATH" FAKE_MODE=create GCORE_API_KEY=k POLL_INTERVAL_SECS=0 bash "$SCRIPT" provision 2>/dev/null) && rc=0 || rc=$?
-check "provision (create instance)" 0 "$out" "$rc" '^storage_id=42$' '^access_key=NEWKEY$'
+check "provision (create instance)" 0 "$out" "$rc" '^storage_id=42$' '^region=s-ed1$' '^access_key=NEWKEY$'
 
 # Test 3: cleanup deletes the access key.
 dir=$(make_fake_curl)

--- a/deploy/packer/gcore-storage.test.sh
+++ b/deploy/packer/gcore-storage.test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Tests for gcore-storage.sh using a fake `curl` on PATH (no network). The fake
+# emulates the gcore object-storage control plane: list/create storages, get a
+# storage, list/create buckets, and list/create/delete access keys.
+# Run: bash deploy/packer/gcore-storage.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT_DIR}/gcore-storage.sh"
+FAILED=0
+TMP_DIRS=()
+
+cleanup_tmp() {
+  local d
+  for d in "${TMP_DIRS[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done
+}
+trap cleanup_tmp EXIT
+
+# Writes a fake `curl` to a fresh temp dir (prepended to PATH) and prints the dir.
+# FAKE_MODE=create makes the storage list empty (forces the create path);
+# anything else returns an existing, active instance (id 42).
+make_fake_curl() {
+  local dir
+  dir=$(mktemp -d)
+  TMP_DIRS+=("$dir")
+  cat > "$dir/curl" <<'FAKE'
+#!/usr/bin/env bash
+method=GET url=""
+prev=""
+for a in "$@"; do
+  [ "$prev" = "-X" ] && method="$a"
+  case "$a" in http://*|https://*) url="$a" ;; esac
+  prev="$a"
+done
+case "$method $url" in
+  "DELETE "*/access_keys/*)   echo '{}' ;;
+  "POST "*/access_keys)        echo '{"access_key":"NEWKEY","secret_key":"NEWSECRET"}' ;;
+  "GET "*/access_keys*)        echo '{"results":[{"access_key":"OLDKEY"}]}' ;;
+  "POST "*/buckets)            echo '{"name":"lantern-box-images"}' ;;
+  "GET "*/buckets*)            echo '{"results":[]}' ;;
+  "POST "*/object_storages)    echo '{"id":42,"address":"lux.storage.example","provisioning_status":"active"}' ;;
+  "GET "*/object_storages/42)  echo '{"id":42,"address":"lux.storage.example","provisioning_status":"active"}' ;;
+  "GET "*/object_storages*)
+    if [ "${FAKE_MODE:-existing}" = "create" ]; then
+      echo '{"results":[]}'
+    else
+      echo '{"results":[{"id":42,"name":"lantern-box-images","address":"lux.storage.example","provisioning_status":"active"}]}'
+    fi ;;
+  *) echo '{}' ;;
+esac
+exit 0
+FAKE
+  chmod +x "$dir/curl"
+  echo "$dir"
+}
+
+check() { # desc, expected-rc-zero(0/1), output, [grep patterns...]
+  local desc="$1" want_ok="$2" out="$3" rc="$4"; shift 4
+  local ok=1 pat
+  if [ "$want_ok" = "0" ] && [ "$rc" -ne 0 ]; then ok=0; fi
+  if [ "$want_ok" = "1" ] && [ "$rc" -eq 0 ]; then ok=0; fi
+  for pat in "$@"; do grep -q "$pat" <<<"$out" || ok=0; done
+  if [ "$ok" -eq 1 ]; then echo "PASS: $desc"; else echo "FAIL: $desc (rc=$rc)"; echo "$out"; FAILED=1; fi
+}
+
+# Test 1: provision against an existing, active instance.
+dir=$(make_fake_curl)
+out=$(PATH="$dir:$PATH" GCORE_API_KEY=k POLL_INTERVAL_SECS=0 bash "$SCRIPT" provision 2>/dev/null) && rc=0 || rc=$?
+check "provision (existing instance)" 0 "$out" "$rc" \
+  '^storage_id=42$' '^address=lux.storage.example$' '^bucket=lantern-box-images$' \
+  '^access_key=NEWKEY$' '^secret_key=NEWSECRET$'
+
+# Test 2: provision when the instance must be created.
+dir=$(make_fake_curl)
+out=$(PATH="$dir:$PATH" FAKE_MODE=create GCORE_API_KEY=k POLL_INTERVAL_SECS=0 bash "$SCRIPT" provision 2>/dev/null) && rc=0 || rc=$?
+check "provision (create instance)" 0 "$out" "$rc" '^storage_id=42$' '^access_key=NEWKEY$'
+
+# Test 3: cleanup deletes the access key.
+dir=$(make_fake_curl)
+out=$(PATH="$dir:$PATH" GCORE_API_KEY=k STORAGE_ID=42 ACCESS_KEY=NEWKEY bash "$SCRIPT" cleanup 2>&1) && rc=0 || rc=$?
+check "cleanup" 0 "$out" "$rc" 'deleted gcore access key'
+
+# Test 4: missing GCORE_API_KEY fails fast.
+out=$(bash "$SCRIPT" provision 2>&1) && rc=0 || rc=$?
+check "missing GCORE_API_KEY" 1 "$out" "$rc" 'must be set'
+
+# Test 5: unknown subcommand is a usage error.
+out=$(GCORE_API_KEY=k bash "$SCRIPT" bogus 2>&1) && rc=0 || rc=$?
+check "unknown subcommand" 1 "$out" "$rc" 'usage:'
+
+if [ "$FAILED" -eq 0 ]; then echo "ALL TESTS PASSED"; else echo "SOME TESTS FAILED"; fi
+cleanup_tmp # explicit (the EXIT trap is the safety net for early exits); rm -rf is idempotent
+exit "$FAILED"

--- a/deploy/packer/gcore-storage.test.sh
+++ b/deploy/packer/gcore-storage.test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Tests for gcore-storage.sh using a fake `curl` on PATH (no network). The fake
 # emulates the gcore object-storage control plane: list/create storages, get a
-# storage, list/create buckets, and list/create/delete access keys.
+# storage, list/create/delete buckets, and list/create/delete access keys.
 # Run: bash deploy/packer/gcore-storage.test.sh
 set -uo pipefail
 
@@ -19,6 +19,8 @@ trap cleanup_tmp EXIT
 # Writes a fake `curl` to a fresh temp dir (prepended to PATH) and prints the dir.
 # FAKE_MODE=create makes the storage list empty (forces the create path);
 # anything else returns an existing, active instance (id 42).
+# FAKE_STALE=1 makes the bucket listing include a leftover stage bucket, so the
+# provision sweep has something to delete.
 make_fake_curl() {
   local dir
   dir=$(mktemp -d)
@@ -36,8 +38,14 @@ case "$method $url" in
   "DELETE "*/access_keys/*)   echo '{}' ;;
   "POST "*/access_keys)        echo '{"access_key":"NEWKEY","secret_key":"NEWSECRET"}' ;;
   "GET "*/access_keys*)        echo '{"results":[{"access_key":"OLDKEY"}]}' ;;
-  "POST "*/buckets)            echo '{"name":"lantern-box-images"}' ;;
-  "GET "*/buckets*)            echo '{"results":[]}' ;;
+  "DELETE "*/buckets/*)        echo '{}' ;;
+  "POST "*/buckets)            echo '{"name":"created"}' ;;
+  "GET "*/buckets*)
+    if [ "${FAKE_STALE:-}" = "1" ]; then
+      echo '{"results":[{"name":"lantern-box-stage-deadbeefdeadbeef"},{"name":"keep-me"}]}'
+    else
+      echo '{"results":[]}'
+    fi ;;
   "GET "*/locations*)          echo '{"results":[{"name":"luxembourg-2","technical_name":"s-ed1","type":"s3_compatible"}]}' ;;
   "POST "*/object_storages)    echo '{"id":42,"address":"lux.storage.example","provisioning_status":"active"}' ;;
   "GET "*/object_storages/42)  echo '{"id":42,"address":"lux.storage.example","provisioning_status":"active"}' ;;
@@ -64,28 +72,41 @@ check() { # desc, expected-rc-zero(0/1), output, [grep patterns...]
   if [ "$ok" -eq 1 ]; then echo "PASS: $desc"; else echo "FAIL: $desc (rc=$rc)"; echo "$out"; FAILED=1; fi
 }
 
-# Test 1: provision against an existing, active instance.
+# Test 1: provision against an existing, active instance. The staged bucket is
+# randomly named, so assert only the "lantern-box-stage-" prefix.
 dir=$(make_fake_curl)
 out=$(PATH="$dir:$PATH" GCORE_API_KEY=k POLL_INTERVAL_SECS=0 bash "$SCRIPT" provision 2>/dev/null) && rc=0 || rc=$?
 check "provision (existing instance)" 0 "$out" "$rc" \
   '^storage_id=42$' '^region=s-ed1$' '^endpoint=https://s-ed1.cloud.gcore.lu$' \
-  '^bucket=lantern-box-images$' '^access_key=NEWKEY$' '^secret_key=NEWSECRET$'
+  '^bucket=lantern-box-stage-[0-9a-f]\{16\}$' '^access_key=NEWKEY$' '^secret_key=NEWSECRET$'
 
 # Test 2: provision when the instance must be created.
 dir=$(make_fake_curl)
 out=$(PATH="$dir:$PATH" FAKE_MODE=create GCORE_API_KEY=k POLL_INTERVAL_SECS=0 bash "$SCRIPT" provision 2>/dev/null) && rc=0 || rc=$?
-check "provision (create instance)" 0 "$out" "$rc" '^storage_id=42$' '^region=s-ed1$' '^access_key=NEWKEY$'
+check "provision (create instance)" 0 "$out" "$rc" '^storage_id=42$' '^region=s-ed1$' \
+  '^bucket=lantern-box-stage-[0-9a-f]\{16\}$' '^access_key=NEWKEY$'
 
-# Test 3: cleanup deletes the access key.
+# Test 3: provision sweeps a leftover stage bucket (diagnostics go to stderr).
+dir=$(make_fake_curl)
+out=$(PATH="$dir:$PATH" FAKE_STALE=1 GCORE_API_KEY=k POLL_INTERVAL_SECS=0 bash "$SCRIPT" provision 2>&1) && rc=0 || rc=$?
+check "provision sweeps stale stage bucket" 0 "$out" "$rc" \
+  'sweeping stale stage bucket lantern-box-stage-deadbeefdeadbeef'
+
+# Test 4: cleanup deletes the stage bucket and the access key.
+dir=$(make_fake_curl)
+out=$(PATH="$dir:$PATH" GCORE_API_KEY=k STORAGE_ID=42 BUCKET=lantern-box-stage-abc ACCESS_KEY=NEWKEY bash "$SCRIPT" cleanup 2>&1) && rc=0 || rc=$?
+check "cleanup" 0 "$out" "$rc" 'deleted gcore stage bucket lantern-box-stage-abc' 'deleted gcore access key'
+
+# Test 5: cleanup without BUCKET still deletes the access key.
 dir=$(make_fake_curl)
 out=$(PATH="$dir:$PATH" GCORE_API_KEY=k STORAGE_ID=42 ACCESS_KEY=NEWKEY bash "$SCRIPT" cleanup 2>&1) && rc=0 || rc=$?
-check "cleanup" 0 "$out" "$rc" 'deleted gcore access key'
+check "cleanup (no bucket)" 0 "$out" "$rc" 'deleted gcore access key'
 
-# Test 4: missing GCORE_API_KEY fails fast.
+# Test 6: missing GCORE_API_KEY fails fast.
 out=$(bash "$SCRIPT" provision 2>&1) && rc=0 || rc=$?
 check "missing GCORE_API_KEY" 1 "$out" "$rc" 'must be set'
 
-# Test 5: unknown subcommand is a usage error.
+# Test 7: unknown subcommand is a usage error.
 out=$(GCORE_API_KEY=k bash "$SCRIPT" bogus 2>&1) && rc=0 || rc=$?
 check "unknown subcommand" 1 "$out" "$rc" 'usage:'
 

--- a/deploy/packer/lantern-box.pkr.hcl
+++ b/deploy/packer/lantern-box.pkr.hcl
@@ -911,12 +911,12 @@ source "oracle-oci" "lantern-box-vap" {
 }
 
 source "linode" "lantern-box" {
-  linode_token      = var.linode_token
-  image             = "linode/ubuntu24.04"
-  region            = var.linode_region
-  instance_type     = "g6-nanode-1"
-  ssh_username      = "root"
-  image_label       = "lantern-box-${var.lantern_box_version}"
+  linode_token  = var.linode_token
+  image         = "linode/ubuntu24.04"
+  region        = var.linode_region
+  instance_type = "g6-nanode-1"
+  ssh_username  = "root"
+  image_label   = "lantern-box-${var.lantern_box_version}"
   image_description = "lantern-box ${var.lantern_box_version} pre-baked image"
 
   # Replicate to Linode regions that support image replication.
@@ -935,12 +935,12 @@ source "linode" "lantern-box" {
 
 # Alibaba Cloud ECS — build in Singapore, copy to all Asia regions.
 source "alicloud-ecs" "lantern-box" {
-  access_key              = var.alicloud_access_key
-  secret_key              = var.alicloud_secret_key
-  region                  = "ap-southeast-1"
-  instance_type           = "ecs.t6-c1m1.large"
-  image_name              = "lantern-box-${var.lantern_box_version}-{{timestamp}}"
-  image_ignore_data_disks = true
+  access_key           = var.alicloud_access_key
+  secret_key           = var.alicloud_secret_key
+  region               = "ap-southeast-1"
+  instance_type        = "ecs.t6-c1m1.large"
+  image_name           = "lantern-box-${var.lantern_box_version}-{{timestamp}}"
+  image_ignore_data_disks       = true
   # Auto-discover the latest Ubuntu 24.04 base image via image_family
   # (requires alicloud plugin >= 1.1.2). This calls DescribeImageFromFamily
   # and always returns the latest system image in the family.
@@ -949,37 +949,37 @@ source "alicloud-ecs" "lantern-box" {
     disk_size     = 20
     disk_category = "cloud_essd"
   }
-  io_optimized               = true
-  internet_charge_type       = "PayByTraffic"
-  internet_max_bandwidth_out = 5
+  io_optimized                  = true
+  internet_charge_type          = "PayByTraffic"
+  internet_max_bandwidth_out    = 5
   # Disable Alibaba's "security enhancement" (China-specific Aegis/CloudMonitor agent).
   # We run our own monitoring and don't want the extra agent on proxy servers.
   security_enhancement_strategy = "Deactive"
   force_stop_instance           = true
-  ssh_username                  = "root"
-  ssh_password                  = var.alicloud_ssh_password
+  ssh_username         = "root"
+  ssh_password         = var.alicloud_ssh_password
 
   wait_copying_image_ready_timeout = 7200 # seconds (2h) — copying to 8 regions can be slow
 
   image_copy_regions = [
-    "ap-southeast-1", # Singapore
-    "ap-southeast-3", # Malaysia (Kuala Lumpur)
-    "ap-southeast-5", # Indonesia (Jakarta)
-    "ap-southeast-6", # Philippines (Manila)
-    "ap-southeast-7", # Thailand (Bangkok)
-    "ap-northeast-1", # Japan (Tokyo)
-    "ap-northeast-2", # South Korea (Seoul)
-    "cn-hongkong",    # Hong Kong
+    "ap-southeast-1",  # Singapore
+    "ap-southeast-3",  # Malaysia (Kuala Lumpur)
+    "ap-southeast-5",  # Indonesia (Jakarta)
+    "ap-southeast-6",  # Philippines (Manila)
+    "ap-southeast-7",  # Thailand (Bangkok)
+    "ap-northeast-1",  # Japan (Tokyo)
+    "ap-northeast-2",  # South Korea (Seoul)
+    "cn-hongkong",     # Hong Kong
   ]
   image_copy_names = [
-    "lantern-box-${var.lantern_box_version}-{{timestamp}}", # Singapore
-    "lantern-box-${var.lantern_box_version}-{{timestamp}}", # Malaysia
-    "lantern-box-${var.lantern_box_version}-{{timestamp}}", # Indonesia
-    "lantern-box-${var.lantern_box_version}-{{timestamp}}", # Philippines
-    "lantern-box-${var.lantern_box_version}-{{timestamp}}", # Thailand
-    "lantern-box-${var.lantern_box_version}-{{timestamp}}", # Japan
-    "lantern-box-${var.lantern_box_version}-{{timestamp}}", # South Korea
-    "lantern-box-${var.lantern_box_version}-{{timestamp}}", # Hong Kong
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Singapore
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Malaysia
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Indonesia
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Philippines
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Thailand
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Japan
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # South Korea
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Hong Kong
   ]
 }
 

--- a/deploy/packer/lantern-box.pkr.hcl
+++ b/deploy/packer/lantern-box.pkr.hcl
@@ -12,6 +12,10 @@ packer {
       version = ">= 1.1.2"
       source  = "github.com/hashicorp/alicloud"
     }
+    qemu = {
+      version = ">= 1.1.0"
+      source  = "github.com/hashicorp/qemu"
+    }
   }
 }
 
@@ -907,12 +911,12 @@ source "oracle-oci" "lantern-box-vap" {
 }
 
 source "linode" "lantern-box" {
-  linode_token  = var.linode_token
-  image         = "linode/ubuntu24.04"
-  region        = var.linode_region
-  instance_type = "g6-nanode-1"
-  ssh_username  = "root"
-  image_label   = "lantern-box-${var.lantern_box_version}"
+  linode_token      = var.linode_token
+  image             = "linode/ubuntu24.04"
+  region            = var.linode_region
+  instance_type     = "g6-nanode-1"
+  ssh_username      = "root"
+  image_label       = "lantern-box-${var.lantern_box_version}"
   image_description = "lantern-box ${var.lantern_box_version} pre-baked image"
 
   # Replicate to Linode regions that support image replication.
@@ -931,12 +935,12 @@ source "linode" "lantern-box" {
 
 # Alibaba Cloud ECS — build in Singapore, copy to all Asia regions.
 source "alicloud-ecs" "lantern-box" {
-  access_key           = var.alicloud_access_key
-  secret_key           = var.alicloud_secret_key
-  region               = "ap-southeast-1"
-  instance_type        = "ecs.t6-c1m1.large"
-  image_name           = "lantern-box-${var.lantern_box_version}-{{timestamp}}"
-  image_ignore_data_disks       = true
+  access_key              = var.alicloud_access_key
+  secret_key              = var.alicloud_secret_key
+  region                  = "ap-southeast-1"
+  instance_type           = "ecs.t6-c1m1.large"
+  image_name              = "lantern-box-${var.lantern_box_version}-{{timestamp}}"
+  image_ignore_data_disks = true
   # Auto-discover the latest Ubuntu 24.04 base image via image_family
   # (requires alicloud plugin >= 1.1.2). This calls DescribeImageFromFamily
   # and always returns the latest system image in the family.
@@ -945,38 +949,80 @@ source "alicloud-ecs" "lantern-box" {
     disk_size     = 20
     disk_category = "cloud_essd"
   }
-  io_optimized                  = true
-  internet_charge_type          = "PayByTraffic"
-  internet_max_bandwidth_out    = 5
+  io_optimized               = true
+  internet_charge_type       = "PayByTraffic"
+  internet_max_bandwidth_out = 5
   # Disable Alibaba's "security enhancement" (China-specific Aegis/CloudMonitor agent).
   # We run our own monitoring and don't want the extra agent on proxy servers.
   security_enhancement_strategy = "Deactive"
   force_stop_instance           = true
-  ssh_username         = "root"
-  ssh_password         = var.alicloud_ssh_password
+  ssh_username                  = "root"
+  ssh_password                  = var.alicloud_ssh_password
 
   wait_copying_image_ready_timeout = 7200 # seconds (2h) — copying to 8 regions can be slow
 
   image_copy_regions = [
-    "ap-southeast-1",  # Singapore
-    "ap-southeast-3",  # Malaysia (Kuala Lumpur)
-    "ap-southeast-5",  # Indonesia (Jakarta)
-    "ap-southeast-6",  # Philippines (Manila)
-    "ap-southeast-7",  # Thailand (Bangkok)
-    "ap-northeast-1",  # Japan (Tokyo)
-    "ap-northeast-2",  # South Korea (Seoul)
-    "cn-hongkong",     # Hong Kong
+    "ap-southeast-1", # Singapore
+    "ap-southeast-3", # Malaysia (Kuala Lumpur)
+    "ap-southeast-5", # Indonesia (Jakarta)
+    "ap-southeast-6", # Philippines (Manila)
+    "ap-southeast-7", # Thailand (Bangkok)
+    "ap-northeast-1", # Japan (Tokyo)
+    "ap-northeast-2", # South Korea (Seoul)
+    "cn-hongkong",    # Hong Kong
   ]
   image_copy_names = [
-    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Singapore
-    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Malaysia
-    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Indonesia
-    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Philippines
-    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Thailand
-    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Japan
-    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # South Korea
-    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Hong Kong
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}", # Singapore
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}", # Malaysia
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}", # Indonesia
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}", # Philippines
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}", # Thailand
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}", # Japan
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}", # South Korea
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}", # Hong Kong
   ]
+}
+
+# QEMU source — Gcore has no Packer plugin, so we build a generic qcow2 here and
+# import it into each Gcore region via deploy/packer/gcore-publish.sh (there is
+# no cross-region copy API). Boots the stock Ubuntu 24.04 cloud image (which
+# ships the OpenStack cloud-init datasource Gcore uses at first boot), runs the
+# SAME shared provisioners as every other builder, then generalizes the disk
+# (see the qemu-only "generalize" provisioner in the build block below).
+source "qemu" "lantern-box-gcore" {
+  iso_url      = "https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img"
+  iso_checksum = "file:https://cloud-images.ubuntu.com/releases/noble/release/SHA256SUMS"
+  disk_image   = true
+  disk_size    = "10G"
+  format       = "qcow2"
+  accelerator  = "kvm"
+  cpus         = 2
+  memory       = 2048
+  headless     = true
+
+  # NoCloud seed: set the ubuntu user's password so Packer can SSH in. The
+  # ubuntu user has passwordless sudo (same as the OCI sources), so the shared
+  # `sudo sh -c` provisioners work unchanged.
+  cd_label = "cidata"
+  cd_content = {
+    "meta-data" = ""
+    "user-data" = <<-EOF
+      #cloud-config
+      ssh_pwauth: true
+      password: ${var.qemu_ssh_password}
+      chpasswd:
+        expire: false
+    EOF
+  }
+
+  ssh_username           = "ubuntu"
+  ssh_password           = var.qemu_ssh_password
+  ssh_timeout            = "20m"
+  ssh_handshake_attempts = 100
+
+  shutdown_command = "echo '${var.qemu_ssh_password}' | sudo -S shutdown -P now"
+  vm_name          = "lantern-box-${var.lantern_box_version}-amd64.qcow2"
+  output_directory = "output-gcore"
 }
 
 # ---------- Build ----------
@@ -1026,6 +1072,7 @@ build {
     "source.oracle-oci.lantern-box-bog",
     "source.oracle-oci.lantern-box-vap",
     "source.alicloud-ecs.lantern-box",
+    "source.qemu.lantern-box-gcore",
   ]
 
   # Ensure datacap placeholder files exist so the file provisioner never fails.
@@ -1040,13 +1087,13 @@ build {
   # Upload the datacap binary for this arch.
   # OCI sources target arm64; Linode/Alicloud target amd64.
   provisioner "file" {
-    only        = ["linode.lantern-box", "alicloud-ecs.lantern-box"]
+    only        = ["linode.lantern-box", "alicloud-ecs.lantern-box", "qemu.lantern-box-gcore"]
     source      = "/tmp/datacap-amd64"
     destination = "/tmp/datacap"
   }
 
   provisioner "file" {
-    except      = ["linode.lantern-box", "alicloud-ecs.lantern-box"]
+    except      = ["linode.lantern-box", "alicloud-ecs.lantern-box", "qemu.lantern-box-gcore"]
     source      = "/tmp/datacap-arm64"
     destination = "/tmp/datacap"
   }
@@ -1093,6 +1140,22 @@ build {
       "rm -f /root/.bash_history /home/*/.bash_history",
       "passwd -l root",
       "sed -i 's/^PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config",
+    ]
+  }
+
+  # Gcore-only: generalize the raw qcow2 so it boots fresh in every region. The
+  # managed builders (Linode/OCI/Alicloud) do this inside their plugins; for a
+  # raw disk import we must sysprep it ourselves. This changes no lantern-box
+  # payload — only per-instance identity that must be regenerated on first boot.
+  provisioner "shell" {
+    only            = ["qemu.lantern-box-gcore"]
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    inline = [
+      "cloud-init clean --logs --seed",
+      "truncate -s 0 /etc/machine-id",
+      "rm -f /var/lib/dbus/machine-id",
+      "rm -f /etc/ssh/ssh_host_*",
+      "passwd -l ubuntu",
     ]
   }
 

--- a/deploy/packer/lantern-box.pkr.hcl
+++ b/deploy/packer/lantern-box.pkr.hcl
@@ -1008,7 +1008,7 @@ source "qemu" "lantern-box-gcore" {
     "user-data" = <<-EOF
       #cloud-config
       ssh_pwauth: true
-      password: ${var.qemu_ssh_password}
+      password: "${var.qemu_ssh_password}"
       chpasswd:
         expire: false
     EOF

--- a/deploy/packer/lantern-box.pkr.hcl
+++ b/deploy/packer/lantern-box.pkr.hcl
@@ -1155,6 +1155,14 @@ build {
       "truncate -s 0 /etc/machine-id",
       "rm -f /var/lib/dbus/machine-id",
       "rm -f /etc/ssh/ssh_host_*",
+      # Remove the build-only SSH password-auth drop-in: cloud-init wrote it
+      # because the NoCloud build seed set `ssh_pwauth: true` (needed so Packer
+      # could SSH into the build VM with a password). provision.sh's
+      # 01-lantern-harden.conf (PasswordAuthentication no) is the authoritative
+      # hardening and sorts ahead of 50-, so password auth is already off — but
+      # dropping this leaves no contradictory `PasswordAuthentication yes` in the
+      # shipped image rather than relying on drop-in ordering.
+      "rm -f /etc/ssh/sshd_config.d/50-cloud-init.conf",
       "passwd -l ubuntu",
     ]
   }

--- a/deploy/packer/lantern-box.pkr.hcl
+++ b/deploy/packer/lantern-box.pkr.hcl
@@ -983,11 +983,10 @@ source "alicloud-ecs" "lantern-box" {
   ]
 }
 
-# QEMU source — Gcore has no Packer plugin, so build a generic qcow2 here and
-# import it per region via deploy/packer/gcore-publish.sh (no cross-region copy
-# API). Boots the stock Ubuntu 24.04 cloud image, which ships the OpenStack
-# cloud-init datasource Gcore uses at first boot, runs the SAME provisioners as
-# every other builder, then generalizes the disk (see "generalize" below).
+# QEMU source — Gcore has no Packer plugin and no cross-region copy API, so build a
+# generic qcow2 here and import it per region via gcore-publish.sh. Boots the stock
+# Ubuntu 24.04 cloud image for the OpenStack cloud-init datasource Gcore uses, runs the
+# SAME provisioners as every other builder, then generalizes the disk (see below).
 source "qemu" "lantern-box-gcore" {
   iso_url      = "https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img"
   iso_checksum = "file:https://cloud-images.ubuntu.com/releases/noble/release/SHA256SUMS"
@@ -999,9 +998,8 @@ source "qemu" "lantern-box-gcore" {
   memory       = 2048
   headless     = true
 
-  # NoCloud seed: set the ubuntu user's password so Packer can SSH in. That user
-  # has passwordless sudo (as on OCI), so the shared `sudo sh -c` provisioners
-  # work unchanged.
+  # NoCloud seed: set the ubuntu user's password so Packer can SSH in. That user has
+  # passwordless sudo (as on OCI), so the shared `sudo sh -c` provisioners work unchanged.
   cd_label = "cidata"
   cd_content = {
     "meta-data" = ""
@@ -1142,10 +1140,9 @@ build {
     ]
   }
 
-  # Gcore-only: generalize the raw qcow2 so it boots fresh in every region. The
-  # managed builders do this inside their plugins; a raw disk import has to
-  # sysprep itself. Touches no lantern-box payload — only per-instance identity
-  # that must be regenerated on first boot.
+  # Gcore-only: generalize the raw qcow2 so it boots fresh in every region — the managed
+  # builders do this in their plugins, a raw disk import must sysprep itself. Touches no
+  # lantern-box payload, only per-instance identity.
   provisioner "shell" {
     only            = ["qemu.lantern-box-gcore"]
     execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
@@ -1154,10 +1151,9 @@ build {
       "truncate -s 0 /etc/machine-id",
       "rm -f /var/lib/dbus/machine-id",
       "rm -f /etc/ssh/ssh_host_*",
-      # Drop the build-only SSH password-auth file cloud-init wrote for the seed's
-      # `ssh_pwauth: true`. provision.sh's 01-lantern-harden.conf already wins on
-      # drop-in ordering, but removing this leaves no contradictory
-      # `PasswordAuthentication yes` in the shipped image at all.
+      # Drop the password-auth file cloud-init wrote for the seed's `ssh_pwauth: true`.
+      # 01-lantern-harden.conf already wins on drop-in ordering; removing this leaves no
+      # contradictory `PasswordAuthentication yes` in the image at all.
       "rm -f /etc/ssh/sshd_config.d/50-cloud-init.conf",
       "passwd -l ubuntu",
     ]

--- a/deploy/packer/lantern-box.pkr.hcl
+++ b/deploy/packer/lantern-box.pkr.hcl
@@ -983,12 +983,11 @@ source "alicloud-ecs" "lantern-box" {
   ]
 }
 
-# QEMU source — Gcore has no Packer plugin, so we build a generic qcow2 here and
-# import it into each Gcore region via deploy/packer/gcore-publish.sh (there is
-# no cross-region copy API). Boots the stock Ubuntu 24.04 cloud image (which
-# ships the OpenStack cloud-init datasource Gcore uses at first boot), runs the
-# SAME shared provisioners as every other builder, then generalizes the disk
-# (see the qemu-only "generalize" provisioner in the build block below).
+# QEMU source — Gcore has no Packer plugin, so build a generic qcow2 here and
+# import it per region via deploy/packer/gcore-publish.sh (no cross-region copy
+# API). Boots the stock Ubuntu 24.04 cloud image, which ships the OpenStack
+# cloud-init datasource Gcore uses at first boot, runs the SAME provisioners as
+# every other builder, then generalizes the disk (see "generalize" below).
 source "qemu" "lantern-box-gcore" {
   iso_url      = "https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img"
   iso_checksum = "file:https://cloud-images.ubuntu.com/releases/noble/release/SHA256SUMS"
@@ -1000,9 +999,9 @@ source "qemu" "lantern-box-gcore" {
   memory       = 2048
   headless     = true
 
-  # NoCloud seed: set the ubuntu user's password so Packer can SSH in. The
-  # ubuntu user has passwordless sudo (same as the OCI sources), so the shared
-  # `sudo sh -c` provisioners work unchanged.
+  # NoCloud seed: set the ubuntu user's password so Packer can SSH in. That user
+  # has passwordless sudo (as on OCI), so the shared `sudo sh -c` provisioners
+  # work unchanged.
   cd_label = "cidata"
   cd_content = {
     "meta-data" = ""
@@ -1144,9 +1143,9 @@ build {
   }
 
   # Gcore-only: generalize the raw qcow2 so it boots fresh in every region. The
-  # managed builders (Linode/OCI/Alicloud) do this inside their plugins; for a
-  # raw disk import we must sysprep it ourselves. This changes no lantern-box
-  # payload — only per-instance identity that must be regenerated on first boot.
+  # managed builders do this inside their plugins; a raw disk import has to
+  # sysprep itself. Touches no lantern-box payload — only per-instance identity
+  # that must be regenerated on first boot.
   provisioner "shell" {
     only            = ["qemu.lantern-box-gcore"]
     execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
@@ -1155,13 +1154,10 @@ build {
       "truncate -s 0 /etc/machine-id",
       "rm -f /var/lib/dbus/machine-id",
       "rm -f /etc/ssh/ssh_host_*",
-      # Remove the build-only SSH password-auth drop-in: cloud-init wrote it
-      # because the NoCloud build seed set `ssh_pwauth: true` (needed so Packer
-      # could SSH into the build VM with a password). provision.sh's
-      # 01-lantern-harden.conf (PasswordAuthentication no) is the authoritative
-      # hardening and sorts ahead of 50-, so password auth is already off — but
-      # dropping this leaves no contradictory `PasswordAuthentication yes` in the
-      # shipped image rather than relying on drop-in ordering.
+      # Drop the build-only SSH password-auth file cloud-init wrote for the seed's
+      # `ssh_pwauth: true`. provision.sh's 01-lantern-harden.conf already wins on
+      # drop-in ordering, but removing this leaves no contradictory
+      # `PasswordAuthentication yes` in the shipped image at all.
       "rm -f /etc/ssh/sshd_config.d/50-cloud-init.conf",
       "passwd -l ubuntu",
     ]

--- a/deploy/packer/variables.pkr.hcl
+++ b/deploy/packer/variables.pkr.hcl
@@ -35,7 +35,10 @@ variable "alicloud_ssh_password" {
 
 # QEMU (gcore) — build-time password so Packer can SSH into the cloud image.
 # Locked again in the generalize step; the real key is injected by cloud-init at
-# first boot.
+# first boot. NOT a stored secret: the build job mints a fresh random value per
+# run, because the account's hash ships in the qcow2 that gcore imports over a
+# brief public URL. Keep it hex/alphanumeric — it is interpolated into the
+# cloud-init YAML and into a single-quoted shell string.
 variable "qemu_ssh_password" {
   type      = string
   sensitive = true

--- a/deploy/packer/variables.pkr.hcl
+++ b/deploy/packer/variables.pkr.hcl
@@ -33,9 +33,9 @@ variable "alicloud_ssh_password" {
   default   = env("ALICLOUD_SSH_PASSWORD")
 }
 
-# QEMU (gcore) — build-time password for the ubuntu user so Packer can SSH into
-# the cloud image during the build. Locked again in the generalize step; the
-# real SSH key is injected by cloud-init at first boot on gcore.
+# QEMU (gcore) — build-time password so Packer can SSH into the cloud image.
+# Locked again in the generalize step; the real key is injected by cloud-init at
+# first boot.
 variable "qemu_ssh_password" {
   type      = string
   sensitive = true

--- a/deploy/packer/variables.pkr.hcl
+++ b/deploy/packer/variables.pkr.hcl
@@ -33,6 +33,15 @@ variable "alicloud_ssh_password" {
   default   = env("ALICLOUD_SSH_PASSWORD")
 }
 
+# QEMU (gcore) — build-time password for the ubuntu user so Packer can SSH into
+# the cloud image during the build. Locked again in the generalize step; the
+# real SSH key is injected by cloud-init at first boot on gcore.
+variable "qemu_ssh_password" {
+  type      = string
+  sensitive = true
+  default   = env("QEMU_SSH_PASSWORD")
+}
+
 # OCI shared variables (same across all regions)
 variable "oci_tenancy_ocid" {
   type      = string

--- a/deploy/packer/variables.pkr.hcl
+++ b/deploy/packer/variables.pkr.hcl
@@ -33,12 +33,10 @@ variable "alicloud_ssh_password" {
   default   = env("ALICLOUD_SSH_PASSWORD")
 }
 
-# QEMU (gcore) — build-time password so Packer can SSH into the cloud image.
-# Locked again in the generalize step; the real key is injected by cloud-init at
-# first boot. NOT a stored secret: the build job mints a fresh random value per
-# run, because the account's hash ships in the qcow2 that gcore imports over a
-# brief public URL. Keep it hex/alphanumeric — it is interpolated into the
-# cloud-init YAML and into a single-quoted shell string.
+# QEMU (gcore) — build-time password so Packer can SSH into the cloud image; locked again
+# in generalize, and cloud-init injects the real key at first boot. NOT a stored secret:
+# the job mints a fresh value per run, since the hash ships in a briefly-public qcow2.
+# Keep it hex/alphanumeric — it is interpolated into YAML and a quoted shell string.
 variable "qemu_ssh_password" {
   type      = string
   sensitive = true


### PR DESCRIPTION
Adds a `gcore` builder so lantern-cloud's gcore provider finds a `lantern-box` boot image (fixes `no gcore image matching prefix "lantern-box-" in region 180`).

This has already been run successfully. 

gcore has no Packer plugin and no cross-region copy API, so one QEMU-built qcow2 — same provisioners as every other builder — is staged in gcore object storage and imported into **29 regions**; prune keeps the 3 newest per region.

- **Staging** — gcore ingests only by URL via an unauthenticated HEAD+GET, so the qcow2 is briefly anonymous-read in a throwaway randomly-named bucket with a per-run access key. Names masked; `always()` teardown ordered revoke → empty → delete; 1-day expiry rule and a next-run sweep as backstops; "could not tell" always fails loudly.
- **Imports** — all started, then polled together with one sleep per round, spaced by `IMPORT_STAGGER_SECS` (30). gcore reaps a task not *started* within 10min of its own `created_on`, and submitting ~30 at once gave them a shared deadline it could not meet.

`GCORE_API_KEY` (needs object-storage permission) and `GCORE_PROJECT_ID` are already set; nothing to pre-create. 37 offline tests. Does not build on the PR — verify with:

```
gh workflow run build-images.yaml --ref add-gcore-image-build -f builders=gcore -f gcore_regions=180
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
