### PR TITLE
metrics: export histograms with delta temporality

### DIFF
--- a/otel/otel.go
+++ b/otel/otel.go
@@ -36,7 +36,7 @@ func Enabled() bool {
 
 func InitGlobalMeterProvider(attrs ...attribute.KeyValue) (func(), error) {
 	exp, err := otlpmetrichttp.New(context.Background(),
-		otlpmetrichttp.WithTemporalitySelector(deltaForCounters),
+		otlpmetrichttp.WithTemporalitySelector(deltaTemporality),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("new meter provider: %w", err)
@@ -78,16 +78,24 @@ func InitGlobalTracerProvider(attrs ...attribute.KeyValue) (func(), error) {
 	}, nil
 }
 
-func deltaForCounters(kind sdkmetric.InstrumentKind) metricdata.Temporality {
-	switch kind {
-	case sdkmetric.InstrumentKindCounter,
-		sdkmetric.InstrumentKindUpDownCounter,
-		sdkmetric.InstrumentKindObservableCounter,
-		sdkmetric.InstrumentKindObservableUpDownCounter:
-		return metricdata.DeltaTemporality
-	default:
-		return metricdata.CumulativeTemporality
-	}
+// deltaTemporality exports every instrument kind with delta temporality,
+// including histograms.
+//
+// Delta is what lets the ops collector aggregate an attribute away. Stripping
+// a label from a cumulative stream merges independent monotonic series whose
+// resets are interleaved, which corrupts rate() silently rather than failing;
+// delta datapoints just sum. The ops collector relies on this to drop
+// route.id/instance.id/host.name from proxy.session.goodput, whose ~10.8k
+// distinct host.name values were driving the histogram to ~55M series (see
+// getlantern/engineering#3831).
+//
+// Temporality is chosen per instrument KIND at the exporter, so this covers
+// every histogram this binary emits, not just goodput. The other one is
+// sing.connection_duration, which the ops collector drops outright (no
+// readers), so goodput is the only histogram whose temporality is observable
+// downstream.
+func deltaTemporality(sdkmetric.InstrumentKind) metricdata.Temporality {
+	return metricdata.DeltaTemporality
 }
 
 // buildResource creates an OTEL resource with a default service name

--- a/otel/otel_test.go
+++ b/otel/otel_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 	sdkotel "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	semconv "github.com/getlantern/semconv"
 )
 
@@ -162,6 +164,12 @@ func TestInitTelemetry(t *testing.T) {
 	require.NoError(t, err)
 	counter.Add(ctx, 1)
 
+	// A histogram too: proxy.session.goodput is one, and histograms were the
+	// last kind still exporting cumulative.
+	hist, err := sdkotel.Meter("test").Float64Histogram("test.histogram")
+	require.NoError(t, err)
+	hist.Record(ctx, 42)
+
 	// Shutdown flushes pending exports.
 	shutdownTracer()
 	shutdownMeter()
@@ -186,5 +194,40 @@ func TestInitTelemetry(t *testing.T) {
 			"collector logs should contain proxy.name attribute")
 		assert.Contains(c, output, "test.counter",
 			"collector logs should contain the metric name")
+		assert.Contains(c, output, "test.histogram",
+			"collector logs should contain the histogram name")
+		// The histogram must arrive as Delta. The ops collector aggregates
+		// resource attributes away on proxy.session.goodput, which silently
+		// corrupts rate() on a cumulative stream (its per-host series carry
+		// interleaved resets), and lantern-cloud reads the paired .count with
+		// timeAggregation=sum, which only matches delta. A name-only assertion
+		// would not catch a revert to cumulative.
+		assert.NotContains(c, output, "AggregationTemporality: Cumulative",
+			"every stream this binary exports must be delta")
 	}, 10*time.Second, 500*time.Millisecond)
+}
+
+// TestDeltaTemporalityCoversHistograms guards the exporter's temporality
+// selection directly, without needing a collector.
+//
+// InstrumentKindHistogram is the one that matters: it was cumulative while
+// counters were already delta, and it is the kind proxy.session.goodput uses.
+// Delta is required for the ops collector to strip route.id/instance.id/
+// host.name from that metric — aggregating an identifier away merges the
+// matching series, and merging cumulative streams interleaves their resets,
+// corrupting rate() with no error.
+func TestDeltaTemporalityCoversHistograms(t *testing.T) {
+	kinds := []sdkmetric.InstrumentKind{
+		sdkmetric.InstrumentKindCounter,
+		sdkmetric.InstrumentKindUpDownCounter,
+		sdkmetric.InstrumentKindHistogram,
+		sdkmetric.InstrumentKindGauge,
+		sdkmetric.InstrumentKindObservableCounter,
+		sdkmetric.InstrumentKindObservableUpDownCounter,
+		sdkmetric.InstrumentKindObservableGauge,
+	}
+	for _, k := range kinds {
+		assert.Equal(t, metricdata.DeltaTemporality, deltaTemporality(k),
+			"instrument kind %v must export delta", k)
+	}
 }


