### PR TITLE
Freshness-filtered external probes with bounded worker pool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getlantern/lantern-box
 
-go 1.24.6
+go 1.25
 
 replace github.com/sagernet/sing => github.com/getlantern/sing v0.7.18-lantern
 

--- a/option/group.go
+++ b/option/group.go
@@ -98,4 +98,7 @@ type MutableAutoSelectOutboundOptions struct {
 	// other failure paths (dial errors, probe failures) catch the
 	// actually-broken cases. Default 4096.
 	DataPlaneProvedReadBytes uint32 `json:"data_plane_proved_read_bytes,omitempty"`
+
+	// ProbeConcurrency caps parallel member probes per batch. Default 6.
+	ProbeConcurrency uint32 `json:"probe_concurrency,omitempty"`
 }

--- a/protocol/group/mutableautoselect.go
+++ b/protocol/group/mutableautoselect.go
@@ -88,9 +88,9 @@ type MutableAutoSelect struct {
 		udp atomic.Value // string; "" when unset
 	}
 
-	// probeMu serializes probe cycles. Fire-and-forget callers
-	// (runProbeCycle) TryLock; callers that need a deterministic outcome
-	// (URLTest, runLadder) Lock so they observe the cycle they triggered.
+	// probeMu serializes all probeAll runs so outcomes can't interleave and
+	// the worker bound is global. Fire-and-forget callers TryLock; callers
+	// that need a deterministic result Lock.
 	probeMu   sync.Mutex
 	laddering atomic.Bool
 	// Unix-nano of the most recent runLadder completion. Read by the
