### PR TITLE
perf(mutableautoselect): cut per-dial allocs and per-packet timer churn

### DIFF
--- a/protocol/group/mutableautoselect.go
+++ b/protocol/group/mutableautoselect.go
@@ -827,13 +827,13 @@ func (s *MutableAutoSelect) rankLocked(now time.Time, freshSince time.Time) []ra
 			haveData  bool
 		)
 		if h, ok := s.peekHistoryLocked(tag); ok {
-			lastDelay, lastAt, c, uf := h.snapshot(now, s.hist.userFailureWindow)
+			lastDelay, lastAt, c, ufCount := h.snapshot(now, s.hist.userFailureWindow)
 			if !freshSince.IsZero() && lastAt.Before(freshSince) {
 				continue
 			}
 			rawDelay = lastDelay
 			consec = c
-			userFails = uint32(len(uf))
+			userFails = ufCount
 			haveData = true
 		} else if freshSince.IsZero() && s.history != nil {
 			// Cold member (added without going through hydrate). Fall back

--- a/protocol/group/mutableautoselect_dataplane.go
+++ b/protocol/group/mutableautoselect_dataplane.go
@@ -32,19 +32,27 @@ func (s *MutableAutoSelect) makeHooks(outerTag string) (onFailure func(adapter.U
 // dataPlaneWatchdog is the no-traffic stall timer shared by the stream
 // and packet wrappers.
 //
-// provedReadBytes gates whether the stall is real: until the wrapped conn
-// has delivered that many cumulative non-empty Read bytes, an
-// idle-window expiry is treated as "established but never carried real
-// traffic" (e.g. a handshake-only or keepalive-only conn) and the
-// stall handler is suppressed.
+// provedReadBytes keeps handshake-only and keepalive-only conns from
+// counting as stalls: the watchdog starts only after that many cumulative
+// non-empty Read bytes have arrived.
 //
-// lastWasWrite separately distinguishes "tunnel is broken" from "user
-// stopped sending traffic" on an already-proven conn. The stall fires
-// only when the most recent non-empty IO was a Write — i.e. we sent
+// The write-vs-read classification distinguishes "tunnel is broken" from
+// "user stopped sending traffic" on an already-proven conn. The stall
+// fires only when the most recent non-empty IO was a Write — i.e. we sent
 // bytes and got nothing back for the idle window. A proven conn whose
 // last activity was a Read (response arrived, then silence) is treated
 // as user-idle, not broken: a healthy keep-alive going unused looks
 // identical to a broken tunnel without this gate.
+//
+// The classification and timestamp are packed into one atomic word so
+// fireStall cannot combine a fresh write flag with a stale timestamp and
+// falsely stall a just-written conn.
+//
+// The timer is lazy on two axes to keep its cost off the data path.
+// It is allocated only when the conn becomes proven. noteIO also avoids
+// timer resets on the IO path; it only stamps activity, and fireStall
+// re-arms when the stamp is still fresh. Steady traffic therefore costs
+// one timer op per idle window instead of one per packet.
 type dataPlaneWatchdog struct {
 	idle            time.Duration
 	onFailure       func(adapter.UserFailureKind)
@@ -52,19 +60,71 @@ type dataPlaneWatchdog struct {
 	provedReadBytes uint64
 	readBytes       atomic.Uint64
 	proven          atomic.Bool
-	lastWasWrite    atomic.Bool
-	stalled         atomic.Bool
-	fired           atomic.Bool
-	timer           *time.Timer
-	closeOnce       sync.Once
+	// activity packs the last non-empty IO: bit 0 is the write flag, the
+	// remaining bits are monotonic nanoseconds since dataPlaneEpoch.
+	activity atomic.Int64
+	stalled  atomic.Bool
+	fired    atomic.Bool
+
+	timerMu   sync.Mutex
+	timer     *time.Timer // nil until proven; guarded by timerMu
+	closeOnce sync.Once
 }
+
+// packActivity stores wasWrite in bit 0. This drops 1 ns of timestamp
+// precision, which is irrelevant for idle-window comparisons.
+func packActivity(nanos int64, wasWrite bool) int64 {
+	v := nanos &^ 1
+	if wasWrite {
+		v |= 1
+	}
+	return v
+}
+
+func unpackActivity(v int64) (nanos int64, wasWrite bool) {
+	return v &^ 1, v&1 != 0
+}
+
+// dataPlaneEpoch anchors activity timestamps to a monotonic clock, so
+// wall-clock changes cannot delay or accelerate stall detection.
+var dataPlaneEpoch = time.Now()
+
+func sinceEpoch() int64 { return int64(time.Since(dataPlaneEpoch)) }
+
+// idleForever seeds activity as old read-side IO: old enough to exceed
+// any real idle window, but small enough to avoid subtraction overflow.
+const idleForever = -int64(24 * time.Hour)
 
 func (w *dataPlaneWatchdog) init(idle time.Duration, provedReadBytes uint64, onFailure func(adapter.UserFailureKind), onActivity func()) {
 	w.idle = idle
 	w.provedReadBytes = provedReadBytes
 	w.onFailure = onFailure
 	w.onActivity = onActivity
-	w.timer = time.AfterFunc(idle, w.fireStall)
+	// Direct fireStall calls in tests should evaluate the gates instead
+	// of treating the missing IO stamp as fresh activity.
+	w.activity.Store(idleForever)
+	// Timer is armed lazily on the proven transition; see armTimer.
+}
+
+// armTimer starts the stall timer on the transition to proven. It skips
+// closed conns so a late proven-crossing cannot leave a live timer.
+func (w *dataPlaneWatchdog) armTimer() {
+	w.timerMu.Lock()
+	defer w.timerMu.Unlock()
+	if w.stalled.Load() {
+		return
+	}
+	w.timer = time.AfterFunc(w.idle, w.fireStall)
+}
+
+// rearm reschedules the stall timer for d, unless the conn is closed.
+func (w *dataPlaneWatchdog) rearm(d time.Duration) {
+	w.timerMu.Lock()
+	defer w.timerMu.Unlock()
+	if w.stalled.Load() || w.timer == nil {
+		return
+	}
+	w.timer.Reset(d)
 }
 
 // isDataPlaneFailure reports whether err should demote the outbound.
@@ -96,13 +156,9 @@ func (w *dataPlaneWatchdog) noteIO(n int, err error, isRead bool) {
 	if n <= 0 || err != nil {
 		return
 	}
-	// Publish the gate value before re-arming the timer so a fireStall
-	// racing the Reset reads the fresh classification, not the previous
-	// IO's value. Otherwise a Read landing just as the timer fires
-	// could leave lastWasWrite=true from an earlier Write and trip
-	// the gate it's supposed to suppress.
-	w.lastWasWrite.Store(!isRead)
-	w.timer.Reset(w.idle)
+	// Stamp timestamp and write flag together so fireStall can't read a
+	// fresh flag against a stale timestamp and fire on a just-written conn.
+	w.activity.Store(packActivity(sinceEpoch(), !isRead))
 	if w.onActivity != nil {
 		w.onActivity()
 	}
@@ -118,17 +174,24 @@ func (w *dataPlaneWatchdog) noteIO(n int, err error, isRead bool) {
 	}
 	total := w.readBytes.Add(uint64(n))
 	if total >= w.provedReadBytes {
-		w.proven.Store(true)
+		// Arm on the proven transition only: CAS so concurrent readers
+		// crossing the threshold together arm exactly one timer.
+		if w.proven.CompareAndSwap(false, true) {
+			w.armTimer()
+		}
 	}
 }
 
-// closeWatchdog sets stalled=true before Stop so any concurrent noteIO
-// short-circuits and any concurrent fireStall CAS-fails — late I/O can't
-// deliver a phantom onFailure after Close.
+// closeWatchdog sets stalled before Stop so concurrent noteIO/fireStall
+// cannot report a failure after Close. The timer is nil until proven.
 func (w *dataPlaneWatchdog) closeWatchdog() (firstClose bool) {
 	w.closeOnce.Do(func() {
 		w.stalled.Store(true)
-		w.timer.Stop()
+		w.timerMu.Lock()
+		if w.timer != nil {
+			w.timer.Stop()
+		}
+		w.timerMu.Unlock()
 		firstClose = true
 	})
 	return firstClose
@@ -136,12 +199,26 @@ func (w *dataPlaneWatchdog) closeWatchdog() (firstClose bool) {
 
 // fireStall is the idle-timer callback: it demotes a conn that went quiet
 // mid-stream. It fires only on a proven conn whose last non-empty IO was a
-// Write.
+// Write and whose idle window has genuinely elapsed.
+//
+// Since noteIO does not reset the timer, a callback can arrive while
+// activity is fresh; fireStall re-arms for the remaining window. It also
+// re-arms after read-only idle so later unanswered Writes remain watched.
 func (w *dataPlaneWatchdog) fireStall() {
+	if w.stalled.Load() {
+		return
+	}
 	if !w.proven.Load() {
 		return
 	}
-	if !w.lastWasWrite.Load() {
+	lastNanos, lastWasWrite := unpackActivity(w.activity.Load())
+	elapsed := time.Duration(sinceEpoch() - lastNanos)
+	if remaining := w.idle - elapsed; remaining > 0 {
+		w.rearm(remaining)
+		return
+	}
+	if !lastWasWrite {
+		w.rearm(w.idle)
 		return
 	}
 	if !w.stalled.CompareAndSwap(false, true) {

--- a/protocol/group/mutableautoselect_dataplane.go
+++ b/protocol/group/mutableautoselect_dataplane.go
@@ -44,9 +44,9 @@ func (s *MutableAutoSelect) makeHooks(outerTag string) (onFailure func(adapter.U
 // as user-idle, not broken: a healthy keep-alive going unused looks
 // identical to a broken tunnel without this gate.
 //
-// The classification and timestamp are packed into one atomic word so
-// fireStall cannot combine a fresh write flag with a stale timestamp and
-// falsely stall a just-written conn.
+// The classification, timestamp, and terminal state share one atomic word
+// so activity publication, stall claims, reset claims, and close claims
+// are serialized without taking timerMu on the IO path.
 //
 // The timer is lazy on two axes to keep its cost off the data path.
 // It is allocated only when the conn becomes proven. noteIO also avoids
@@ -60,11 +60,10 @@ type dataPlaneWatchdog struct {
 	provedReadBytes uint64
 	readBytes       atomic.Uint64
 	proven          atomic.Bool
-	// activity packs the last non-empty IO: bit 0 is the write flag, the
-	// remaining bits are monotonic nanoseconds since dataPlaneEpoch.
+	// activity is either activityTerminal or the last non-empty IO packed
+	// as monotonic nanoseconds since dataPlaneEpoch plus a write flag in
+	// bit 0.
 	activity atomic.Int64
-	stalled  atomic.Bool
-	fired    atomic.Bool
 
 	timerMu   sync.Mutex
 	timer     *time.Timer // nil until proven; guarded by timerMu
@@ -89,11 +88,15 @@ func unpackActivity(v int64) (nanos int64, wasWrite bool) {
 // wall-clock changes cannot delay or accelerate stall detection.
 var dataPlaneEpoch = time.Now()
 
-func sinceEpoch() int64 { return int64(time.Since(dataPlaneEpoch)) }
+func sinceEpoch() int64 { return time.Since(dataPlaneEpoch).Nanoseconds() }
 
 // idleForever seeds activity as old read-side IO: old enough to exceed
 // any real idle window, but small enough to avoid subtraction overflow.
 const idleForever = -int64(24 * time.Hour)
+
+// activityTerminal is the reserved terminal activity value. Real IO stamps
+// are non-negative, so this marker cannot collide with activity.
+const activityTerminal = -1
 
 func (w *dataPlaneWatchdog) init(idle time.Duration, provedReadBytes uint64, onFailure func(adapter.UserFailureKind), onActivity func()) {
 	w.idle = idle
@@ -106,22 +109,21 @@ func (w *dataPlaneWatchdog) init(idle time.Duration, provedReadBytes uint64, onF
 	// Timer is armed lazily on the proven transition; see armTimer.
 }
 
-// armTimer starts the stall timer on the transition to proven. It skips
-// closed conns so a late proven-crossing cannot leave a live timer.
+// armTimer starts the stall timer on the transition to proven.
 func (w *dataPlaneWatchdog) armTimer() {
 	w.timerMu.Lock()
 	defer w.timerMu.Unlock()
-	if w.stalled.Load() {
+	if w.isTerminal() {
 		return
 	}
 	w.timer = time.AfterFunc(w.idle, w.fireStall)
 }
 
-// rearm reschedules the stall timer for d, unless the conn is closed.
+// rearm reschedules the stall timer for d, unless the watchdog is terminal.
 func (w *dataPlaneWatchdog) rearm(d time.Duration) {
 	w.timerMu.Lock()
 	defer w.timerMu.Unlock()
-	if w.stalled.Load() || w.timer == nil {
+	if w.isTerminal() || w.timer == nil {
 		return
 	}
 	w.timer.Reset(d)
@@ -141,12 +143,6 @@ func isDataPlaneFailure(err error) bool {
 }
 
 func (w *dataPlaneWatchdog) noteIO(n int, err error, isRead bool) {
-	// Short-circuit once stalled: a late noteIO must not re-arm the
-	// timer, fire onActivity, or attribute a failure after the conn is
-	// logically gone.
-	if w.stalled.Load() {
-		return
-	}
 	// Attribute mid-stream transport failures immediately.
 	if isDataPlaneFailure(err) {
 		w.fireResetFailure()
@@ -156,9 +152,11 @@ func (w *dataPlaneWatchdog) noteIO(n int, err error, isRead bool) {
 	if n <= 0 || err != nil {
 		return
 	}
-	// Stamp timestamp and write flag together so fireStall can't read a
-	// fresh flag against a stale timestamp and fire on a just-written conn.
-	w.activity.Store(packActivity(sinceEpoch(), !isRead))
+	// Publish activity before callbacks/proving so a racing fireStall
+	// either observes the new activity or wins the terminal claim.
+	if !w.publishActivity(!isRead) || w.isTerminal() {
+		return
+	}
 	if w.onActivity != nil {
 		w.onActivity()
 	}
@@ -182,11 +180,12 @@ func (w *dataPlaneWatchdog) noteIO(n int, err error, isRead bool) {
 	}
 }
 
-// closeWatchdog sets stalled before Stop so concurrent noteIO/fireStall
-// cannot report a failure after Close. The timer is nil until proven.
+// closeWatchdog marks the watchdog terminal before Stop so concurrent
+// noteIO/fireStall cannot report a failure after Close. The timer is nil
+// until proven.
 func (w *dataPlaneWatchdog) closeWatchdog() (firstClose bool) {
 	w.closeOnce.Do(func() {
-		w.stalled.Store(true)
+		w.claimTerminal()
 		w.timerMu.Lock()
 		if w.timer != nil {
 			w.timer.Stop()
@@ -205,13 +204,14 @@ func (w *dataPlaneWatchdog) closeWatchdog() (firstClose bool) {
 // activity is fresh; fireStall re-arms for the remaining window. It also
 // re-arms after read-only idle so later unanswered Writes remain watched.
 func (w *dataPlaneWatchdog) fireStall() {
-	if w.stalled.Load() {
-		return
-	}
 	if !w.proven.Load() {
 		return
 	}
-	lastNanos, lastWasWrite := unpackActivity(w.activity.Load())
+	act := w.activity.Load()
+	if act == activityTerminal {
+		return
+	}
+	lastNanos, lastWasWrite := unpackActivity(act)
 	elapsed := time.Duration(sinceEpoch() - lastNanos)
 	if remaining := w.idle - elapsed; remaining > 0 {
 		w.rearm(remaining)
@@ -221,10 +221,10 @@ func (w *dataPlaneWatchdog) fireStall() {
 		w.rearm(w.idle)
 		return
 	}
-	if !w.stalled.CompareAndSwap(false, true) {
-		return
-	}
-	if !w.fired.CompareAndSwap(false, true) {
+	// Claim exactly the sampled activity. If IO won the race, re-arm; if
+	// this CAS wins, later IO cannot overwrite the terminal state.
+	if !w.claimStall(act) {
+		w.rearm(w.idle)
 		return
 	}
 	if w.onFailure != nil {
@@ -232,19 +232,53 @@ func (w *dataPlaneWatchdog) fireStall() {
 	}
 }
 
-// fireResetFailure demotes on a mid-stream transport error. Unlike fireStall it skips
-// the proven/lastWasWrite gates — an explicit reset is unambiguous even before a
-// conn is proven. Fire and attribution happens at most once.
-func (w *dataPlaneWatchdog) fireResetFailure() {
-	if !w.stalled.CompareAndSwap(false, true) {
-		return
+func (w *dataPlaneWatchdog) isTerminal() bool {
+	return w.activity.Load() == activityTerminal
+}
+
+// publishActivity records a non-empty Read/Write unless the watchdog is
+// terminal.
+func (w *dataPlaneWatchdog) publishActivity(wasWrite bool) bool {
+	for {
+		cur := w.activity.Load()
+		if cur == activityTerminal {
+			return false
+		}
+		// Stamp timestamp and write flag together so fireStall can't read a
+		// fresh flag against a stale timestamp and fire on a just-written conn.
+		next := packActivity(sinceEpoch(), wasWrite)
+		if w.activity.CompareAndSwap(cur, next) {
+			return true
+		}
 	}
-	if !w.fired.CompareAndSwap(false, true) {
+}
+
+// claimTerminal marks the watchdog terminal. The first close/reset/stall
+// path to claim the terminal sentinel owns the transition.
+func (w *dataPlaneWatchdog) claimTerminal() bool {
+	return w.activity.Swap(activityTerminal) != activityTerminal
+}
+
+// claimStall CASes the activity word to the terminal sentinel, succeeding
+// only if no IO republished activity since act was sampled.
+func (w *dataPlaneWatchdog) claimStall(act int64) bool {
+	if act == activityTerminal {
+		return false
+	}
+	return w.activity.CompareAndSwap(act, activityTerminal)
+}
+
+// fireResetFailure demotes on a mid-stream transport error. Unlike
+// fireStall, it skips the proven/lastWasWrite gates: an explicit reset is
+// unambiguous even before a conn is proven. Fire and attribution happens
+// at most once.
+func (w *dataPlaneWatchdog) fireResetFailure() {
+	if !w.claimTerminal() {
 		return
 	}
 	if w.onFailure != nil {
-		// run onFailure in a goroutine to avoid deadlocks: the callback may call back
-		// into the selector, which may hold locks that the data-plane IO path also needs.
+		// Avoid deadlocks: the callback may call back into the selector,
+		// which may hold locks that the data-plane IO path also needs.
 		go w.onFailure(adapter.UserFailureReset)
 	}
 }

--- a/protocol/group/mutableautoselect_history.go
+++ b/protocol/group/mutableautoselect_history.go
@@ -126,17 +126,16 @@ func (h *localHistory) userFailureCount(now time.Time, window time.Duration) uin
 	return uint32(len(h.userFailures))
 }
 
-func (h *localHistory) snapshot(now time.Time, window time.Duration) (lastDelay uint32, lastAt time.Time, consec uint32, userFails []adapter.UserFailure) {
+// snapshot returns probe state plus the live user-failure count, pruning
+// stale failures in place.
+func (h *localHistory) snapshot(now time.Time, window time.Duration) (lastDelay uint32, lastAt time.Time, consec uint32, userFailCount uint32) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.userFailures = pruneUserFailures(h.userFailures, now, window)
 	lastDelay = h.lastSuccessDelayMs
 	lastAt = h.lastOutcomeAt
 	consec = h.consecutiveFailures
-	if len(h.userFailures) > 0 {
-		userFails = make([]adapter.UserFailure, len(h.userFailures))
-		copy(userFails, h.userFailures)
-	}
+	userFailCount = uint32(len(h.userFailures))
 	return
 }
 

--- a/protocol/group/mutableautoselect_test.go
+++ b/protocol/group/mutableautoselect_test.go
@@ -604,7 +604,7 @@ func TestDataPlaneStream_StallFiresAfterProven(t *testing.T) {
 		time.Second, 5*time.Millisecond, "proven stall should have fired by now")
 
 	d.fireStall()
-	assert.Equal(t, uint32(1), calls.Load(), "fired CAS should suppress duplicate fires")
+	assert.Equal(t, uint32(1), calls.Load(), "terminal activity state should suppress duplicate fires")
 }
 
 func TestDataPlaneStream_StallSuppressedOnReadOnlyIdle(t *testing.T) {
@@ -627,6 +627,30 @@ func TestDataPlaneStream_StallSuppressedOnReadOnlyIdle(t *testing.T) {
 	time.Sleep(80 * time.Millisecond)
 	assert.Equal(t, uint32(0), calls.Load(),
 		"proven conn with read-only history must not fire stall")
+}
+
+func TestClaimStall_AbortsOnConcurrentActivity(t *testing.T) {
+	// fireStall samples activity, then commits; a Read that republishes
+	// activity in that gap must abort the stall so a live conn is not
+	// demoted.
+	d := newDataPlaneStream(echoConn{}, time.Hour, 0, func(adapter.UserFailureKind) {}, nil)
+
+	// Sample a stale write, then simulate a concurrent Read republishing
+	// fresh activity before the commit.
+	act := packActivity(idleForever, true)
+	d.activity.Store(act)
+	d.activity.Store(packActivity(sinceEpoch(), false))
+	assert.False(t, d.claimStall(act), "claim must abort when activity advanced since the sample")
+
+	// A successful claim marks the terminal state. Later activity must not
+	// overwrite it.
+	fresh := d.activity.Load()
+	assert.True(t, d.claimStall(fresh), "claim must succeed when activity is unchanged")
+	assert.False(t, d.publishActivity(false), "activity must not overwrite a terminal claim")
+	d.noteIO(1, nil, true)
+	assert.Equal(t, int64(activityTerminal), d.activity.Load(), "a claim marks the terminal state")
+	assert.False(t, d.proven.Load(), "terminal claims must suppress later Read-side proving")
+	assert.False(t, d.claimStall(activityTerminal), "the sentinel itself is not a claimable sample")
 }
 
 func TestPackActivity_RoundTrip(t *testing.T) {
@@ -798,6 +822,19 @@ func TestRecordUserFailure_AppendsAndBoundedByMembership(t *testing.T) {
 	assert.False(t, exists)
 }
 
+// firstUserFailure reads the failure count and first-recorded kind under
+// h.mu. The stall/reset hooks kick a background runLadder that mutates
+// history concurrently, so these fields must not be read raw.
+func firstUserFailure(h *localHistory) (n int, kind adapter.UserFailureKind) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	n = len(h.userFailures)
+	if n > 0 {
+		kind = h.userFailures[0].Kind
+	}
+	return
+}
+
 func TestMakeHooks_StallAppendsSingleUserFailure(t *testing.T) {
 	// A stall counts as one failure — same weight as a single dial
 	// error. The demote rule hits hard at three failures in window, not
@@ -811,8 +848,9 @@ func TestMakeHooks_StallAppendsSingleUserFailure(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, uint32(1), h.userFailureCount(time.Now(), s.hist.userFailureWindow),
 		"a single stall must contribute exactly one user-failure timestamp")
-	require.Len(t, h.userFailures, 1)
-	assert.Equal(t, adapter.UserFailureStall, h.userFailures[0].Kind,
+	n, kind := firstUserFailure(h)
+	require.Equal(t, 1, n, "a single stall must record exactly one failure")
+	assert.Equal(t, adapter.UserFailureStall, kind,
 		"the stall hook must record the failure as a stall")
 }
 
@@ -824,8 +862,9 @@ func TestMakeHooks_PropagatesFailureKind(t *testing.T) {
 	h, ok := s.peekHistoryLocked("a")
 	s.access.Unlock()
 	require.True(t, ok)
-	require.Len(t, h.userFailures, 1)
-	assert.Equal(t, adapter.UserFailureReset, h.userFailures[0].Kind,
+	n, kind := firstUserFailure(h)
+	require.Equal(t, 1, n, "a single reset must record exactly one failure")
+	assert.Equal(t, adapter.UserFailureReset, kind,
 		"makeHooks must record the failure under the kind the watchdog reports")
 }
 
@@ -836,8 +875,9 @@ func TestRecordUserFailure_AttributesDialKind(t *testing.T) {
 	h, ok := s.peekHistoryLocked("a")
 	s.access.Unlock()
 	require.True(t, ok)
-	require.Len(t, h.userFailures, 1)
-	assert.Equal(t, adapter.UserFailureDial, h.userFailures[0].Kind,
+	n, kind := firstUserFailure(h)
+	require.Equal(t, 1, n, "a single dial error must record exactly one failure")
+	assert.Equal(t, adapter.UserFailureDial, kind,
 		"a dial-site failure must record the failure as a dial error")
 }
 
@@ -1243,9 +1283,9 @@ func TestDataPlaneStream_TimeoutDoesNotAttribute(t *testing.T) {
 }
 
 func TestDataPlaneStream_NoAttributeAfterClose(t *testing.T) {
-	// After our own Close, closeWatchdog has set stalled; a racing read that
-	// surfaces net.ErrClosed must short-circuit, not attribute a phantom
-	// failure.
+	// After our own Close, closeWatchdog has marked the watchdog
+	// terminal; a racing read that surfaces net.ErrClosed must not
+	// attribute a phantom failure.
 	var calls atomic.Uint32
 	c := &failingConn{err: net.ErrClosed}
 	d := newDataPlaneStream(c, time.Hour, 1, func(adapter.UserFailureKind) { calls.Add(1) }, nil)
@@ -1259,7 +1299,7 @@ func TestDataPlaneStream_NoAttributeAfterClose(t *testing.T) {
 }
 
 func TestDataPlaneStream_FailureFiresOnce(t *testing.T) {
-	// Repeated errored reads attribute at most once per conn (the fired CAS).
+	// Repeated errored reads attribute at most once per conn.
 	var calls atomic.Uint32
 	c := &failingConn{err: connResetErr()}
 	d := newDataPlaneStream(c, time.Hour, 1, func(adapter.UserFailureKind) { calls.Add(1) }, nil)

--- a/protocol/group/mutableautoselect_test.go
+++ b/protocol/group/mutableautoselect_test.go
@@ -296,9 +296,9 @@ func TestHydrateLocalHistory_DropsAgedUserFailures(t *testing.T) {
 		UpdatedAt: now.Add(-time.Minute),
 	}
 	h := hydrateLocalHistory(persisted, now, 5*time.Minute)
-	lastDelay, _, _, userFails := h.snapshot(now, 5*time.Minute)
+	lastDelay, _, _, userFailCount := h.snapshot(now, 5*time.Minute)
 	assert.Equal(t, uint32(120), lastDelay)
-	assert.Len(t, userFails, 1, "stale user-failure timestamp must be dropped on hydrate")
+	assert.Equal(t, uint32(1), userFailCount, "stale user-failure timestamp must be dropped on hydrate")
 }
 
 func TestBehaviorFor_Timeouts(t *testing.T) {
@@ -566,9 +566,7 @@ func (stallConn) SetReadDeadline(time.Time) error  { return nil }
 func (stallConn) SetWriteDeadline(time.Time) error { return nil }
 
 func TestDataPlaneStream_StallSuppressedUntilProven(t *testing.T) {
-	// A handshake-only conn that never delivers payload is "established
-	// but inactive" — the stall timer fires but onStall is suppressed
-	// because provedReadBytes hasn't been crossed.
+	// A handshake-only conn never becomes proven, so idle is not a stall.
 	var calls atomic.Uint32
 	const provedReadBytes = 100
 	d := newDataPlaneStream(stallConn{}, 10*time.Millisecond, provedReadBytes,
@@ -599,7 +597,8 @@ func TestDataPlaneStream_StallFiresAfterProven(t *testing.T) {
 	_, err = d.Write([]byte("ping"))
 	require.NoError(t, err, "Write should succeed on echoConn")
 
-	require.True(t, d.lastWasWrite.Load(), "Write should set the last-was-write gate")
+	_, wasWrite := unpackActivity(d.activity.Load())
+	require.True(t, wasWrite, "Write should set the last-was-write gate")
 	// Wait past the idle window.
 	require.Eventually(t, func() bool { return calls.Load() == 1 },
 		time.Second, 5*time.Millisecond, "proven stall should have fired by now")
@@ -623,10 +622,56 @@ func TestDataPlaneStream_StallSuppressedOnReadOnlyIdle(t *testing.T) {
 	require.NoError(t, err, "Read should succeed on echoConn")
 
 	require.True(t, d.proven.Load(), "Read should have proven the conn")
-	require.False(t, d.lastWasWrite.Load(), "Read-only conn must not set the last-was-write gate")
+	_, wasWrite := unpackActivity(d.activity.Load())
+	require.False(t, wasWrite, "Read-only conn must not set the last-was-write gate")
 	time.Sleep(80 * time.Millisecond)
 	assert.Equal(t, uint32(0), calls.Load(),
 		"proven conn with read-only history must not fire stall")
+}
+
+func TestPackActivity_RoundTrip(t *testing.T) {
+	// fireStall depends on one atomic snapshot preserving both fields.
+	cases := []struct {
+		nanos    int64
+		wasWrite bool
+	}{
+		{0, false},
+		{0, true},
+		{1, false}, // odd timestamp: low bit must not leak into wasWrite
+		{1, true},
+		{123456788, true},
+		{idleForever, false},
+		{idleForever, true},
+	}
+	for _, c := range cases {
+		gotNanos, gotWrite := unpackActivity(packActivity(c.nanos, c.wasWrite))
+		assert.Equal(t, c.wasWrite, gotWrite, "wasWrite must survive the round-trip")
+		assert.Equal(t, c.nanos&^1, gotNanos, "timestamp must survive minus its low bit")
+	}
+}
+
+func TestDataPlaneStream_StallAfterReadIdleThenWrite(t *testing.T) {
+	// Read-only idle must keep the timer alive for a later unanswered Write.
+	var calls atomic.Uint32
+	const provedReadBytes = 50
+	d := newDataPlaneStream(echoConn{}, 20*time.Millisecond, provedReadBytes,
+		func(adapter.UserFailureKind) { calls.Add(1) }, nil)
+	defer d.Close()
+
+	_, err := d.Read(make([]byte, provedReadBytes))
+	require.NoError(t, err, "Read should succeed on echoConn")
+	require.True(t, d.proven.Load(), "Read should have proven the conn")
+
+	// Let several read-only idle windows lapse; each must re-arm, not fire.
+	time.Sleep(70 * time.Millisecond)
+	require.Equal(t, uint32(0), calls.Load(), "read-only idle must not stall")
+
+	// A now-unanswered Write on the still-armed watchdog must stall.
+	_, err = d.Write([]byte("ping"))
+	require.NoError(t, err, "Write should succeed on echoConn")
+	require.Eventually(t, func() bool { return calls.Load() == 1 },
+		time.Second, 5*time.Millisecond,
+		"unanswered Write after a read-idle window must still stall")
 }
 
 func TestDataPlaneStream_CloseIsIdempotent(t *testing.T) {
@@ -638,8 +683,8 @@ func TestDataPlaneStream_CloseIsIdempotent(t *testing.T) {
 func TestDataPlaneStream_NoStallAfterClose(t *testing.T) {
 	var calls atomic.Uint32
 	d := newDataPlaneStream(stallConn{}, time.Hour, 0, func(adapter.UserFailureKind) { calls.Add(1) }, nil)
-	d.proven.Store(true)       // simulate a proven conn so fireStall isn't gated on the proven check
-	d.lastWasWrite.Store(true) // ...nor on the write-without-read gate
+	d.proven.Store(true)                              // simulate a proven conn so fireStall isn't gated on the proven check
+	d.activity.Store(packActivity(idleForever, true)) // ...nor on the write-without-read or freshness gates
 	d.Close()
 	d.fireStall()
 	assert.Equal(t, uint32(0), calls.Load(), "no stall callbacks must fire after Close")
@@ -649,7 +694,7 @@ func TestDataPlanePacket_NoStallAfterClose(t *testing.T) {
 	var calls atomic.Uint32
 	d := newDataPlanePacket(stallPacketConn{}, time.Hour, 0, func(adapter.UserFailureKind) { calls.Add(1) }, nil)
 	d.proven.Store(true)
-	d.lastWasWrite.Store(true)
+	d.activity.Store(packActivity(idleForever, true))
 	d.Close()
 	d.fireStall()
 	assert.Equal(t, uint32(0), calls.Load(), "no stall callbacks must fire after Close")
@@ -1104,7 +1149,7 @@ func TestDataPlaneStream_Stall_AttributesStallKind(t *testing.T) {
 	d := newDataPlaneStream(stallConn{}, time.Hour, 0, func(k adapter.UserFailureKind) { got.Store(k) }, nil)
 	defer d.Close()
 	d.proven.Store(true)
-	d.lastWasWrite.Store(true)
+	d.activity.Store(packActivity(idleForever, true))
 	d.fireStall()
 
 	require.NotNil(t, got.Load(), "a stall must attribute a failure")


### PR DESCRIPTION
## Summary

Reduce MutableAutoSelect's steady-state CPU and memory cost — memory the priority — while preserving selection and stall-detection behavior. Two independent hot paths are addressed: the per-dial ranking allocation, and the per-connection / per-packet stall-timer machinery.

## Changes

**perf(mutableautoselect): cut per-dial allocs and per-packet timer churn**

- **Ranking hot path** (`snapshot` / `rankLocked`): `snapshot` now returns the live user-failure *count* instead of allocating and copying a `[]UserFailure` slice. `rankLocked` — the only hot-path caller, run once per member on every dial — uses only the length, so each dial drops a throwaway allocation proportional to a member's failure history.

- **Data-plane stall watchdog** (`mutableautoselect_dataplane.go`):
  - *Lazy timer creation* — the stall timer is created only on the transition to *proven* (a conn that has carried real Read traffic). Unproven conns (handshake-only, keepalive-only, short-lived) can never pass `fireStall`'s proven gate, so they no longer allocate a runtime timer at all (~147 B each). Live-timer count drops from "all conns" to "proven, open conns".
  - *Debounced re-arm* — `noteIO` stamps a monotonic activity timestamp instead of calling `timer.Reset` on every non-empty Read/Write (which took the runtime timer-heap lock per packet). `fireStall` debounces off the stamp: it re-arms while activity is fresh and fires only once the idle window has genuinely elapsed. Steady traffic now costs one timer op per idle window instead of one per packet.
  - *Monotonic clock* — the activity stamp is anchored to a monotonic epoch, so wall-clock (NTP) steps can't delay a stall or demote a healthy conn early.
  - *One word for activity and terminal state* — the timestamp, write flag, and terminal state all live in a single `atomic.Int64`. `fireStall` reads a consistent `(timestamp, wasWrite)` snapshot from one load (separate stores could pair a fresh write flag with a stale timestamp and stall a just-written conn), and stall / reset / close each claim the conn by moving that word to a terminal sentinel — stall via CAS from its sampled value, reset/close unconditionally. Exactly one claim wins, so the failure kind is never decided by a downstream race, `fireStall` can't demote a conn whose activity was republished after it sampled, and `noteIO` stops republishing activity once terminal.

- **Tests**: added `TestPackActivity_RoundTrip` (packing invariant), `TestDataPlaneStream_StallAfterReadIdleThenWrite` (the timer keeps watching a later unanswered Write after a read-idle window), and `TestClaimStall_AbortsOnConcurrentActivity` (a stall aborts when activity was republished since it was sampled); updated existing watchdog tests to the unified activity word. Also fixed a test-only data race in the `makeHooks` failure-kind tests, which read `localHistory` fields without `h.mu` while the background `runLadder` mutated them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection stall detection during periods of read-only activity.
  * Ensured monitoring continues reliably after connections become validated.
  * Improved timer handling for connection activity, including concurrent access and shutdown scenarios.
  * Prevented late activity reports from affecting connections that have already closed or reset.

* **Performance**
  * Reduced overhead when tracking recent user failures by avoiding unnecessary data copying.
  * Improved reliability and efficiency when recording connection activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