### PR DESCRIPTION
## What

Extend `deltaForCounters` to every instrument kind (renamed `deltaTemporality`), so histograms — notably `proxy.session.goodput` — export as **delta** instead of cumulative.

Part of getlantern/engineering#3831. Companion PRs: getlantern/http-proxy#683 (same change), getlantern/lantern-cloud (collector + readers), getlantern/lantern-dashboard (query hint).

## Why

SigNoz reported `proxy.session.goodput.bucket` at **~55M unique time series**, timing out every query over a window of ~1 week or longer.

Measured cause, from `signoz_check_metric_cardinality` over 7d: `host.name` has **10,854** distinct values on this metric, with `route.id` and `instance.id` in the same range. Times 15 bucket boundaries × track × ~200 client countries.

**No reader anywhere uses those labels.** Audited org-wide (`gh search code --owner getlantern` plus every local clone): the experiment evaluator (`cmd/api/experiment/signoz.go`) and lantern-dashboard both slice goodput by `track` and `geo.country.iso_code` only, and the metric backs 0 dashboards and 0 alerts.

They ride along because `deploy/packer/otelcol.yaml` tags every metric via `OTEL_RESOURCE_ATTRIBUTES` + `resourcedetection`, and SigNoz promotes resource attributes to queryable labels. Per-host goodput was never a deliberate choice — the emitter comment in `tracker/metrics/metrics.go` says only `track`, `geo.country.iso_code`, and `network.io.direction` are meant to be sliceable.

The fix is to aggregate them away in the ops collector, but that is **only safe on a delta stream**. Stripping a label from a cumulative stream merges independent monotonic series whose resets interleave, corrupting `rate()` silently instead of failing.

## Scope note

Temporality is selected per instrument **kind**, so this also covers `sing.connection_duration` — which the ops collector drops outright (no readers). Goodput is the only histogram here whose temporality is observable downstream.

## Deploy ordering (important)

lantern-cloud switches the paired `.count` read from `increase` to `sum` to match delta. The two are **not** interchangeable: measured on RU over one day of still-cumulative data, `sum` returned **3.59e9** sessions where `increase` returned **7.0e6**, a ~500x overcount that silently clears every sample floor in the evaluator and the impact ledger.

So:
1. Hold `experiment_evaluator_autoact_enabled` **off**.
2. Land this + http-proxy + lantern-cloud together; roll the fleet.
3. Confirm every host reports delta, then re-enable.

## Testing

- `go build ./otel/ ./tracker/...` and `go vet ./otel/ ./tracker/metrics/` clean.
- Delta/strip behavior verified end to end against otelcol-contrib 0.146.0 with the real ops config: goodput loses `host.name`/`route.id`/`instance.id` while `proxy.io` and `system.cpu.utilization` keep them.

/cc @jay-418 @Crosse


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metric export consistency by using delta temporality across all metric instrument types, including histograms.
  * Prevented non-counter metrics from being exported with cumulative temporality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->