### PR TITLE
fix(clientcontext): pass destination directly on UDP client-info

### DIFF
--- a/tracker/clientcontext/injector.go
+++ b/tracker/clientcontext/injector.go
@@ -248,28 +248,13 @@ func (c *writePacketConn) sendInfo(conn net.PacketConn) error {
 	if err != nil {
 		return fmt.Errorf("marshaling client info: %w", err)
 	}
-	dest := c.metadata.Destination
-	var addr *net.UDPAddr
-	if dest.IsIP() {
-		addr = dest.UDPAddr()
-	} else if len(c.metadata.DestinationAddresses) > 0 {
-		// Use the already-resolved address from the routing pipeline. The
-		// destination was resolved earlier during DNS routing; re-resolving
-		// here is redundant and adds latency to every packet connection.
-		addr = &net.UDPAddr{
-			IP:   c.metadata.DestinationAddresses[0].AsSlice(),
-			Port: int(dest.Port),
-		}
-	} else if addr, err = net.ResolveUDPAddr("udp", dest.String()); err != nil {
-		return fmt.Errorf("resolving destination %s: %w", dest, err)
-	}
 	// Best effort: conns that don't support deadlines keep the old unbounded
 	// behavior rather than failing the exchange.
 	_ = conn.SetDeadline(time.Now().Add(sendInfoTimeout))
 	defer conn.SetDeadline(time.Time{})
 
 	packet := append([]byte(packetPrefix), buf...)
-	if _, err = conn.WriteTo(packet, addr); err != nil {
+	if _, err = conn.WriteTo(packet, c.metadata.Destination); err != nil {
 		return fmt.Errorf("writing packet: %w", err)
 	}
 

--- a/tracker/clientcontext/injector.go
+++ b/tracker/clientcontext/injector.go
@@ -248,13 +248,26 @@ func (c *writePacketConn) sendInfo(conn net.PacketConn) error {
 	if err != nil {
 		return fmt.Errorf("marshaling client info: %w", err)
 	}
+	dest := c.metadata.Destination
+	var addr net.Addr
+	switch {
+	case dest.IsIP():
+		addr = dest.UDPAddr()
+	case len(c.metadata.DestinationAddresses) > 0:
+		addr = &net.UDPAddr{
+			IP:   c.metadata.DestinationAddresses[0].AsSlice(),
+			Port: int(dest.Port),
+		}
+	default:
+		addr = dest
+	}
 	// Best effort: conns that don't support deadlines keep the old unbounded
 	// behavior rather than failing the exchange.
 	_ = conn.SetDeadline(time.Now().Add(sendInfoTimeout))
 	defer conn.SetDeadline(time.Time{})
 
 	packet := append([]byte(packetPrefix), buf...)
-	if _, err = conn.WriteTo(packet, c.metadata.Destination); err != nil {
+	if _, err = conn.WriteTo(packet, addr); err != nil {
 		return fmt.Errorf("writing packet: %w", err)
 	}
 

--- a/tracker/clientcontext/injector_test.go
+++ b/tracker/clientcontext/injector_test.go
@@ -74,41 +74,39 @@ func TestSendInfoWithDomainAndResolvedAddresses(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestSendInfoWithDomainFallsBackToDNS(t *testing.T) {
-	serverAddr := startUDPEchoOK(t)
-
-	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer conn.Close()
-
-	// Domain destination with no DestinationAddresses — falls back to DNS resolution.
-	// "localhost" resolves to 127.0.0.1 so this reaches our echo server.
-	dest := M.Socksaddr{Fqdn: "localhost", Port: uint16(serverAddr.Port)}
-
-	wpc := &writePacketConn{
-		metadata: adapter.InboundContext{Destination: dest},
-		info:     &ClientInfo{DeviceID: "test-device", Platform: "test"},
-	}
-
-	err = wpc.sendInfo(conn)
-	assert.NoError(t, err)
+type recordingPacketConn struct {
+	writtenAddr net.Addr
 }
 
-func TestSendInfoWithUnresolvableDomainFails(t *testing.T) {
-	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer conn.Close()
+func (c *recordingPacketConn) ReadFrom(p []byte) (int, net.Addr, error) {
+	n := copy(p, []byte("OK"))
+	return n, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1}, nil
+}
 
-	dest := M.Socksaddr{Fqdn: "this.domain.does.not.exist.invalid", Port: 12345}
+func (c *recordingPacketConn) WriteTo(p []byte, addr net.Addr) (int, error) {
+	c.writtenAddr = addr
+	return len(p), nil
+}
+
+func (c *recordingPacketConn) Close() error                       { return nil }
+func (c *recordingPacketConn) LocalAddr() net.Addr                { return &net.UDPAddr{} }
+func (c *recordingPacketConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *recordingPacketConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *recordingPacketConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+func TestSendInfoWithDomainPassesThrough(t *testing.T) {
+	conn := &recordingPacketConn{}
+
+	dest := M.Socksaddr{Fqdn: "example.com", Port: 443}
 
 	wpc := &writePacketConn{
 		metadata: adapter.InboundContext{Destination: dest},
 		info:     &ClientInfo{DeviceID: "test-device", Platform: "test"},
 	}
 
-	err = wpc.sendInfo(conn)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "resolving destination")
+	err := wpc.sendInfo(conn)
+	require.NoError(t, err)
+	assert.Equal(t, dest, conn.writtenAddr)
 }
 
 func setSendInfoTimeout(t *testing.T, d time.Duration) {


### PR DESCRIPTION
## What

The UDP path of the client-context injector (`writePacketConn.sendInfo`) built a
`*net.UDPAddr` for the destination before writing the `CLIENTINFO` packet,
resolving the host itself when it had neither an IP nor a pre-resolved address:

```go
} else if addr, err = net.ResolveUDPAddr("udp", dest.String()); err != nil {
```

Under a fakeip DNS setup a UDP flow arrives with its **domain** in
`metadata.Destination` and nothing in `metadata.DestinationAddresses` (resolution
is deferred to the exit proxy). That drove the code into the `net.ResolveUDPAddr`
branch, whose lookup routes back through the tunnel's own DNS and times out — so
the `CLIENTINFO` packet was never sent, the handshake-success report failed, and
the flow was torn down after the resolver's retry budget (~20s). The deadline set
just below the resolve never bounded it.

## Fix

Pass `c.metadata.Destination` (a domain-bearing `M.Socksaddr`) straight to
`conn.WriteTo` and drop the address-construction block. This matches how the
surrounding data plane already writes to the same outbound packet conn: the
destination is carried to the proxy, which resolves it at the exit.
`M.SocksaddrFromNet` returns an already-`Socksaddr` argument unchanged, so the
domain is preserved rather than coerced to an IP, and no client-side DNS lookup
runs on the send path.

## Effect

UDP client-info delivery no longer stalls or fails on fakeip/domain destinations,
so those flows carry the client info instead of being dropped by the 20s resolver
timeout. Verified against a macOS build where datacap usage had been under-counting
UDP-carried traffic; usage is attributed after the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UDP packet delivery by sending data directly to the configured destination.
  * Preserved existing send timeouts and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->