### PR TITLE
fix(metrics): make Conn/PacketConn Close idempotent

### DIFF
--- a/tracker/metrics/close_idempotency_test.go
+++ b/tracker/metrics/close_idempotency_test.go
@@ -1,0 +1,84 @@
+package metrics
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/sagernet/sing-box/adapter"
+	N "github.com/sagernet/sing/common/network"
+	sdkotel "go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/getlantern/geo"
+	"github.com/stretchr/testify/require"
+)
+
+// Close must be idempotent: sing-box closes a routed conn up to 3x on
+// non-graceful teardown, and redundant closes must not drift the gauge.
+func TestConnCloseIdempotent(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Conn", func(t *testing.T) {
+		reader := newMeter(t)
+		tr := NewTracker(ctx)
+		defer tr.Close()
+		_, server := net.Pipe()
+		assertCloseIdempotent(t, reader,
+			tr.RoutedConnection(ctx, server, adapter.InboundContext{}, nil, nil)) // gauge +1
+	})
+
+	t.Run("PacketConn", func(t *testing.T) {
+		reader := newMeter(t)
+		tr := NewTracker(ctx)
+		defer tr.Close()
+		assertCloseIdempotent(t, reader,
+			tr.RoutedPacketConnection(ctx, fakePacketConn{}, adapter.InboundContext{}, nil, nil)) // gauge +1
+	})
+}
+
+// assertCloseIdempotent closes conn 3x and asserts the gauge returns to 0.
+func assertCloseIdempotent(t *testing.T, reader *sdkmetric.ManualReader, conn io.Closer) {
+	t.Helper()
+	for range 3 {
+		require.NoError(t, conn.Close()) // gauge -1 on the first call only
+	}
+	require.Equal(t, int64(0), activeConns(t, reader),
+		"active-connection gauge must return to 0 no matter how many times Close is called")
+}
+
+// fakePacketConn is an N.PacketConn whose Close is a no-op (only Close is used).
+type fakePacketConn struct{ N.PacketConn }
+
+func (fakePacketConn) Close() error { return nil }
+
+func newMeter(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	sdkotel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	SetupMetricsManager(geo.NoLookup{}, "")
+	return reader
+}
+
+// activeConns returns the summed value of the sing.connections up/down counter.
+func activeConns(t *testing.T, r *sdkmetric.ManualReader) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, r.Collect(context.Background(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "sing.connections" {
+				continue
+			}
+			var total int64
+			for _, dp := range m.Data.(metricdata.Sum[int64]).DataPoints {
+				total += dp.Value
+			}
+			return total
+		}
+	}
+	t.Fatal("sing.connections metric not found")
+	return 0
+}

--- a/tracker/metrics/close_idempotency_test.go
+++ b/tracker/metrics/close_idempotency_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"io"
 	"net"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/sagernet/sing-box/adapter"
 	N "github.com/sagernet/sing/common/network"
@@ -17,7 +19,7 @@ import (
 )
 
 // Close must be idempotent: sing-box closes a routed conn up to 3x on
-// non-graceful teardown, and redundant closes must not drift the gauge.
+// non-graceful teardown, and redundant closes must not drift the metrics.
 func TestConnCloseIdempotent(t *testing.T) {
 	ctx := context.Background()
 
@@ -26,34 +28,60 @@ func TestConnCloseIdempotent(t *testing.T) {
 		tr := NewTracker(ctx)
 		defer tr.Close()
 		_, server := net.Pipe()
-		assertCloseIdempotent(t, reader,
-			tr.RoutedConnection(ctx, server, adapter.InboundContext{}, nil, nil)) // gauge +1
+		conn := tr.RoutedConnection(ctx, server, adapter.InboundContext{}, nil, nil).(*Conn)
+		primeGoodput(&conn.rxBytes, &conn.startTime)
+		assertCloseIdempotent(t, reader, conn)
 	})
 
 	t.Run("PacketConn", func(t *testing.T) {
 		reader := newMeter(t)
 		tr := NewTracker(ctx)
 		defer tr.Close()
-		assertCloseIdempotent(t, reader,
-			tr.RoutedPacketConnection(ctx, fakePacketConn{}, adapter.InboundContext{}, nil, nil)) // gauge +1
+		conn := tr.RoutedPacketConnection(ctx, fakePacketConn{}, adapter.InboundContext{}, nil, nil).(*PacketConn)
+		primeGoodput(&conn.rxBytes, &conn.startTime)
+		assertCloseIdempotent(t, reader, conn)
 	})
 }
 