@@ -99,12 +99,9 @@ type MutableAutoSelect struct {
 	lastLadderAt atomic.Int64
 	exhaustionCh chan struct{}
 
-	// externalProbeMu serializes Add / CheckOutbounds probes; overlapping
-	// external triggers are dropped. internalActive, guarded by access,
-	// prevents an external probe from starting while an internal cycle is
-	// already active.
+	// externalProbeMu drops overlapping Add / CheckOutbounds probes; probeMu
+	// also makes them drop during an internal cycle.
 	externalProbeMu sync.Mutex
-	internalActive  bool
 
 	// Unix-nano of the most recent non-empty data-plane Read/Write; 0
 	// means no traffic observed yet. Drives the adaptive probe cadence.
@@ -940,19 +937,19 @@ func (s *MutableAutoSelect) runProbeCycle(ctx context.Context) {
 }
 
 // runExternalProbe runs a fire-and-forget, freshness-filtered probe for tags,
-// or all members when tags is nil. It serializes only with other external
-// probes; unlike internal probes, it does not rank after refreshing history.
+// or all members when tags is nil. It drops if another external probe or
+// internal cycle is running and does not rank after refreshing history.
 func (s *MutableAutoSelect) runExternalProbe(tags []string) {
 	if !s.externalProbeMu.TryLock() {
 		return
 	}
 	defer s.externalProbeMu.Unlock()
-
-	s.access.Lock()
-	if s.internalActive {
-		s.access.Unlock()
+	if !s.probeMu.TryLock() {
 		return
 	}
+	defer s.probeMu.Unlock()
+
+	s.access.Lock()
 	jobs := s.collectProbeJobsLocked(time.Now(), tags, false)
 	s.access.Unlock()
 
@@ -960,20 +957,12 @@ func (s *MutableAutoSelect) runExternalProbe(tags []string) {
 }
 
 // internalProbe probes every non-excluded member, streaming successes to
-// onSuccess when provided. It marks internalActive for the duration so new
-// external probes drop instead of starting mid-cycle. Caller should hold
-// s.probeMu to serialize with other internal cycles.
+// onSuccess when provided. Caller must hold s.probeMu. Unlike external probes,
+// it bypasses freshness filtering; callers rank separately when needed.
 func (s *MutableAutoSelect) internalProbe(ctx context.Context, onSuccess func(probeResult)) {
 	s.access.Lock()
-	s.internalActive = true
 	jobs := s.collectProbeJobsLocked(time.Now(), nil, true)
 	s.access.Unlock()
-
-	defer func() {
-		s.access.Lock()
-		s.internalActive = false
-		s.access.Unlock()
-	}()
 	s.probeAll(ctx, jobs, onSuccess)
 }
 

--- a/protocol/group/mutableautoselect.go
+++ b/protocol/group/mutableautoselect.go
@@ -47,7 +47,11 @@ var (
 	_ adapter.ExhaustionSignaler   = (*MutableAutoSelect)(nil)
 )
 
-const probeConcurrency = 6
+const defaultProbeConcurrency = 6
+
+// probeFreshnessWindow lets external probes skip members with recent outcomes.
+// Internal probes always force a fresh probe.
+const probeFreshnessWindow = 30 * time.Second
 
 // MutableAutoSelect is the client-side server-selection group.
 type MutableAutoSelect struct {
@@ -95,6 +99,13 @@ type MutableAutoSelect struct {
 	lastLadderAt atomic.Int64
 	exhaustionCh chan struct{}
 
+	// externalProbeMu serializes Add / CheckOutbounds probes; overlapping
+	// external triggers are dropped. internalActive, guarded by access,
+	// prevents an external probe from starting while an internal cycle is
+	// already active.
+	externalProbeMu sync.Mutex
+	internalActive  bool
+
 	// Unix-nano of the most recent non-empty data-plane Read/Write; 0
 	// means no traffic observed yet. Drives the adaptive probe cadence.
 	lastActive atomic.Int64
@@ -113,6 +124,7 @@ type mutableAutoSelectConfig struct {
 	dataPlaneIdle       time.Duration
 	dataPlaneProvedRead uint64
 	maxPersistedAge     time.Duration
+	probeConcurrency    int
 }
 
 func resolveMutableAutoSelectOptions(o option.MutableAutoSelectOutboundOptions) (mutableAutoSelectConfig, historyParams) {
@@ -126,6 +138,7 @@ func resolveMutableAutoSelectOptions(o option.MutableAutoSelectOutboundOptions) 
 		dataPlaneIdle:       time.Duration(o.DataPlaneIdleSeconds) * time.Second,
 		dataPlaneProvedRead: uint64(o.DataPlaneProvedReadBytes),
 		maxPersistedAge:     time.Duration(o.MaxPersistedAgeSeconds) * time.Second,
+		probeConcurrency:    int(o.ProbeConcurrency),
 	}
 	if cfg.switchTolerance == 0 {
 		cfg.switchTolerance = 200 * time.Millisecond
@@ -153,6 +166,9 @@ func resolveMutableAutoSelectOptions(o option.MutableAutoSelectOutboundOptions) 
 	}
 	if cfg.maxPersistedAge == 0 {
 		cfg.maxPersistedAge = defaultMaxPersistedAge
+	}
+	if cfg.probeConcurrency == 0 {
+		cfg.probeConcurrency = defaultProbeConcurrency
 	}
 
 	hp := defaultHistoryParams()
@@ -306,7 +322,7 @@ func (s *MutableAutoSelect) Add(tags ...string) (n int, err error) {
 	if s.isClosed() {
 		return 0, adapter.ErrGroupClosed
 	}
-	var missing []string
+	var missing, added []string
 	for _, tag := range tags {
 		if _, exists := s.members.Load(tag); exists {
 			continue
@@ -324,7 +340,13 @@ func (s *MutableAutoSelect) Add(tags ...string) (n int, err error) {
 		if !alreadyListed {
 			s.tags = append(s.tags, tag)
 		}
+		added = append(added, tag)
 		n++
+	}
+	// Probe new members so dial-time ranking has data before the next
+	// background cycle.
+	if len(added) > 0 {
+		go s.runExternalProbe(added)
 	}
 	if len(missing) > 0 {
 		return n, fmt.Errorf("%d outbounds not found: %v", len(missing), missing)
@@ -395,7 +417,7 @@ func (s *MutableAutoSelect) invalidateHistoryLocked(tag string) {
 }
 
 func (s *MutableAutoSelect) CheckOutbounds() {
-	go s.runProbeCycle(s.ctx)
+	go s.runExternalProbe(nil)
 }
 
 // ExhaustionSignal returns a receive-only channel that emits when every
@@ -417,10 +439,6 @@ func (s *MutableAutoSelect) URLTest(ctx context.Context) (map[string]uint16, err
 	defer s.probeMu.Unlock()
 
 	s.access.Lock()
-	if len(s.tags) == 0 {
-		s.access.Unlock()
-		return results, nil
-	}
 	for _, tag := range s.tags {
 		if _, ok := s.members.Load(tag); ok {
 			continue
@@ -435,10 +453,9 @@ func (s *MutableAutoSelect) URLTest(ctx context.Context) (map[string]uint16, err
 		// an empty in-memory localHistory.
 		s.hydrateHistoryLocked(tag)
 	}
-	jobs := s.collectProbeJobsLocked()
 	s.access.Unlock()
 
-	s.probeAll(ctx, jobs, func(res probeResult) {
+	s.internalProbe(ctx, func(res probeResult) {
 		results[res.tag] = uint16(min(65535, res.delayMs))
 	})
 	return results, nil
@@ -678,10 +695,15 @@ func (s *MutableAutoSelect) peekHistoryLocked(tag string) (*localHistory, bool) 
 	return h, ok
 }
 
-// Caller must hold s.access. Skips excludeFromPool members.
-func (s *MutableAutoSelect) collectProbeJobsLocked() []probeJob {
-	jobs := make([]probeJob, 0, len(s.tags))
-	for _, tag := range s.tags {
+// collectProbeJobsLocked builds jobs for tags, or all members when tags is nil.
+// excludeFromPool members are skipped. With force=false, members with outcomes
+// newer than probeFreshnessWindow are skipped. Caller must hold s.access.
+func (s *MutableAutoSelect) collectProbeJobsLocked(now time.Time, tags []string, force bool) []probeJob {
+	if tags == nil {
+		tags = s.tags
+	}
+	jobs := make([]probeJob, 0, len(tags))
+	for _, tag := range tags {
 		o, ok := s.members.Load(tag)
 		if !ok {
 			continue
@@ -689,6 +711,13 @@ func (s *MutableAutoSelect) collectProbeJobsLocked() []probeJob {
 		beh := behaviorFor(o.Type())
 		if beh.excludeFromPool {
 			continue
+		}
+		if !force {
+			if h, ok := s.peekHistoryLocked(tag); ok {
+				if at := h.outcomeAt(); !at.IsZero() && now.Sub(at) < probeFreshnessWindow {
+					continue
+				}
+			}
 		}
 		jobs = append(jobs, probeJob{
 			outbound: o,
@@ -900,38 +929,52 @@ func (s *MutableAutoSelect) rankLocked(now time.Time, freshSince time.Time) []ra
 	return out
 }
 
-// runProbeCycle is the fire-and-forget entry point; it skips when another
-// cycle is in flight. Callers that need a deterministic outcome acquire
-// s.probeMu directly and call probeCycleInner.
+// runProbeCycle is the fire-and-forget internal probe path; it skips when
+// another internal cycle is already in flight.
 func (s *MutableAutoSelect) runProbeCycle(ctx context.Context) {
 	if !s.probeMu.TryLock() {
 		return
 	}
 	defer s.probeMu.Unlock()
-	s.probeCycleInner(ctx, time.Now())
+	s.internalProbe(ctx, nil)
 }
 
-// probeCycleInner probes every non-excluded member in parallel and
-// returns the lowest-delay candidate that succeeded at or after
-// cycleStart, or nil when no candidate succeeded. Caller must hold
-// s.probeMu so concurrent cycles can't interleave recordProbeOutcome
-// calls.
-func (s *MutableAutoSelect) probeCycleInner(ctx context.Context, cycleStart time.Time) A.Outbound {
-	s.access.Lock()
-	jobs := s.collectProbeJobsLocked()
-	s.access.Unlock()
-	if len(jobs) == 0 {
-		return nil
+// runExternalProbe runs a fire-and-forget, freshness-filtered probe for tags,
+// or all members when tags is nil. It serializes only with other external
+// probes; unlike internal probes, it does not rank after refreshing history.
+func (s *MutableAutoSelect) runExternalProbe(tags []string) {
+	if !s.externalProbeMu.TryLock() {
+		return
 	}
-	s.probeAll(ctx, jobs, nil)
+	defer s.externalProbeMu.Unlock()
 
 	s.access.Lock()
-	defer s.access.Unlock()
-	ranked := s.rankLocked(time.Now(), cycleStart)
-	if len(ranked) == 0 {
-		return nil
+	if s.internalActive {
+		s.access.Unlock()
+		return
 	}
-	return ranked[0].outbound
+	jobs := s.collectProbeJobsLocked(time.Now(), tags, false)
+	s.access.Unlock()
+
+	s.probeAll(s.ctx, jobs, nil)
+}
+
+// internalProbe probes every non-excluded member, streaming successes to
+// onSuccess when provided. It marks internalActive for the duration so new
+// external probes drop instead of starting mid-cycle. Caller should hold
+// s.probeMu to serialize with other internal cycles.
+func (s *MutableAutoSelect) internalProbe(ctx context.Context, onSuccess func(probeResult)) {
+	s.access.Lock()
+	s.internalActive = true
+	jobs := s.collectProbeJobsLocked(time.Now(), nil, true)
+	s.access.Unlock()
+
+	defer func() {
+		s.access.Lock()
+		s.internalActive = false
+		s.access.Unlock()
+	}()
+	s.probeAll(ctx, jobs, onSuccess)
 }
 
 // mutateHistory applies fn to tag's history under s.access and persists
@@ -1023,7 +1066,14 @@ func (s *MutableAutoSelect) runLadder(target string) {
 	s.probeMu.Lock()
 	fullCtx, cancel := context.WithTimeout(s.ctx, s.cfg.ladderTotalBudget)
 	defer cancel()
-	winner := s.probeCycleInner(fullCtx, time.Now())
+	cycleStart := time.Now()
+	s.internalProbe(fullCtx, nil)
+	var winner A.Outbound
+	s.access.Lock()
+	if ranked := s.rankLocked(time.Now(), cycleStart); len(ranked) > 0 {
+		winner = ranked[0].outbound
+	}
+	s.access.Unlock()
 	s.probeMu.Unlock()
 	// Stamp on completion, not entry, so a slow ladder's runtime counts
 	// toward the cooldown.

--- a/protocol/group/mutableautoselect_history.go
+++ b/protocol/group/mutableautoselect_history.go
@@ -64,6 +64,13 @@ type localHistory struct {
 
 func newLocalHistory() *localHistory { return &localHistory{} }
 
+// outcomeAt returns the most recent probe outcome time, or zero if unset.
+func (h *localHistory) outcomeAt() time.Time {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.lastOutcomeAt
+}
+
 // recordProbeSuccess updates the probe scalars on a successful probe.
 // delayMs has already been clamped to ≥1 ms by the caller so the
 // "no measurement" sentinel (0) stays unambiguous.

--- a/protocol/group/mutableautoselect_probe.go
+++ b/protocol/group/mutableautoselect_probe.go
@@ -104,10 +104,9 @@ func runProbe(
 	return probeResult{tag: tag, success: true, delayMs: delayMs}
 }
 
-// probeAll fans out one probe per job over up to probeConcurrency
-// goroutines, recording each outcome via recordProbeOutcome and
-// streaming successes through onSuccess (called serialized). Returns
-// when every probe completes or ctx fires.
+// probeAll runs jobs with up to probeConcurrency workers, records each
+// outcome, and calls onSuccess serially for successful probes. It returns
+// after all queued probes complete or ctx is canceled.
 func (s *MutableAutoSelect) probeAll(
 	ctx context.Context,
 	jobs []probeJob,
@@ -117,29 +116,40 @@ func (s *MutableAutoSelect) probeAll(
 		return
 	}
 	var (
-		wg  sync.WaitGroup
-		mu  sync.Mutex
-		sem = make(chan struct{}, probeConcurrency)
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		queue   = make(chan probeJob)
+		workers = max(1, min(len(jobs), s.cfg.probeConcurrency))
 	)
-	for _, j := range jobs {
-		wg.Add(1)
-		go func(j probeJob) {
-			defer wg.Done()
-			select {
-			case sem <- struct{}{}:
-			case <-ctx.Done():
-				return
+	for range workers {
+		wg.Go(func() {
+			for j := range queue {
+				res := runProbe(ctx, j.outbound, j.probeURL, j.beh)
+				// Batch cancellation (shutdown or ladder budget) is not member
+				// evidence. Per-probe timeouts use a child context, so the
+				// batch ctx remains live and the failure still counts.
+				if ctx.Err() != nil {
+					continue
+				}
+				s.recordProbeOutcome(res.tag, res.success, res.delayMs)
+				if !res.success || onSuccess == nil {
+					continue
+				}
+				mu.Lock()
+				onSuccess(res)
+				mu.Unlock()
 			}
-			defer func() { <-sem }()
-			res := runProbe(ctx, j.outbound, j.probeURL, j.beh)
-			s.recordProbeOutcome(res.tag, res.success, res.delayMs)
-			if !res.success || onSuccess == nil {
-				return
-			}
-			mu.Lock()
-			onSuccess(res)
-			mu.Unlock()
-		}(j)
+		})
 	}
+	for _, j := range jobs {
+		select {
+		case queue <- j:
+		case <-ctx.Done():
+			close(queue)
+			wg.Wait()
+			return
+		}
+	}
+	close(queue)
 	wg.Wait()
 }

--- a/protocol/group/mutableautoselect_test.go
+++ b/protocol/group/mutableautoselect_test.go
@@ -51,6 +51,7 @@ func newTestMUR(t *testing.T, tags ...string) (*MutableAutoSelect, map[string]*m
 			ladderTotalBudget: 100 * time.Millisecond,
 			dataPlaneIdle:     time.Hour,
 			maxPersistedAge:   defaultMaxPersistedAge,
+			probeConcurrency:  defaultProbeConcurrency,
 		},
 		hist:         defaultHistoryParams(),
 		history:      adapter.NewAutoSelectHistoryStorage(),
@@ -73,6 +74,14 @@ func recordSuccess(s *MutableAutoSelect, tag string, delay uint32) time.Time {
 	h := s.historyForLocked(tag)
 	h.recordProbeSuccess(delay, now)
 	return now
+}
+
+func jobTags(jobs []probeJob) []string {
+	tags := make([]string, len(jobs))
+	for i, j := range jobs {
+		tags[i] = j.outbound.Tag()
+	}
+	return tags
 }
 
 func TestPruneUserFailures(t *testing.T) {
@@ -1329,6 +1338,115 @@ func TestInterfaceUpdated_TriggersReprobe(t *testing.T) {
 	s.probeMu.Lock()
 	s.probeMu.Unlock()
 	obs["a"].AssertNumberOfCalls(t, "DialContext", 1)
+}
+
+func TestCollectProbeJobs_FreshnessFilter(t *testing.T) {
+	s, _ := newTestMUR(t, "fresh", "stale")
+	now := time.Now()
+	s.historyForLocked("fresh").recordProbeSuccess(100, now)
+	s.historyForLocked("stale").recordProbeSuccess(100, now.Add(-2*probeFreshnessWindow))
+
+	s.access.Lock()
+	defer s.access.Unlock()
+
+	forced := s.collectProbeJobsLocked(now, nil, true)
+	assert.ElementsMatch(t, []string{"fresh", "stale"}, jobTags(forced),
+		"force=true probes every member regardless of freshness")
+
+	filtered := s.collectProbeJobsLocked(now, nil, false)
+	assert.Equal(t, []string{"stale"}, jobTags(filtered),
+		"force=false skips members probed within the freshness window")
+}
+
+func TestRunExternalProbe_SkipsFreshMembers(t *testing.T) {
+	s, obs := newTestMUR(t, "fresh", "stale")
+	s.defaultURL = "http://probe.test/"
+	obs["fresh"].On("DialContext").Return(nil, errors.New("dial denied"))
+	obs["stale"].On("DialContext").Return(nil, errors.New("dial denied"))
+	s.historyForLocked("fresh").recordProbeSuccess(100, time.Now())
+	s.historyForLocked("stale").recordProbeSuccess(100, time.Now().Add(-2*probeFreshnessWindow))
+
+	s.runExternalProbe(nil)
+
+	obs["fresh"].AssertNumberOfCalls(t, "DialContext", 0)
+	obs["stale"].AssertNumberOfCalls(t, "DialContext", 1)
+}
+
+func TestAdd_ProbesNewMembers(t *testing.T) {
+	s, _ := newTestMUR(t)
+	s.defaultURL = "http://probe.test/"
+	newOb := &mockOutbound{tag: "new"}
+	dialed := make(chan struct{}, 1)
+	newOb.On("DialContext").Run(func(mock.Arguments) {
+		select {
+		case dialed <- struct{}{}:
+		default:
+		}
+	}).Return(nil, errors.New("dial denied"))
+	s.outboundMgr = &mockOutboundManager{outbounds: map[string]sbAdapter.Outbound{"new": newOb}}
+
+	n, err := s.Add("new")
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	select {
+	case <-dialed:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "Add did not trigger a probe of the new member")
+	}
+	s.externalProbeMu.Lock()
+	s.externalProbeMu.Unlock()
+	newOb.AssertNumberOfCalls(t, "DialContext", 1)
+}
+
+func TestRunExternalProbe_DropsWhenInternalActive(t *testing.T) {
+	s, obs := newTestMUR(t, "a")
+	s.defaultURL = "http://probe.test/"
+	obs["a"].On("DialContext").Return(nil, errors.New("dial denied"))
+
+	s.access.Lock()
+	s.internalActive = true
+	s.access.Unlock()
+
+	s.runExternalProbe(nil)
+	obs["a"].AssertNumberOfCalls(t, "DialContext", 0)
+}
+
+func TestRunExternalProbe_DropsWhenAnotherExternalRunning(t *testing.T) {
+	s, obs := newTestMUR(t, "a")
+	s.defaultURL = "http://probe.test/"
+	obs["a"].On("DialContext").Return(nil, errors.New("dial denied"))
+
+	s.externalProbeMu.Lock()
+	defer s.externalProbeMu.Unlock()
+
+	s.runExternalProbe(nil)
+	obs["a"].AssertNumberOfCalls(t, "DialContext", 0)
+}
+
+func TestProbeAll_CanceledBatchDoesNotRecordOutcome(t *testing.T) {
+	// A probe whose batch ctx is canceled mid-flight (group shutdown or
+	// ladder budget) must not record a failure that would spuriously demote
+	// a member that simply didn't finish in time.
+	s, obs := newTestMUR(t, "a")
+	s.defaultURL = "http://probe.test/"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	obs["a"].On("DialContext").Run(func(mock.Arguments) {
+		cancel()
+	}).Return(nil, errors.New("dial denied"))
+
+	seed := time.Now().Add(-time.Hour)
+	s.historyForLocked("a").recordProbeSuccess(50, seed)
+
+	s.access.Lock()
+	jobs := s.collectProbeJobsLocked(time.Now(), nil, true)
+	s.access.Unlock()
+	s.probeAll(ctx, jobs, nil)
+
+	obs["a"].AssertNumberOfCalls(t, "DialContext", 1)
+	assert.Equal(t, seed, s.historyForLocked("a").outcomeAt(),
+		"canceled batch must not overwrite the seeded outcome")
 }
 
 type fakePauseManager struct {

--- a/protocol/group/mutableautoselect_test.go
+++ b/protocol/group/mutableautoselect_test.go
@@ -1399,14 +1399,14 @@ func TestAdd_ProbesNewMembers(t *testing.T) {
 	newOb.AssertNumberOfCalls(t, "DialContext", 1)
 }
 
-func TestRunExternalProbe_DropsWhenInternalActive(t *testing.T) {
+func TestRunExternalProbe_DropsWhenInternalRunning(t *testing.T) {
 	s, obs := newTestMUR(t, "a")
 	s.defaultURL = "http://probe.test/"
 	obs["a"].On("DialContext").Return(nil, errors.New("dial denied"))
 
-	s.access.Lock()
-	s.internalActive = true
-	s.access.Unlock()
+	// External probes drop while an internal cycle holds probeMu.
+	s.probeMu.Lock()
+	defer s.probeMu.Unlock()
 
 	s.runExternalProbe(nil)
 	obs["a"].AssertNumberOfCalls(t, "DialContext", 0)


### PR DESCRIPTION
## Summary

Reworks `MutableAutoSelect` probing into two coordinated classes with a single bounded worker pool.

**Internal cycles** (background loop, interface change, reconnection ladder, `URLTest`) probe every member through one `internalProbe` primitive. Probing is bounded by a fixed worker pool draining a shared queue, sized by `probeConcurrency` (default 6, now configurable via the `ProbeConcurrency` option) instead of spawning a goroutine per member.

**External triggers** (`Add`, `CheckOutbounds`) run a non-blocking, freshness-filtered probe:
- Skips members probed within the last 30s, so a probe triggered right after another doesn't re-probe fresh members.
- Drops while an internal cycle is running (internal cycles take priority) and serializes against other external probes.
- `Add` now probes only its newly added members immediately, instead of leaving them unmeasured until the next background cycle.

## Other changes

- **Ranking moved out of the probe cycle** into `runLadder`, its only consumer. Background and interface cycles previously ranked and discarded the result on every run; they no longer do.
- **Canceled batches don't record outcomes.** A probe canceled by group shutdown or the ladder budget no longer records a failure, which previously could spuriously demote a member that simply didn't finish in time.
- `go` directive bumped to 1.25 (required by `sync.WaitGroup.Go`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration for limiting the number of simultaneous outbound probes, with a default of six.
  - Newly added members are probed promptly, while recently checked members can be skipped to reduce unnecessary checks.
  - Probe results now stream during internal URL tests.

- **Bug Fixes**
  - Prevented overlapping probe cycles and avoided recording incomplete results when probing is canceled.
  - Improved probe coordination and result handling during concurrent activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->