### PR TITLE
fix(tracker): judge the client-info prefix on a stream, not one Read

### DIFF
--- a/tracker/clientcontext/manager.go
+++ b/tracker/clientcontext/manager.go
@@ -160,13 +160,16 @@ func (c *readConn) readInfo() (*ClientInfo, error) {
 	// response read, and the prefix bytes would be forwarded to the destination.
 	n, err := io.ReadAtLeast(c.Conn, buf[:], len(packetPrefix))
 	if n == 0 {
+		// Nothing was read, so there is nothing to pass through. Store and return
+		// the error unchanged: RoutedConnection compares the two to tell a dead
+		// connection from malformed client info, and only logs the latter.
 		c.readErr = err
 		c.n = n
 		return nil, err
 	}
-	// Short of the prefix, or unreadable: not client info. Fall through with the
-	// bytes preserved rather than failing -- this hook is telemetry and must
-	// never tear down a working flow.
+	// Bytes arrived but they are short of the prefix, or the read stopped early.
+	// Treat the flow as ordinary traffic and pass the bytes on rather than
+	// failing it: this hook is telemetry and must not tear down a working flow.
 	if err != nil || !bytes.HasPrefix(buf[:n], []byte(packetPrefix)) {
 		c.reader = io.MultiReader(bytes.NewReader(buf[:n]), c.Conn)
 		return nil, nil

--- a/tracker/clientcontext/manager.go
+++ b/tracker/clientcontext/manager.go
@@ -153,13 +153,21 @@ func (c *readConn) Read(b []byte) (n int, err error) {
 // readInfo reads and decodes client info, then sends an HTTP 200 OK response.
 func (c *readConn) readInfo() (*ClientInfo, error) {
 	var buf [32]byte
-	n, err := c.Conn.Read(buf[:])
-	if err != nil {
+	// Read until the prefix can actually be judged. A single Read may return
+	// fewer bytes than the prefix on a segmented stream -- common under DPI
+	// throttling -- and deciding on that would misread client info as ordinary
+	// traffic: the OK would never be sent, leaving the client blocked on its
+	// response read, and the prefix bytes would be forwarded to the destination.
+	n, err := io.ReadAtLeast(c.Conn, buf[:], len(packetPrefix))
+	if n == 0 {
 		c.readErr = err
 		c.n = n
 		return nil, err
 	}
-	if !bytes.HasPrefix(buf[:n], []byte(packetPrefix)) {
+	// Short of the prefix, or unreadable: not client info. Fall through with the
+	// bytes preserved rather than failing -- this hook is telemetry and must
+	// never tear down a working flow.
+	if err != nil || !bytes.HasPrefix(buf[:n], []byte(packetPrefix)) {
 		c.reader = io.MultiReader(bytes.NewReader(buf[:n]), c.Conn)
 		return nil, nil
 	}

--- a/tracker/clientcontext/manager_readinfo_test.go
+++ b/tracker/clientcontext/manager_readinfo_test.go
@@ -1,0 +1,108 @@
+package clientcontext
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The server decides whether a flow carries client info by prefix-matching what
+// it has read so far. TCP is a stream, so the prefix can arrive split across
+// reads -- routine under DPI throttling. Judging one Read's worth would classify
+// client info as ordinary traffic: no OK is ever sent, the client blocks on its
+// response read, and the prefix bytes are forwarded on to the destination.
+func TestReadInfoRecognizesSplitPrefix(t *testing.T) {
+	for _, chunk := range []int{1, 5, 10, 11, 32} {
+		t.Run(fmt.Sprintf("%d-byte-chunks", chunk), func(t *testing.T) {
+			client, server := net.Pipe()
+			defer client.Close()
+			defer server.Close()
+
+			payload, err := json.Marshal(ClientInfo{DeviceID: "test-device", Platform: "test"})
+			require.NoError(t, err)
+			packet := append([]byte(packetPrefix), payload...)
+
+			// net.Pipe is unbuffered, so each Write lands as its own Read.
+			go func() {
+				for off := 0; off < len(packet); off += chunk {
+					end := min(off+chunk, len(packet))
+					if _, err := client.Write(packet[off:end]); err != nil {
+						return
+					}
+				}
+				io.Copy(io.Discard, client) // drain the OK
+			}()
+
+			c := &readConn{Conn: server, reader: server, mgr: &Manager{}}
+
+			done := make(chan struct{})
+			var info *ClientInfo
+			var readErr error
+			go func() {
+				info, readErr = c.readInfo()
+				close(done)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("readInfo blocked")
+			}
+
+			require.NoError(t, readErr)
+			require.NotNil(t, info, "client info must be recognized when the prefix arrives in %d-byte chunks", chunk)
+			assert.Equal(t, "test-device", info.DeviceID)
+		})
+	}
+}
+
+// A peer whose whole first message is shorter than the prefix is not sending
+// client info. Those bytes must still reach the destination unaltered, and the
+// flow must not be failed.
+func TestReadInfoPassesThroughShortNonClientInfo(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	go func() {
+		client.Write([]byte("hi"))
+		client.Close()
+	}()
+
+	c := &readConn{Conn: server, reader: server, mgr: &Manager{}}
+	info, err := c.readInfo()
+	require.NoError(t, err, "a short non-client-info opening must not fail the flow")
+	require.Nil(t, info)
+
+	got, err := io.ReadAll(c)
+	require.NoError(t, err)
+	assert.Equal(t, "hi", string(got), "the bytes already consumed must be replayed to the destination")
+}
+
+// Ordinary traffic longer than the prefix keeps flowing untouched.
+func TestReadInfoPassesThroughNonClientInfo(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	const payload = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
+	go func() {
+		client.Write([]byte(payload))
+		client.Close()
+	}()
+
+	c := &readConn{Conn: server, reader: server, mgr: &Manager{}}
+	info, err := c.readInfo()
+	require.NoError(t, err)
+	require.Nil(t, info)
+
+	got, err := io.ReadAll(c)
+	require.NoError(t, err)
+	assert.Equal(t, payload, string(got))
+}

--- a/tracker/clientcontext/manager_readinfo_test.go
+++ b/tracker/clientcontext/manager_readinfo_test.go
@@ -106,3 +106,21 @@ func TestReadInfoPassesThroughNonClientInfo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, payload, string(got))
 }
+
+// A peer that closes without sending anything leaves nothing to pass through.
+// The read error is returned and stored unchanged, so RoutedConnection's
+// `err != c.readErr` check treats it as a dead connection rather than
+// reporting it as a client-info failure.
+func TestReadInfoPropagatesErrorWhenNothingWasRead(t *testing.T) {
+	client, server := net.Pipe()
+	defer server.Close()
+	client.Close()
+
+	c := &readConn{Conn: server, reader: server, mgr: &Manager{}}
+	info, err := c.readInfo()
+
+	require.Error(t, err)
+	require.Nil(t, info)
+	assert.Equal(t, err, c.readErr, "the caller distinguishes a dead conn from bad client info by identity")
+	assert.Zero(t, c.n)
+}


### PR DESCRIPTION
Answers the open question behind getlantern/engineering#3718, #3772 and the current RU reports: **why the server never responds to client info.**

## The bug

`readConn.readInfo` decided whether a flow carried client info from a **single** `Conn.Read` into a 32-byte buffer:

```go
var buf [32]byte
n, err := c.Conn.Read(buf[:])          // one read, no minimum
...
if !bytes.HasPrefix(buf[:n], []byte(packetPrefix)) {   // "CLIENTINFO " — 11 bytes
    c.reader = io.MultiReader(bytes.NewReader(buf[:n]), c.Conn)
    return nil, nil                     // silently: ordinary traffic
}
```

TCP is a stream. If those 11 bytes don't all land in the first `Read`, the check fails and the server treats real client info as ordinary traffic. Under DPI throttling — small, fragmented segments — that is not an edge case.

## Two field-visible consequences

**The client hangs.** The server never writes `"OK"`, so the client blocks on its 2-byte response read. Before the client-side deadline shipped in v0.0.106 that meant blocking until the kernel gave up. In RU Android logs (ticket 180956, 438 occurrences over Aug 1–5):

| | |
|---|---|
| median | **954s (~16 min)** |
| p90 | 1026s |
| max | 1964s (~33 min) |
| over 2 min | 312 of 438 |

~954s is essentially the Linux `tcp_retries2=15` ceiling, i.e. no application deadline at all.

**The destination gets garbage.** The fall-through replays the consumed bytes upstream via `io.MultiReader`, so the real destination receives `CLIENTINFO {"deviceID":…}` where it expected a TLS ClientHello — and resets. That matches the 156 `software caused connection abort` errors in the same logs.

## The fix

Read until the prefix can actually be judged. Anything shorter, or a read error, falls through with the bytes preserved rather than failing — this hook is telemetry and must never tear down a working flow, which is also what #3718 argues for.

## Why the UDP path is fine

Datagram boundaries keep the prefix intact, so `readPacketConn.readInfo` isn't affected. The field logs agree: every hang and reset is on `read tcp`; the only UDP failures are a different mode (`connection refused`).

## Verification

`TestReadInfoRecognizesSplitPrefix` delivers the packet in 1, 5, 10, 11 and 32-byte chunks. With the one-shot read restored, exactly the split cases fail:

```
--- FAIL: TestReadInfoRecognizesSplitPrefix/1-byte-chunks
--- FAIL: TestReadInfoRecognizesSplitPrefix/5-byte-chunks
--- FAIL: TestReadInfoRecognizesSplitPrefix/10-byte-chunks
    (11- and 32-byte chunks pass either way — the prefix lands whole)
```

Two more tests cover the pass-through contract: a peer whose entire opening is shorter than the prefix, and ordinary HTTP traffic. Both must reach the destination byte-identical and must not fail the flow.

Full `./...` suite passes.

## Note on rollout

This is the **server** half. Bumping lantern-box in the client (v0.0.104 → v0.0.106, which both v9.1.17-beta and v9.1.18-beta still miss) converts the 16-minute hang into a 10s failure and stops one bad flow holding a healthy-pool slot — worth shipping on its own — but it doesn't make the exchange succeed. This change has to reach the **proxy fleet** for these connections to work.

The client half already reads its response with `io.ReadFull` and has `TestStreamSendInfoReadsSplitOK`; this is the same treatment for the server half, which had gone untouched since #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVgb2MDpZ4wpH6fywKC2hE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling when client information arrives in multiple parts.
  * Preserved short or unrecognized connection data instead of rejecting it.
  * Ensured valid traffic continues without unnecessary timeouts.

* **Tests**
  * Added coverage for split client-information prefixes, short messages, and ordinary non-client traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->