-// assertCloseIdempotent closes conn 3x and asserts the gauge returns to 0.
+// assertCloseIdempotent closes conn 3x and asserts every metric the close guard
+// covers lands exactly once.
 func assertCloseIdempotent(t *testing.T, reader *sdkmetric.ManualReader, conn io.Closer) {
 	t.Helper()
-	for range 3 {
-		require.NoError(t, conn.Close()) // gauge -1 on the first call only
+	require.Equal(t, int64(1), activeConns(t, reader), "gauge must count the open conn")
+
+	require.NoError(t, conn.Close())
+	assertClosedOnce(t, reader)
+
+	for range 2 {
+		require.NoError(t, conn.Close())
 	}
-	require.Equal(t, int64(0), activeConns(t, reader),
-		"active-connection gauge must return to 0 no matter how many times Close is called")
+	assertClosedOnce(t, reader)
 }
 
-// fakePacketConn is an N.PacketConn whose Close is a no-op (only Close is used).
+func assertClosedOnce(t *testing.T, reader *sdkmetric.ManualReader) {
+	t.Helper()
+	require.Equal(t, int64(0), activeConns(t, reader),
+		"active-connection gauge must return to 0 no matter how many times Close is called")
+	require.Equal(t, uint64(1), sampleCount(t, reader, "sing.connection_duration"),
+		"duration must be recorded once no matter how many times Close is called")
+	require.Equal(t, uint64(1), sampleCount(t, reader, "proxy.session.goodput"),
+		"goodput must be recorded once no matter how many times Close is called")
+}
+
+// primeGoodput backdates a session that moved bytes, since recordGoodput drops
+// zero-byte and zero-duration sessions.
+func primeGoodput(rxBytes *atomic.Int64, startTime *time.Time) {
+	rxBytes.Store(1024)
+	*startTime = time.Now().Add(-time.Second)
+}
+
+// fakePacketConn is an N.PacketConn that only implements Close.
 type fakePacketConn struct{ N.PacketConn }
 
 func (fakePacketConn) Close() error { return nil }
 
+// newMeter points the process-wide provider at an isolated reader and rebuilds
+// the package's instruments against it, so tests here must not run in parallel.
 func newMeter(t *testing.T) *sdkmetric.ManualReader {
 	t.Helper()
 	reader := sdkmetric.NewManualReader()
@@ -65,20 +93,44 @@ func newMeter(t *testing.T) *sdkmetric.ManualReader {
 // activeConns returns the summed value of the sing.connections up/down counter.
 func activeConns(t *testing.T, r *sdkmetric.ManualReader) int64 {
 	t.Helper()
+	var total int64
+	for _, dp := range collect(t, r, "sing.connections").(metricdata.Sum[int64]).DataPoints {
+		total += dp.Value
+	}
+	return total
+}
+
+// sampleCount returns how many samples the named histogram holds.
+func sampleCount(t *testing.T, r *sdkmetric.ManualReader, name string) uint64 {
+	t.Helper()
+	var total uint64
+	switch data := collect(t, r, name).(type) {
+	case metricdata.Histogram[int64]:
+		for _, dp := range data.DataPoints {
+			total += dp.Count
+		}
+	case metricdata.Histogram[float64]:
+		for _, dp := range data.DataPoints {
+			total += dp.Count
+		}
+	default:
+		t.Fatalf("%s is not a histogram: %T", name, data)
+	}
+	return total
+}
+
+// collect gathers the named metric, failing the test if it was never recorded.
+func collect(t *testing.T, r *sdkmetric.ManualReader, name string) metricdata.Aggregation {
+	t.Helper()
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, r.Collect(context.Background(), &rm))
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
-			if m.Name != "sing.connections" {
-				continue
+			if m.Name == name {
+				return m.Data
 			}
-			var total int64
-			for _, dp := range m.Data.(metricdata.Sum[int64]).DataPoints {
-				total += dp.Value
-			}
-			return total
 		}
 	}
-	t.Fatal("sing.connections metric not found")
-	return 0
+	t.Fatalf("%s metric not found", name)
+	return nil
 }

--- a/tracker/metrics/conn.go
+++ b/tracker/metrics/conn.go
@@ -13,6 +13,7 @@ type Conn struct {
 	tracker   *MetricsTracker
 	startTime time.Time
 	rxBytes   atomic.Int64
+	closed    atomic.Bool
 }
 
 // NewConn creates a new Conn instance.
@@ -44,11 +45,15 @@ func (c *Conn) Write(b []byte) (n int, err error) {
 	return
 }
 
-// Close overrides net.Conn's Close method to track connection duration.
+// Close records the session's metrics exactly once, then forwards the close.
+// sing-box closes a routed conn up to 3x on non-graceful teardown; the guard
+// stops the connections gauge and duration/goodput from being counted repeatedly.
 func (c *Conn) Close() error {
-	duration := time.Since(c.startTime).Milliseconds()
-	c.tracker.Leave(duration, c.attrs)
-	c.tracker.recordGoodput(c.rxBytes.Load(), duration, c.attrs)
+	if !c.closed.Swap(true) {
+		duration := time.Since(c.startTime).Milliseconds()
+		c.tracker.Leave(duration, c.attrs)
+		c.tracker.recordGoodput(c.rxBytes.Load(), duration, c.attrs)
+	}
 	return c.Conn.Close()
 }
 

--- a/tracker/metrics/conn.go
+++ b/tracker/metrics/conn.go
@@ -45,9 +45,8 @@ func (c *Conn) Write(b []byte) (n int, err error) {
 	return
 }
 
-// Close records the session's metrics exactly once, then forwards the close.
-// sing-box closes a routed conn up to 3x on non-graceful teardown; the guard
-// stops the connections gauge and duration/goodput from being counted repeatedly.
+// Close records the session's metrics once, then forwards the close: sing-box
+// closes a routed conn up to 3x on non-graceful teardown.
 func (c *Conn) Close() error {
 	if !c.closed.Swap(true) {
 		duration := time.Since(c.startTime).Milliseconds()

--- a/tracker/metrics/packet_conn.go
+++ b/tracker/metrics/packet_conn.go
@@ -16,6 +16,7 @@ type PacketConn struct {
 	tracker   *MetricsTracker
 	startTime time.Time
 	rxBytes   atomic.Int64
+	closed    atomic.Bool
 }
 
 // NewPacketConn creates a new PacketConn instance.
@@ -49,11 +50,14 @@ func (c *PacketConn) WritePacket(buffer *buf.Buffer, destination M.Socksaddr) er
 	return c.PacketConn.WritePacket(buffer, destination)
 }
 
-// Close overrides net.PacketConn's Close method to track connection duration.
+// Close records the session's metrics exactly once, then forwards the close.
+// See Conn.Close.
 func (c *PacketConn) Close() error {
-	duration := time.Since(c.startTime).Milliseconds()
-	c.tracker.Leave(duration, c.attrs)
-	c.tracker.recordGoodput(c.rxBytes.Load(), duration, c.attrs)
+	if !c.closed.Swap(true) {
+		duration := time.Since(c.startTime).Milliseconds()
+		c.tracker.Leave(duration, c.attrs)
+		c.tracker.recordGoodput(c.rxBytes.Load(), duration, c.attrs)
+	}
 	return c.PacketConn.Close()
 }
 

--- a/tracker/metrics/packet_conn.go
+++ b/tracker/metrics/packet_conn.go
@@ -50,8 +50,7 @@ func (c *PacketConn) WritePacket(buffer *buf.Buffer, destination M.Socksaddr) er
 	return c.PacketConn.WritePacket(buffer, destination)
 }
 
-// Close records the session's metrics exactly once, then forwards the close.
-// See Conn.Close.
+// Close mirrors Conn.Close: metrics once, then forward the close.
 func (c *PacketConn) Close() error {
 	if !c.closed.Swap(true) {
 		duration := time.Since(c.startTime).Milliseconds()


### PR DESCRIPTION
- sing-box closes a routed conn up to 3x on non-graceful teardown; guard Leave/goodput so the connections gauge doesn't drift and duration isn't double-counted
- in production this only surfaces for pro users, since datacap's outermost wrapper is already close-guarded and absorbs the repeats for everyone else
- adds a regression test covering Conn and PacketConn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made connection closing idempotent so repeated `Close()` calls no longer double-count session duration, byte transfer, or goodput metrics.
  * Ensured both stream and packet connections keep accurate active-connection and performance statistics when teardown triggers multiple close attempts.

* **Tests**
  * Added tests covering idempotent `Close()` behavior for both stream and packet connections, including verification that metrics counters return to zero and guarded metrics are recorded only once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
