### PR TITLE
unbounded: stop broflake workers before closing the QUIC layer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ replace github.com/refraction-networking/water => github.com/getlantern/water v0
 require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52
-	github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86
+	github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952
 	github.com/getlantern/geo v0.0.0-20241129152027-2fc88c10f91e
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395
 	github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/gaukas/wazerofs v0.1.0 h1:wIkW1bAxSnpaaVkQ5LOb1tm1BXdVap3eKjJpVWIqt2E
 github.com/gaukas/wazerofs v0.1.0/go.mod h1:+JECB9Fwt0taPqSgHckG9lmT3tcoVK+9VJozTsq9UlI=
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 h1:w2/RqYPw7PbTYfUMS2aToD5DMKLBnQed+fkTEYTKAqQ=
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52/go.mod h1:PrNR8tMXO26YNs8K9653XCUH7u2Kv4OdfFC3Ke1GsX0=
-github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86 h1:r7j54Ol1wak59OY0SK2Fw5lOI3YvrAEDW3QAQEj12mA=
-github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86/go.mod h1:bIxM6xon/ADgprn6tZXYdXGrUIMCzq6u8zO9rET50IE=
+github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952 h1:nD8iJ4IpaTq/09PhoOzmaGTwatOxsR41neSmbCY6RS8=
+github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952/go.mod h1:1+1kCIg9Zj+2CgN+vl868AlAZVUItuN4wLhFur5QakA=
 github.com/getlantern/context v0.0.0-20190109183933-c447772a6520/go.mod h1:L+mq6/vvYHKjCX2oez0CgEAJmbq1fbb/oNJIWQkBybY=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=

--- a/protocol/unbounded/outbound.go
+++ b/protocol/unbounded/outbound.go
@@ -227,8 +227,7 @@ func (o *Outbound) Close() error {
 	// Stop the broflake workers before closing the QUIC layer they drain into. A
 	// worker blocked mid-send cannot be cancelled until that send completes, so
 	// removing the drain first risks stranding one — which blocks the engine's
-	// teardown and retains its whole stack. broflake now guards its control-plane
-	// sends, so this ordering is defense in depth for any future blocking send.
+	// teardown and retains its whole stack.
 	if o.ui != nil {
 		o.ui.Stop()
 	}

--- a/protocol/unbounded/outbound.go
+++ b/protocol/unbounded/outbound.go
@@ -224,11 +224,16 @@ func (o *Outbound) Start(stage adapter.StartStage) error {
 }
 
 func (o *Outbound) Close() error {
-	if o.ql != nil {
-		o.ql.Close()
-	}
+	// Stop the broflake workers before closing the QUIC layer they drain into. A
+	// worker blocked mid-send cannot be cancelled until that send completes, so
+	// removing the drain first risks stranding one — which blocks the engine's
+	// teardown and retains its whole stack. broflake now guards its control-plane
+	// sends, so this ordering is defense in depth for any future blocking send.
 	if o.ui != nil {
 		o.ui.Stop()
+	}
+	if o.ql != nil {
+		o.ql.Close()
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

`Outbound.Close()` tore down the QUIC layer first, then stopped the broflake engine:

```go
if o.ql != nil { o.ql.Close() }   // removes the drain
if o.ui != nil { o.ui.Stop() }    // then asks the writers to stop
```

That closes the reader while the writers are still running. A broflake worker blocked mid-send on a full `com.tx` buffer cannot be cancelled until that send completes — the FSM only checks `ctx.Done()` **between** states — so it strands, its `wg.Done()` never runs, and `BroflakeEngine.stop()`, which waits on that `WaitGroup` before cancelling the engine ctx, never releases the bus, the routers, or any other worker. Every re-create of this outbound then accumulates a full WebRTC/ICE stack.

Seen downstream in Freshdesk 181174 (Windows 9.1.18, CN): this outbound re-created 82 times in 13h at a flat ~6/hr, CPU climbing to 80% with disk at 0 MB/s and network at 0 Mbps — the signature of a per-event leak rather than a spin.

## Changes

**1. Stop the writers, then close the reader.** One reordering in `Close()`, no behavior change on the happy path.

**2. Bump broflake** to `v0.0.0-20260810172605-bef5e5234952` (getlantern/unbounded#412), which fixes the strand at its source:

- control-plane sends now abandon on cancellation (`sendCtx`, checking `ctx.Err()` first so a cancelled ctx wins deterministically over an available buffer)
- `NewWorkerFSM` initializes `ctx`/`cancel`, so `Stop()` before `Start()` no longer calls a nil `CancelFunc` — it previously **panicked**
- `BroflakeEngine.stop()` bounds its wait then cancels regardless, so any future unguarded blocking send degrades to a bounded leak instead of a permanent one

The two halves are complementary, and the bump is what makes the reordering *effective* rather than merely defensive: before it, a worker blocked mid-send stranded regardless of teardown order, because nothing could cancel it. After it, the ordering additionally keeps `Close()` correct if a future blocking send lands unguarded, and lets in-flight control messages land while the drain is still up.

`go mod tidy` pulled in no other changes — the diff is one line in `go.mod` and two in `go.sum`.

## Notes on what this deliberately does *not* change

- **`o.broflakeConn` is still not closed.** `BroflakeConn.Close()` is a no-op (`return nil`); it exists only to satisfy `net.PacketConn`. Calling it would do nothing.
- **The `Close()` comment does not mention broflake's guarded sends**, even though that is now true of the pinned version. Asserting a dependency's internals in a comment goes stale on the next bump in either direction; the rationale stands on its own, and the context lives here and in the commit messages.
- `QUICLayer.Close()` is already idempotent (nil-guarded, and `cancel` is idempotent), so the reorder introduces no double-close hazard.

## Testing

`go build ./...`, `gofmt`, `go vet ./protocol/unbounded/`, and the full `go test ./...` (16 packages, 0 failures) all pass against the bumped dependency. Verified the fetched module actually carries the fix: `sendCtx` present, `NewWorkerFSM` sets ctx/cancel, `Stop()` nil-guards, `stopGrace` present, and zero bare `com.tx <-` sends remain across `consumer.go`, `producer.go`, `egress_consumer.go` and `jit_egress_consumer.go`.

Note for CI: the Makefile's `test` target sets `GOEXPERIMENT=synctest`, which a Go 1.26 toolchain rejects with `unknown GOEXPERIMENT synctest` — `synctest` graduated in 1.25. Not touched here, but that target will need updating whenever CI's Go moves up.

## Pre-PR review (local Codex gate)
- Rounds: 1 — final: `CODEX GATE: verdict=approve critical=0 important=0 minor=0`
- Exit: `approve`
- Fixed: none (no findings raised)
- Dismissed: none

Copilot review after opening raised one finding — the `Close()` comment asserted broflake behavior the then-pinned version did not have — fixed in da783ce and re-reviewed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVgb2MDpZ4wpH6fywKC2hE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection shutdown reliability by stopping background interface activity before closing the network connection.
  * Reduced the risk of lingering activity or unexpected behavior during disconnects.

* **Maintenance**
  * Updated supporting connectivity components to improve overall stability and shutdown handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->