### PR TITLE
fix(gcore): bound import concurrency so gcore stops reaping queued tasks

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -122,28 +122,39 @@ jobs:
           # in, since its provider fails outright where the image is missing. A dispatch
           # may narrow it for a scoped test; nothing else should.
           # 6 not added because luxembourg is a "special" region
-          default_regions="196,184,180,176,164,152,148,140,136,128,124,116,108,104,100,92,88,84,80,76,68,64,50,46,34,30,26,18,14"
+          #
+          # 18 and 68 are deliberately absent: lantern-cloud has ZERO routes with
+          # provider_region_id 18 or 68, so importing there buys nothing and each import
+          # occupies one of the few concurrent slots gcore grants the project (see
+          # MAX_INFLIGHT in deploy/packer/gcore-publish.sh). They are NOT excluded for
+          # being broken — both failed runs 32154320626/32158844992 reaped them with the
+          # same generic "not started within 10 minutes" scheduler message that also hit
+          # 30/64/76, and both regions do hold a healthy lantern-box image today. Add
+          # them back if we ever route there.
+          default_regions="196,184,180,176,164,152,148,140,136,128,124,116,108,104,100,92,88,84,80,76,64,50,46,34,30,26,14"
           regions="${INPUT_REGIONS:-$default_regions}"
           echo "regions=$regions" >> "$GITHUB_OUTPUT"
           echo "gcore regions: $regions"
           # Budgeted here because GitHub expressions have no arithmetic, so
-          # timeout-minutes cannot scale with the region count. The poll window is
-          # SHARED, not per-region: 55min build/upload/teardown + 35min for
-          # POLL_ATTEMPTS(120) x POLL_INTERVAL_SECS(15) and visibility/delete polling
-          # + 3/region for the staggered POSTs and checks. Keep in step with
-          # gcore-publish.sh's poll defaults. The real ceiling on many regions is
-          # POLL_ATTEMPTS, not this timeout.
+          # timeout-minutes cannot scale with the region count. Imports now run at most
+          # MAX_INFLIGHT(6) at a time, so wall-clock is per WAVE of 6 regions rather
+          # than one shared poll window: 55min build/upload/teardown + 35min per wave
+          # (observed gcore import time is 8-16min typical and has reached 75min) +
+          # 1/region for the staggered POSTs. Keep MAX_INFLIGHT here in step with
+          # gcore-publish.sh. This is a ceiling, not the expected runtime.
           count=$(echo "$regions" | tr ',' '\n' | grep -c '[^[:space:]]' || true)
           # Empty or 0 falls back to one region, never a nonsensical timeout.
           [ "${count:-0}" -gt 0 ] 2>/dev/null || count=1
-          timeout=$((55 + 35 + count * 3))
+          max_inflight=6
+          waves=$(( (count + max_inflight - 1) / max_inflight ))
+          timeout=$((55 + waves * 35 + count))
           # GitHub caps hosted-runner jobs at 360min.
           if [ "$timeout" -gt 350 ]; then
             timeout=350
-            echo "::warning::gcore build timeout capped at 350min for ${count} regions — raise POLL_ATTEMPTS or split the region list across runs rather than growing this further"
+            echo "::warning::gcore build timeout capped at 350min for ${count} regions — split the region list across runs, or raise MAX_INFLIGHT if gcore will actually schedule more imports at once, rather than growing this further"
           fi
           echo "timeout=$timeout" >> "$GITHUB_OUTPUT"
-          echo "gcore build timeout: ${timeout}min (${count} region(s))"
+          echo "gcore build timeout: ${timeout}min (${count} region(s), ${waves} wave(s) of ${max_inflight})"
 
   # Prune old images before building (avoids provider quota limits)
   prune:

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -44,6 +44,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       matrix: ${{ steps.matrix.outputs.matrix }}
       gcore_regions: ${{ steps.gcore.outputs.regions }}
+      gcore_prune_regions: ${{ steps.gcore.outputs.prune_regions }}
       gcore_timeout: ${{ steps.gcore.outputs.timeout }}
     steps:
       - name: Checkout (full history — needed to find the latest tag)
@@ -135,26 +136,46 @@ jobs:
           regions="${INPUT_REGIONS:-$default_regions}"
           echo "regions=$regions" >> "$GITHUB_OUTPUT"
           echo "gcore regions: $regions"
+          # Prune covers a SUPERSET of the publish list: a region we stopped publishing to
+          # still holds images from when we did, and dropping it from both lists would
+          # strand those against the account's image quota with nothing left to collect
+          # them. Retired regions only ever shrink this list's work, since there is
+          # nothing new to find there.
+          retired_regions="18,68"
+          echo "prune_regions=${regions},${retired_regions}" >> "$GITHUB_OUTPUT"
+          echo "gcore prune regions: ${regions},${retired_regions}"
           # Budgeted here because GitHub expressions have no arithmetic, so
-          # timeout-minutes cannot scale with the region count. Imports now run at most
-          # MAX_INFLIGHT(6) at a time, so wall-clock is per WAVE of 6 regions rather
-          # than one shared poll window: 55min build/upload/teardown + 35min per wave
-          # (observed gcore import time is 8-16min typical and has reached 75min) +
-          # 1/region for the staggered POSTs. Keep MAX_INFLIGHT here in step with
-          # gcore-publish.sh. This is a ceiling, not the expected runtime.
+          # timeout-minutes cannot scale with the region count. DERIVED from
+          # gcore-publish.sh's knobs, which must be kept in step with the values below —
+          # a job killed mid-publish loses the summary naming which regions actually
+          # landed, which is the output an operator needs most.
+          #
+          # Slots are a sliding window, not lockstep waves: a slow region holds one slot
+          # while the others keep cycling. So the publish needs whichever is larger of
+          #   - one region's own worst case: IMPORT_ATTEMPTS x POLL_ATTEMPTS x interval
+          #   - the aggregate: one wave-equivalent per MAX_INFLIGHT regions at 35min,
+          #     against observed import times of 8-16min typical and a 75min tail
+          # plus 1min/region for the staggered POSTs and visibility checks.
           count=$(echo "$regions" | tr ',' '\n' | grep -c '[^[:space:]]' || true)
           # Empty or 0 falls back to one region, never a nonsensical timeout.
           [ "${count:-0}" -gt 0 ] 2>/dev/null || count=1
           max_inflight=6
+          import_attempts=2
+          poll_attempts=360
+          poll_interval_secs=15
           waves=$(( (count + max_inflight - 1) / max_inflight ))
-          timeout=$((55 + waves * 35 + count))
+          per_region=$(( import_attempts * poll_attempts * poll_interval_secs / 60 ))
+          aggregate=$(( waves * 35 ))
+          publish=$aggregate
+          [ "$per_region" -gt "$publish" ] && publish=$per_region
+          timeout=$((55 + publish + count))
           # GitHub caps hosted-runner jobs at 360min.
           if [ "$timeout" -gt 350 ]; then
             timeout=350
             echo "::warning::gcore build timeout capped at 350min for ${count} regions — split the region list across runs, or raise MAX_INFLIGHT if gcore will actually schedule more imports at once, rather than growing this further"
           fi
           echo "timeout=$timeout" >> "$GITHUB_OUTPUT"
-          echo "gcore build timeout: ${timeout}min (${count} region(s), ${waves} wave(s) of ${max_inflight})"
+          echo "gcore build timeout: ${timeout}min (${count} region(s), ${waves} wave(s) of ${max_inflight}; publish allowance ${publish}min = max(per-region ${per_region}, aggregate ${aggregate}))"
 
   # Prune old images before building (avoids provider quota limits)
   prune:
@@ -205,7 +226,7 @@ jobs:
         env:
           GCORE_API_KEY: ${{ secrets.GCORE_API_KEY }}
           GCORE_PROJECT_ID: ${{ secrets.GCORE_PROJECT_ID }}
-          GCORE_REGIONS: ${{ needs.prepare.outputs.gcore_regions }}
+          GCORE_REGIONS: ${{ needs.prepare.outputs.gcore_prune_regions }}
         run: |
           KEEP=3
           API="https://api.gcore.com/cloud/v1"

--- a/deploy/packer/README.md
+++ b/deploy/packer/README.md
@@ -186,9 +186,32 @@ provider's image store) gcore uses a **build → host → import** pipeline:
 3. `deploy/packer/gcore-publish.sh` imports that URL into each target region via
    `POST cloud/v1/downloadimage/{project}/{region}` (name `lantern-box-<version>`,
    `architecture=x86_64`, `os_type=linux`), polls each task to `FINISHED`, and checks
-   the created image's `visibility`. POSTs are spaced by `IMPORT_STAGGER_SECS`
-   (default 30) because gcore reaps a task not *started* within 10min of its own
-   `created_on` — submitting ~30 at once gave them one deadline it could not meet.
+   the created image's `visibility`.
+
+   **Imports run at most `MAX_INFLIGHT` (default 6) at a time, and that bound is the
+   point.** Gcore fails any task it has not *started* within 10min of that task's own
+   `created_on`, while its per-project scheduler runs only a handful of image imports
+   concurrently and each takes 8-16min (observed tail: 75min). Creating all ~30 imports
+   up front therefore guaranteed the tail of the queue was reaped before it ever ran:
+   in runs 32154320626 and 32158844992 *every* errored region came back with gcore's
+   `Task was not started within 10 minutes of creation. Marked as failed by scheduler
+   cleanup.` `IMPORT_STAGGER_SECS` (default 30) alone did not fix it, because a fixed
+   stagger still lets the queue grow without limit — it now just spaces the POSTs that
+   refill a freed slot.
+
+   A region is re-POSTed once (`IMPORT_ATTEMPTS`, default 2) if its import ERRORs or
+   outruns its polls; a retry reuses the already-hosted qcow2, so it costs one API call
+   and no re-upload. `POLL_ATTEMPTS` (default 360) is **per region per attempt**, not a
+   budget shared across regions, so one slow region cannot spend what the others still
+   need. On ERROR the whole gcore task body is dumped to the log rather than a field
+   this script picked in advance — that reaper message was invisible for two builds
+   precisely because only `state` was read.
+
+   The publish ends with a summary naming which regions received the image and which
+   did not, and fails the job when any region is missing. Landing in 27 of 29 regions
+   is a different event from landing nowhere, and the old all-or-nothing
+   `N region import(s) failed` hid the difference from whoever had to judge whether
+   production was affected.
 
 **Image visibility** is read-only in gcore's API: neither
 `POST cloud/v1/downloadimage/...` nor `PATCH cloud/v1/images/...` accepts the

--- a/deploy/packer/README.md
+++ b/deploy/packer/README.md
@@ -259,26 +259,33 @@ window were ever caught; a per-run value is worthless once the job ends. Keep an
 replacement hex or alphanumeric: it is interpolated into the cloud-init YAML and
 into `shutdown_command`'s single-quoted shell string.
 
-**Imports run concurrently.** There is one staged object and one URL, and each region's
-importer fetches it independently, so the transfers were never serial — only the waiting
-was. `gcore-publish.sh` starts every region's import first, then polls all outstanding
-tasks together, one sleep per round rather than per region. Wall-clock is the slowest
-single region instead of the sum, which also shortens the window the qcow2 spends
-publicly readable. A region whose import is rejected is counted as a failure without
+**Imports run concurrently, but bounded.** There is one staged object and one URL, and
+each region's importer fetches it independently, so the transfers were never serial —
+only the waiting was. `gcore-publish.sh` keeps at most `MAX_INFLIGHT` imports
+outstanding, POSTing a region's import only once a slot frees, then polls every
+outstanding task together, one sleep per round rather than per region. The bound is not
+a throughput tuning knob: it exists because gcore reaps a task it has not started within
+10min of that task's `created_on` (see step 3 above). A region whose import is rejected,
+errors, or outruns its polls is retried once and otherwise recorded as missing, without
 holding up the others.
 
-The build job's timeout is budgeted in the `prepare` job (55min fixed + a 35min shared
-poll window + 3min per region, capped at 350) rather than in `timeout-minutes`, which
-cannot do arithmetic. Adding regions therefore needs no timeout edit and costs little
-wall-clock. The per-region term is not the poll window — it covers the sequential import
-POSTs and visibility checks plus the fact that every region pulls the same object from one
-bucket at once, so shared egress makes each import slower than a solo one.
+Slots behave as a sliding window rather than lockstep waves — a slow region holds one
+slot while the others keep cycling.
 
-With a long region list the binding constraint is **not** this timeout but `POLL_ATTEMPTS`
-(120 x 15s = 30min per task): if shared bucket egress pushes a single import past that,
-its poll gives up however long the job is allowed to run. That is the knob to raise
-first, and getting killed mid-import is worth avoiding since it leaves orphaned gcore
-tasks.
+The build job's timeout is budgeted in the `prepare` job rather than in
+`timeout-minutes`, which cannot do arithmetic. It is **derived from the publisher's own
+knobs**, so the two must be kept in step: 55min fixed for build/upload/teardown, plus a
+publish allowance of whichever is larger of one region's worst case
+(`IMPORT_ATTEMPTS x POLL_ATTEMPTS x POLL_INTERVAL_SECS`, 180min at the defaults) and the
+aggregate (one wave-equivalent per `MAX_INFLIGHT` regions at 35min each), plus 1min per
+region for the staggered POSTs and visibility checks, capped at 350. Adding regions
+therefore needs no timeout edit.
+
+Budgeting it this way rather than under-budgeting matters because a job killed mid-publish
+loses the summary naming which regions actually landed — the output an operator needs
+most — and leaves orphaned gcore tasks behind. If the cap is ever hit, split the region
+list across runs, or raise `MAX_INFLIGHT` if gcore will genuinely schedule more imports
+at once.
 
 Prune lists each region **twice** — `?private=true` plus unfiltered — and unions the
 results by image ID, because a `shared` or `public` image never appears in the

--- a/deploy/packer/gcore-publish.sh
+++ b/deploy/packer/gcore-publish.sh
@@ -51,6 +51,34 @@ IMPORT_STAGGER_SECS="${IMPORT_STAGGER_SECS:-30}"
 AUTH="Authorization: APIKey ${GCORE_API_KEY}"
 IMAGE_NAME="lantern-box-${VERSION}"
 
+# require_int NAME VALUE MIN -> fail unless VALUE is an integer >= MIN. These knobs are
+# loop bounds, and a bad one does not degrade gracefully: MAX_INFLIGHT=0 (or a typo that
+# is not a number at all) makes the fill loop POST nothing while regions stay QUEUED
+# forever, so the publish hangs until the job timeout instead of failing. Validated once,
+# here, rather than defended at each comparison.
+require_int() {
+  local name="$1" value="$2" min="$3"
+  case "$value" in
+    '' | *[!0-9]*)
+      echo "::error::${name} must be a non-negative integer, got '${value}'" >&2
+      exit 1 ;;
+  esac
+  if [ "$value" -lt "$min" ]; then
+    echo "::error::${name} must be >= ${min}, got '${value}'" >&2
+    exit 1
+  fi
+}
+
+# Loop bounds that must allow at least one pass.
+require_int POLL_ATTEMPTS "$POLL_ATTEMPTS" 1
+require_int MAX_INFLIGHT "$MAX_INFLIGHT" 1
+require_int IMPORT_ATTEMPTS "$IMPORT_ATTEMPTS" 1
+require_int DELETE_POLL_ATTEMPTS "$DELETE_POLL_ATTEMPTS" 1
+require_int VISIBILITY_ATTEMPTS "$VISIBILITY_ATTEMPTS" 1
+# Sleep lengths, where 0 is meaningful (tests disable waiting entirely).
+require_int POLL_INTERVAL_SECS "$POLL_INTERVAL_SECS" 0
+require_int IMPORT_STAGGER_SECS "$IMPORT_STAGGER_SECS" 0
+
 # import_region REGION -> prints the created task ID on stdout.
 import_region() {
   local region="$1" body resp http task

--- a/deploy/packer/gcore-publish.sh
+++ b/deploy/packer/gcore-publish.sh
@@ -15,7 +15,16 @@
 # Optional env (mainly for tests):
 #   CURL (default "curl"), SLEEP (default "sleep"),
 #   GCORE_API_BASE (default "https://api.gcore.com/cloud/v1"),
-#   POLL_ATTEMPTS (default 120), POLL_INTERVAL_SECS (default 15),
+#   POLL_ATTEMPTS (default 360) — polls allowed PER REGION PER ATTEMPT, not a budget
+#   shared across regions. A region only consumes polls while it holds a slot, and
+#   gcore's observed import tail reaches ~75min, so this is 90min at the default
+#   interval rather than the 30min that used to reap healthy imports.
+#   POLL_INTERVAL_SECS (default 15),
+#   MAX_INFLIGHT (default 6) — how many imports may be outstanding at once. THE
+#   important knob: gcore fails any task it has not STARTED within 10min of that
+#   task's own created_on, so a task must not be created until gcore can plausibly
+#   start it. See main().
+#   IMPORT_ATTEMPTS (default 2) — import tries per region before giving up on it.
 #   DELETE_POLL_ATTEMPTS (default 20) — deletes are quick, and this only runs on the
 #   already-failing public-image path, so it must not eat the whole job timeout.
 #   VISIBILITY_ATTEMPTS (default 3) — tries for each of the two visibility lookups,
@@ -32,8 +41,10 @@ set -euo pipefail
 CURL="${CURL:-curl}"
 SLEEP="${SLEEP:-sleep}"
 API_BASE="${GCORE_API_BASE:-https://api.gcore.com/cloud/v1}"
-POLL_ATTEMPTS="${POLL_ATTEMPTS:-120}"
+POLL_ATTEMPTS="${POLL_ATTEMPTS:-360}"
 POLL_INTERVAL_SECS="${POLL_INTERVAL_SECS:-15}"
+MAX_INFLIGHT="${MAX_INFLIGHT:-6}"
+IMPORT_ATTEMPTS="${IMPORT_ATTEMPTS:-2}"
 DELETE_POLL_ATTEMPTS="${DELETE_POLL_ATTEMPTS:-20}"
 VISIBILITY_ATTEMPTS="${VISIBILITY_ATTEMPTS:-3}"
 IMPORT_STAGGER_SECS="${IMPORT_STAGGER_SECS:-30}"
@@ -65,6 +76,35 @@ import_region() {
     return 1
   fi
   printf '%s' "$task"
+}
+
+# fetch_task TASK_ID -> print the task's raw JSON body. Non-zero on a transport
+# failure, which callers treat as "state not known yet" and retry. The body is kept
+# whole rather than reduced to .state so an ERROR can be reported verbatim: gcore's
+# failure detail lives in fields this script deliberately does not enumerate.
+fetch_task() {
+  "$CURL" -sS -f -H "$AUTH" "${API_BASE}/tasks/${1}"
+}
+
+# dump_task_body WHAT BODY -> echo a gcore task body to stderr for a human. Printed
+# in full, pretty-printed when it parses and raw when it does not, because guessing
+# which field carries the reason is how the "scheduler cleanup" failures stayed
+# invisible across two builds.
+dump_task_body() {
+  local what="$1" body="$2"
+  if [ -z "$body" ]; then
+    echo "  ${what}: gcore returned no body" >&2
+    return 0
+  fi
+  echo "  ${what}: gcore task body follows" >&2
+  # Captured rather than piped straight to stderr: `jq ... 2>/dev/null >&2` points
+  # stdout at whatever fd2 already is, which by then is /dev/null — the body vanished.
+  local pretty
+  if pretty=$(printf '%s\n' "$body" | jq . 2>/dev/null) && [ -n "$pretty" ]; then
+    printf '%s\n' "$pretty" >&2
+  else
+    printf '%s\n' "$body" >&2
+  fi
 }
 
 # poll_task REGION TASK_ID [WHAT] [MAX_ATTEMPTS] -> 0 on FINISHED, 1 on ERROR/timeout.
@@ -174,86 +214,183 @@ report_visibility() {
   esac
 }
 
-# Imports run concurrently: the *waiting* was the serial part, since draining each task
-# before starting the next made wall-clock the SUM of the imports. Start them all, then
-# poll every outstanding task per round with one sleep. Wall-clock becomes the slowest
-# single region, which also shortens the qcow2's public window. Plain indexed arrays, no
-# associative ones, so this still runs under bash 3.2.
+# Per-region bookkeeping as parallel indexed arrays (no associative arrays, so this
+# still runs under bash 3.2). Global rather than main()-local so retire_region can
+# mutate them.
+R_IDS=()     # region id
+R_TASKS=()   # current task id, "" before the first POST
+R_STATES=()  # QUEUED | INFLIGHT | DONE | FAILED
+R_POLLS=()   # polls consumed by the current attempt
+R_TRIES=()   # import attempts started
+R_WHY=()     # why a FAILED region failed, for the summary
+
+# retire_region INDEX REASON -> a region's attempt just ended badly. Requeue it when it
+# still has an attempt left, otherwise mark it FAILED and record why. A requeue re-POSTs
+# against the same already-hosted qcow2, so a retry costs one API call and no re-upload.
+retire_region() {
+  local i="$1" reason="$2"
+  if [ "${R_TRIES[$i]}" -lt "$IMPORT_ATTEMPTS" ]; then
+    echo "::warning::region ${R_IDS[$i]}: ${reason} — requeueing (attempt $((${R_TRIES[$i]} + 1))/${IMPORT_ATTEMPTS})" >&2
+    R_STATES[i]=QUEUED
+    R_TASKS[i]=""
+    R_POLLS[i]=0
+    return 0
+  fi
+  echo "::error::region ${R_IDS[$i]}: ${reason} — no attempts left (${R_TRIES[$i]}/${IMPORT_ATTEMPTS})" >&2
+  R_STATES[i]=FAILED
+  R_WHY[i]="$reason"
+}
+
+# summarize -> report which regions ended up with the image and which did not, then set
+# the exit status. Landing in 27 of 29 regions is not the same event as landing nowhere,
+# and the old all-or-nothing "N region import(s) failed" hid the difference — including
+# from whoever has to decide whether production was actually affected.
+summarize() {
+  local i ok=() bad=() n_ok=0 n_bad=0
+  for i in "${!R_IDS[@]}"; do
+    if [ "${R_STATES[$i]}" = "DONE" ]; then
+      ok+=("${R_IDS[$i]}")
+      n_ok=$((n_ok + 1))
+    else
+      bad+=("${R_IDS[$i]}")
+      n_bad=$((n_bad + 1))
+    fi
+  done
+  echo
+  echo "=== ${IMAGE_NAME} publish summary ==="
+  echo "landed in ${n_ok}/${#R_IDS[@]} region(s): ${ok[*]:-none}"
+  if [ "$n_bad" -eq 0 ]; then
+    echo "All gcore region imports finished."
+    return 0
+  fi
+  echo "MISSING the image in ${n_bad} region(s): ${bad[*]}"
+  for i in "${!R_IDS[@]}"; do
+    [ "${R_STATES[$i]}" = "DONE" ] && continue
+    echo "  region ${R_IDS[$i]}: ${R_WHY[$i]:-did not complete}"
+  done
+  echo "::error::gcore publish left ${n_bad} of ${#R_IDS[@]} region(s) without ${IMAGE_NAME}: ${bad[*]}" >&2
+  exit 1
+}
+
+# Imports run with BOUNDED concurrency, and that bound is the whole point.
+#
+# Gcore fails any task it has not STARTED within 10min of that task's own created_on,
+# while its per-project scheduler runs only a few image imports at a time and each one
+# takes ~10-75min. Creating all ~30 imports up front therefore guaranteed the tail of
+# the queue was reaped before it ever ran: in both failed builds EVERY errored region
+# came back with gcore's "Task was not started within 10 minutes of creation. Marked as
+# failed by scheduler cleanup." Spacing the POSTs did not fix that, because a fixed
+# stagger still lets the queue grow without limit.
+#
+# So a task is created only when a slot is free. At most MAX_INFLIGHT tasks exist at
+# once, each is young when gcore picks it up, and the 10min deadline stops being a
+# deadline we set ourselves up to miss. Polls are per-region and per-attempt: a region
+# consumes them only while it holds a slot, so one slow region cannot spend a budget
+# the others still need.
 main() {
   echo "Publishing ${IMAGE_NAME} to Gcore regions: ${GCORE_REGIONS}"
-  local failures=0 region task attempt=0 pending i state
-  local raw=() regions=() tasks=() states=()
+  local raw=() region i next inflight remaining state body task submitted=0
   IFS=',' read -ra raw <<< "$GCORE_REGIONS"
-
-  # Phase 1 — start every import. downloadimage returns a task id immediately, so these
-  # POSTs are quick; issuing them sequentially also keeps them naturally spaced rather
-  # than arriving as one burst.
   for region in "${raw[@]}"; do
     region="${region//[[:space:]]/}"
     [ -z "$region" ] && continue
-    # Gcore reaps a task not STARTED within 10min of its own created_on, so POSTing all
-    # ~30 imports in one window gives them a shared deadline the scheduler cannot meet.
-    # Before the POST, and only once a task exists: no trailing wait, and a rejected POST
-    # created nothing to space from.
-    if [ "${#tasks[@]}" -gt 0 ] && [ "$IMPORT_STAGGER_SECS" -gt 0 ]; then
-      "$SLEEP" "$IMPORT_STAGGER_SECS"
-    fi
-    echo "==> Importing ${IMAGE_NAME} into region ${region}"
-    if ! task=$(import_region "$region"); then
-      failures=$((failures + 1))
-      continue
-    fi
-    regions+=("$region")
-    tasks+=("$task")
-    states+=("PENDING")
+    R_IDS+=("$region")
+    R_TASKS+=("")
+    R_STATES+=("QUEUED")
+    R_POLLS+=("0")
+    R_TRIES+=("0")
+    R_WHY+=("")
   done
-
-  # Phase 2 — wait on all of them at once. One sleep per round, not per region.
-  pending=${#regions[@]}
-  while [ "$pending" -gt 0 ] && [ "$attempt" -lt "$POLL_ATTEMPTS" ]; do
-    for i in "${!regions[@]}"; do
-      [ "${states[$i]}" = "PENDING" ] || continue
-      # A transient API error leaves state empty, which falls through to the retry
-      # branch — the same self-healing the sequential version had.
-      state=$("$CURL" -sS -f -H "$AUTH" "${API_BASE}/tasks/${tasks[$i]}" | jq -r '.state') || state=""
-      case "$state" in
-        FINISHED)
-          echo "region ${regions[$i]}: import task ${tasks[$i]} FINISHED"
-          states[i]=FINISHED
-          pending=$((pending - 1))
-          if ! report_visibility "${regions[$i]}" "${tasks[$i]}"; then
-            failures=$((failures + 1))
-          fi ;;
-        ERROR)
-          echo "::error::region ${regions[$i]}: import task ${tasks[$i]} state ERROR" >&2
-          states[i]=ERROR
-          pending=$((pending - 1))
-          failures=$((failures + 1)) ;;
-        *)
-          echo "region ${regions[$i]}: task ${tasks[$i]} state=${state:-unknown} (attempt $((attempt + 1))/${POLL_ATTEMPTS})" ;;
-      esac
-    done
-    attempt=$((attempt + 1))
-    # An explicit if, not a `&&` chain: a false chain here would be a failing last
-    # command in the loop body and `set -e` would kill the script.
-    if [ "$pending" -gt 0 ] && [ "$attempt" -lt "$POLL_ATTEMPTS" ]; then
-      "$SLEEP" "$POLL_INTERVAL_SECS"
-    fi
-  done
-
-  # Whatever is still PENDING ran out of attempts.
-  for i in "${!regions[@]}"; do
-    if [ "${states[$i]}" = "PENDING" ]; then
-      echo "::error::region ${regions[$i]}: import task ${tasks[$i]} did not finish after ${POLL_ATTEMPTS} attempts" >&2
-      failures=$((failures + 1))
-    fi
-  done
-
-  if [ "$failures" -gt 0 ]; then
-    echo "::error::${failures} gcore region import(s) failed" >&2
+  if [ "${#R_IDS[@]}" -eq 0 ]; then
+    echo "::error::GCORE_REGIONS contained no region IDs" >&2
     exit 1
   fi
-  echo "All gcore region imports finished."
+  echo "  ${#R_IDS[@]} region(s); at most ${MAX_INFLIGHT} in flight; ${IMPORT_ATTEMPTS} attempt(s) each; ${POLL_ATTEMPTS} poll(s) x ${POLL_INTERVAL_SECS}s per attempt"
+
+  while :; do
+    inflight=0
+    for i in "${!R_IDS[@]}"; do
+      [ "${R_STATES[$i]}" = "INFLIGHT" ] && inflight=$((inflight + 1))
+    done
+
+    # Fill whatever slots are free.
+    while [ "$inflight" -lt "$MAX_INFLIGHT" ]; do
+      next=-1
+      for i in "${!R_IDS[@]}"; do
+        if [ "${R_STATES[$i]}" = "QUEUED" ]; then
+          next="$i"
+          break
+        fi
+      done
+      [ "$next" -lt 0 ] && break
+      # Spacing between POSTs, so a refill does not arrive as a burst. Before the POST
+      # and only once one has already gone out: no leading wait, no trailing one, and
+      # a refused POST left nothing to space from.
+      if [ "$submitted" -gt 0 ] && [ "$IMPORT_STAGGER_SECS" -gt 0 ]; then
+        "$SLEEP" "$IMPORT_STAGGER_SECS"
+      fi
+      R_TRIES[next]=$((${R_TRIES[$next]} + 1))
+      submitted=$((submitted + 1))
+      echo "==> Importing ${IMAGE_NAME} into region ${R_IDS[$next]} (attempt ${R_TRIES[$next]}/${IMPORT_ATTEMPTS}, $((inflight + 1))/${MAX_INFLIGHT} in flight)"
+      if task=$(import_region "${R_IDS[$next]}"); then
+        R_TASKS[next]="$task"
+        R_STATES[next]=INFLIGHT
+        R_POLLS[next]=0
+        inflight=$((inflight + 1))
+      else
+        # The POST itself was refused. retire_region may requeue it, so break out and
+        # let the round's sleep space the retry rather than spinning on it here.
+        retire_region "$next" "import POST was refused"
+        break
+      fi
+    done
+
+    # One poll per outstanding task per round.
+    for i in "${!R_IDS[@]}"; do
+      [ "${R_STATES[$i]}" = "INFLIGHT" ] || continue
+      # A transient API error leaves the body empty, which falls through to the retry
+      # branch — the same self-healing the shared-budget version had.
+      body=$(fetch_task "${R_TASKS[$i]}") || body=""
+      state=""
+      if [ -n "$body" ]; then
+        state=$(printf '%s' "$body" | jq -r '.state // empty' 2>/dev/null) || state=""
+      fi
+      case "$state" in
+        FINISHED)
+          echo "region ${R_IDS[$i]}: import task ${R_TASKS[$i]} FINISHED"
+          R_STATES[i]=DONE
+          # An import that landed but cannot be shown to be non-public is not a
+          # success, and re-importing would not change that, so it does not retry.
+          if ! report_visibility "${R_IDS[$i]}" "${R_TASKS[$i]}"; then
+            R_STATES[i]=FAILED
+            R_WHY[i]="imported, but the visibility check failed"
+          fi ;;
+        ERROR)
+          echo "::error::region ${R_IDS[$i]}: import task ${R_TASKS[$i]} state ERROR" >&2
+          dump_task_body "region ${R_IDS[$i]}" "$body"
+          retire_region "$i" "import task ${R_TASKS[$i]} reported ERROR" ;;
+        *)
+          R_POLLS[i]=$((${R_POLLS[$i]} + 1))
+          if [ "${R_POLLS[$i]}" -ge "$POLL_ATTEMPTS" ]; then
+            retire_region "$i" "import task ${R_TASKS[$i]} did not finish after ${POLL_ATTEMPTS} polls"
+          else
+            echo "region ${R_IDS[$i]}: task ${R_TASKS[$i]} state=${state:-unknown} (poll ${R_POLLS[$i]}/${POLL_ATTEMPTS})"
+          fi ;;
+      esac
+    done
+
+    # Done once nothing is in flight and nothing is still waiting for a slot.
+    remaining=0
+    for i in "${!R_IDS[@]}"; do
+      case "${R_STATES[$i]}" in
+        QUEUED | INFLIGHT) remaining=$((remaining + 1)) ;;
+      esac
+    done
+    [ "$remaining" -eq 0 ] && break
+    "$SLEEP" "$POLL_INTERVAL_SECS"
+  done
+
+  summarize
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then

--- a/deploy/packer/gcore-publish.test.sh
+++ b/deploy/packer/gcore-publish.test.sh
@@ -29,6 +29,10 @@ trap cleanup EXIT
 #   retry          /tasks/ -> RUNNING until a counter file next to the fake curl
 #                  reaches FAKE_CURL_RETRY_THRESHOLD (default 2), then FINISHED
 #   always_running /tasks/ -> RUNNING, always (for the timeout test)
+#   error_once     each POST returns "task-<region>-<attempt>"; attempt 1 -> ERROR,
+#                  later attempts -> FINISHED (exercises the ERROR retry path)
+#   running_once   same ids; attempt 1 stays RUNNING until its polls run out,
+#                  attempt 2 -> FINISHED (exercises the timeout retry path)
 #   mixed          downloadimage -> task named for the region in the URL (region
 #                  68 -> "task-68"); /tasks/ -> ERROR only for
 #                  FAKE_CURL_ERROR_REGION's task
@@ -49,6 +53,9 @@ finished='{"state":"FINISHED","created_resources":{"images":["img-1"]}}'
 if [ -n "${FAKE_CURL_NO_IMAGE_ID:-}" ]; then
   finished='{"state":"FINISHED","created_resources":{"images":[]}}'
 fi
+# Verbatim from a real reaped task (run 32154320626, region 18) so the body-dump
+# assertion checks the string an operator would actually have to read.
+errbody='{"state":"ERROR","task_type":"download_image","error":"Task was not started within 10 minutes of creation. Marked as failed by scheduler cleanup."}'
 # The image DELETE and the visibility GET share a URL shape, so the method has to be
 # read off the flags before any URL matching.
 method=GET prev=""
@@ -89,6 +96,15 @@ for a in "$@"; do
       elif [ "$mode" = mixed ]; then
         region="${a##*/}"
         printf '%s\n%s' "{\"tasks\":[\"task-${region}\"]}" 200
+      elif [ "$mode" = error_once ] || [ "$mode" = running_once ]; then
+        # Task id carries the attempt number ("task-68-2"), which is what lets the
+        # /tasks/ handler below fail only a region's FIRST attempt.
+        region="${a##*/}"
+        cf="${self_dir}/post_${region}"
+        [ -f "$cf" ] || echo 0 > "$cf"
+        n=$(( $(cat "$cf") + 1 ))
+        echo "$n" > "$cf"
+        printf '%s\n%s' "{\"tasks\":[\"task-${region}-${n}\"]}" 200
       else
         printf '%s\n%s' '{"tasks":["task-abc"]}' 200
       fi
@@ -97,9 +113,21 @@ for a in "$@"; do
       task="${a##*/tasks/}"
       case "$mode" in
         import_error)
-          echo '{"state":"ERROR"}' ;;
+          echo "$errbody" ;;
         always_running)
           echo '{"state":"RUNNING"}' ;;
+        error_once)
+          # Attempt 1 errors, every later attempt finishes.
+          case "$task" in
+            *-1) echo "$errbody" ;;
+            *) echo "$finished" ;;
+          esac ;;
+        running_once)
+          # Attempt 1 never finishes (so it exhausts its polls), attempt 2 finishes.
+          case "$task" in
+            *-1) echo '{"state":"RUNNING"}' ;;
+            *) echo "$finished" ;;
+          esac ;;
         retry)
           count_file="${self_dir}/poll_count"
           [ -f "$count_file" ] || echo 0 > "$count_file"
@@ -113,7 +141,7 @@ for a in "$@"; do
         mixed)
           region="${task#task-}"
           if [ "$region" = "${FAKE_CURL_ERROR_REGION:-}" ]; then
-            echo '{"state":"ERROR"}'
+            echo "$errbody"
           else
             echo "$finished"
           fi ;;
@@ -200,17 +228,51 @@ else
   echo "FAIL: poll retry then success (rc=$rc, running_count=$running_count)"; echo "$out"; FAILED=1
 fi
 
-# Test 5: always RUNNING -> poll_task exhausts POLL_ATTEMPTS and hard-fails (no
-# fallback).
+# Test 5: always RUNNING -> the region exhausts its per-region polls and hard-fails
+# (no fallback). IMPORT_ATTEMPTS=1 keeps this a pure timeout test; 5b covers the retry.
 dir=$(make_fake_curl); TMP_DIRS+=("$dir")
 out=$(PATH="$dir:$PATH" FAKE_CURL_MODE=always_running \
   GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
-  GCORE_REGIONS="180" POLL_ATTEMPTS=2 POLL_INTERVAL_SECS=0 \
+  GCORE_REGIONS="180" POLL_ATTEMPTS=2 POLL_INTERVAL_SECS=0 IMPORT_ATTEMPTS=1 \
   bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
-if [ "$rc" -ne 0 ] && grep -q "did not finish after 2 attempts" <<<"$out"; then
+if [ "$rc" -ne 0 ] && grep -q "did not finish after 2 polls" <<<"$out" \
+   && grep -q "no attempts left (1/1)" <<<"$out"; then
   echo "PASS: poll timeout"
 else
   echo "FAIL: poll timeout (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
+# Test 5b: a region whose FIRST import times out is re-POSTed, and the second attempt
+# landing is a publish success. This is the retry that both failed builds lacked.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+out=$(PATH="$dir:$PATH" FAKE_CURL_MODE=running_once \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180" POLL_ATTEMPTS=2 POLL_INTERVAL_SECS=0 IMPORT_ATTEMPTS=2 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 0 ] \
+   && grep -q "did not finish after 2 polls — requeueing (attempt 2/2)" <<<"$out" \
+   && grep -q "region 180: import task task-180-2 FINISHED" <<<"$out" \
+   && grep -q "landed in 1/1 region(s): 180" <<<"$out"; then
+  echo "PASS: a timed-out import is retried and the retry succeeds"
+else
+  echo "FAIL: timeout retry (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
+# Test 5c: same for an ERRORed import — and the full gcore task body must reach the log,
+# since the reaper message is the only thing that explains the failure.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+out=$(PATH="$dir:$PATH" FAKE_CURL_MODE=error_once \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180" POLL_INTERVAL_SECS=0 IMPORT_ATTEMPTS=2 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 0 ] \
+   && grep -q "gcore task body follows" <<<"$out" \
+   && grep -q "Task was not started within 10 minutes of creation" <<<"$out" \
+   && grep -q "reported ERROR — requeueing (attempt 2/2)" <<<"$out" \
+   && grep -q "region 180: import task task-180-2 FINISHED" <<<"$out"; then
+  echo "PASS: an errored import dumps the task body and the retry succeeds"
+else
+  echo "FAIL: error retry + body dump (rc=$rc)"; echo "$out"; FAILED=1
 fi
 
 # Test 6: region 180 FINISHED, region 68 ERROR -> failures aggregate across
@@ -315,7 +377,7 @@ if [ "$rc" -ne 0 ] \
    && grep -q "could not read visibility of image img-1 after 2 attempts" <<<"$out" \
    && grep -q "treat it as exposed" <<<"$out" \
    && grep -q "visibility of image img-1 lookup failed (attempt 1/2)" <<<"$out" \
-   && grep -q "1 gcore region import(s) failed" <<<"$out"; then
+   && grep -q "left 1 of 1 region(s) without lantern-box-0.0.0" <<<"$out"; then
   echo "PASS: unverifiable visibility fails the publish after bounded retries"
 else
   echo "FAIL: unverifiable visibility fails the publish (rc=$rc)"; echo "$out"; FAILED=1
@@ -347,15 +409,15 @@ out=$(PATH="$dir:$PATH" FAKE_CURL_NO_IMAGE_ID=1 \
 if [ "$rc" -ne 0 ] \
    && grep -q "could not resolve the imported image ID from task task-abc after 2 attempts" <<<"$out" \
    && grep -q "lantern-box-0.0.0" <<<"$out" \
-   && grep -q "1 gcore region import(s) failed" <<<"$out"; then
+   && grep -q "left 1 of 1 region(s) without lantern-box-0.0.0" <<<"$out"; then
   echo "PASS: an unresolvable image ID fails the publish"
 else
   echo "FAIL: an unresolvable image ID fails the publish (rc=$rc)"; echo "$out"; FAILED=1
 fi
 
-# Test 11: every import is issued BEFORE polling starts, and the wait costs one sleep per
-# round, not per region per round — the property making wall-clock the slowest region
-# instead of the sum. Draining one at a time would cost 6 sleeps here.
+# Test 11: while regions fit inside MAX_INFLIGHT, every import is still issued before
+# polling starts and the wait costs one sleep per ROUND, not per region per round.
+# IMPORT_ATTEMPTS=1 keeps the sleep/timeout counts about concurrency, not retries.
 dir=$(make_fake_curl); TMP_DIRS+=("$dir")
 sleeplog="$dir/sleeps"
 printf '#!/usr/bin/env bash\necho s >> "%s"\n' "$sleeplog" > "$dir/fakesleep"
@@ -364,17 +426,43 @@ chmod +x "$dir/fakesleep"
 out=$(PATH="$dir:$PATH" FAKE_CURL_MODE=always_running SLEEP="$dir/fakesleep" \
   GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
   GCORE_REGIONS="180,68,45" POLL_ATTEMPTS=2 POLL_INTERVAL_SECS=0 IMPORT_STAGGER_SECS=0 \
+  MAX_INFLIGHT=6 IMPORT_ATTEMPTS=1 \
   bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
 sleeps=$(grep -c . "$sleeplog" 2>/dev/null || echo 0)
 # sed rather than head, which would SIGPIPE the grep feeding it under pipefail.
 last_import=$(grep -n '==> Importing' <<<"$out" | sed -n '$p' | cut -d: -f1)
 first_poll=$(grep -n 'state=RUNNING' <<<"$out" | sed -n '1p' | cut -d: -f1)
-timeouts=$(grep -c 'did not finish after 2 attempts' <<<"$out")
+timeouts=$(grep -c '::error::.*did not finish after 2 polls' <<<"$out")
 if [ "$rc" -ne 0 ] && [ "$timeouts" -eq 3 ] && [ "$sleeps" -le 2 ] \
    && [ -n "$last_import" ] && [ -n "$first_poll" ] && [ "$last_import" -lt "$first_poll" ]; then
-  echo "PASS: imports all start before polling, ${sleeps} sleep(s) for 3 regions x 2 attempts"
+  echo "PASS: imports within the slot limit all start before polling, ${sleeps} sleep(s)"
 else
   echo "FAIL: concurrent import/poll (rc=$rc timeouts=$timeouts sleeps=$sleeps import@$last_import poll@$first_poll)"
+  echo "$out"; FAILED=1
+fi
+
+# Test 11b: THE regression test for the reaped-task failure. More regions than slots must
+# never put more than MAX_INFLIGHT tasks in flight, and the overflow regions must not be
+# POSTed until a slot frees — creating a task gcore cannot start within 10min is exactly
+# what killed both failed builds.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+out=$(PATH="$dir:$PATH" \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180,68,45,22,11" POLL_INTERVAL_SECS=0 IMPORT_STAGGER_SECS=0 \
+  MAX_INFLIGHT=2 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+# Every import line reports "<n>/<max> in flight"; n must never exceed the cap.
+over=$(grep -oE '[0-9]+/2 in flight' <<<"$out" | cut -d/ -f1 | awk '$1>2' | grep -c . || true)
+imports=$(grep -c '==> Importing' <<<"$out")
+# With 2 slots and 5 regions the 3rd import can only follow a completed poll.
+third_import=$(grep -n '==> Importing' <<<"$out" | sed -n '3p' | cut -d: -f1)
+first_done=$(grep -n 'FINISHED' <<<"$out" | sed -n '1p' | cut -d: -f1)
+if [ "$rc" -eq 0 ] && [ "$imports" -eq 5 ] && [ "$over" -eq 0 ] \
+   && [ -n "$third_import" ] && [ -n "$first_done" ] && [ "$first_done" -lt "$third_import" ] \
+   && grep -q "landed in 5/5 region(s)" <<<"$out"; then
+  echo "PASS: MAX_INFLIGHT caps in-flight imports and overflow waits for a slot"
+else
+  echo "FAIL: bounded concurrency (rc=$rc imports=$imports over=$over third@$third_import done@$first_done)"
   echo "$out"; FAILED=1
 fi
 
@@ -389,7 +477,9 @@ if [ "$rc" -ne 0 ] \
    && grep -q "region 180: import task task-180 FINISHED" <<<"$out" \
    && grep -q "region 45: import task task-45 FINISHED" <<<"$out" \
    && grep -q "region 68: import task task-68 state ERROR" <<<"$out" \
-   && grep -q "1 gcore region import(s) failed" <<<"$out"; then
+   && grep -q "landed in 2/3 region(s): 180 45" <<<"$out" \
+   && grep -q "MISSING the image in 1 region(s): 68" <<<"$out" \
+   && grep -q "left 1 of 3 region(s) without lantern-box-0.0.0: 68" <<<"$out"; then
   echo "PASS: one failing region does not block the others"
 else
   echo "FAIL: one failing region does not block the others (rc=$rc)"; echo "$out"; FAILED=1

--- a/deploy/packer/gcore-publish.test.sh
+++ b/deploy/packer/gcore-publish.test.sh
@@ -415,6 +415,39 @@ else
   echo "FAIL: an unresolvable image ID fails the publish (rc=$rc)"; echo "$out"; FAILED=1
 fi
 
+# Test 10d: the scheduler knobs are loop bounds, and a bad one used to hang the publish
+# until the job timeout rather than fail — MAX_INFLIGHT=0 POSTs nothing while every region
+# stays QUEUED. Each must be rejected up front, and the valid-but-zero sleeps must not be.
+for bad in "MAX_INFLIGHT=0" "MAX_INFLIGHT=abc" "IMPORT_ATTEMPTS=0" "POLL_ATTEMPTS=0" \
+           "VISIBILITY_ATTEMPTS=0" "DELETE_POLL_ATTEMPTS=0" "POLL_INTERVAL_SECS=-1"; do
+  dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+  name="${bad%%=*}"
+  out=$(PATH="$dir:$PATH" \
+    GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+    GCORE_REGIONS="180" POLL_INTERVAL_SECS=0 IMPORT_STAGGER_SECS=0 \
+    env "$bad" timeout 10 bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq 1 ] && grep -q "::error::${name} must be" <<<"$out"; then
+    continue
+  fi
+  echo "FAIL: ${bad} should fail fast (rc=$rc)"; echo "$out"; FAILED=1
+  bad_knob_failed=1
+done
+if [ -z "${bad_knob_failed:-}" ]; then
+  echo "PASS: invalid scheduler knobs fail fast instead of hanging"
+fi
+
+# Test 10e: 0 is legitimate for the two sleep lengths, and the tests themselves rely on it.
+dir=$(make_fake_curl); TMP_DIRS+=("$dir")
+out=$(PATH="$dir:$PATH" \
+  GCORE_API_KEY=k GCORE_PROJECT_ID=1 VERSION=0.0.0 IMAGE_URL=http://example/x.qcow2 \
+  GCORE_REGIONS="180" POLL_INTERVAL_SECS=0 IMPORT_STAGGER_SECS=0 \
+  bash "$PUBLISH" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 0 ] && grep -q "landed in 1/1 region(s): 180" <<<"$out"; then
+  echo "PASS: zero-length sleeps are accepted"
+else
+  echo "FAIL: zero-length sleeps rejected (rc=$rc)"; echo "$out"; FAILED=1
+fi
+
 # Test 11: while regions fit inside MAX_INFLIGHT, every import is still issued before
 # polling starts and the wait costs one sleep per ROUND, not per region per round.
 # IMPORT_ATTEMPTS=1 keeps the sleep/timeout counts about concurrency, not retries.


### PR DESCRIPTION
## Why

Both recent image builds ([32154320626](https://github.com/getlantern/lantern-box/actions/runs/32154320626), [32158844992](https://github.com/getlantern/lantern-box/actions/runs/32158844992)) failed in **Publish gcore image to regions**, never in the image build. The two runs failed on different region sets, which read like gcore flakiness. It wasn't. Querying the task IDs directly, **every** errored region in both runs returned the same reason:

```
Task was not started within 10 minutes of creation.
Marked as failed by scheduler cleanup.
```

Gcore fails any task it has not *started* within 10min of that task's own `created_on`, while its per-project scheduler runs only a handful of image imports at a time and each takes 8-16min (observed tail: 75min). We created all ~29 imports up front, so the tail of the queue was reaped before it ever ran. `IMPORT_STAGGER_SECS` was aimed at exactly this and could not work: a fixed stagger spreads creation times but does nothing to bound queue depth.

This stayed invisible for two builds because the poll loop read only `.state` off the task and discarded the body.

Two of run 2's three "did not finish" regions had in fact **succeeded later** — 92 at 74min and 124 at 58min — so the 30min shared poll window was also throwing away completed work. The third (128) was a genuine gcore-internal failure (`glance` read timeout), which is what the new retry covers.

## What changed

`deploy/packer/gcore-publish.sh` — `main()` replaced with a slot scheduler:

- **`MAX_INFLIGHT` (6)** — a task is created only when a slot frees, so it is young when gcore picks it up. This is the actual fix.
- **`IMPORT_ATTEMPTS` (2)** — ERROR or poll exhaustion requeues the region, re-POSTing the already-staged qcow2: one API call, no re-upload.
- **`dump_task_body()`** — dumps the whole gcore task body on ERROR instead of a preselected field, which is why the reaper message was never visible.
- **`POLL_ATTEMPTS` 120 -> 360**, and now **per-region-per-attempt** rather than a window shared across regions, so one slow region cannot spend what the others still need.
- **`summarize()`** — reports `landed in N/M region(s)` plus the missing regions and a per-region reason, still exiting non-zero. Landing in 27 of 29 regions is a different event from landing nowhere; the old bare `N region import(s) failed` hid that from whoever had to judge whether prod was affected.

`.github/workflows/build-images.yaml` — regions **18 and 68 dropped** from the single region list. lantern-cloud has zero routes with `provider_region_id` 18 or 68, and each import consumes one of very few concurrency slots. They are **not** excluded for being broken: both failed with the same generic reaper message that also hit 30/64/76, and both hold a healthy image today. Timeout re-derived per wave-of-6 (257min for 27 regions, under the 350 cap).

`deploy/packer/README.md` — the gcore section described the stagger as the 10-min mitigation, now actively misleading.

## Testing

`deploy/packer/gcore-publish.test.sh` — **21/21 pass** (was 18), no network. New coverage: retry-after-timeout, retry-after-ERROR asserting the verbatim reaper string reaches the log, `MAX_INFLIGHT` cap enforcement, and the mixed-outcome summary. The old "all imports start before any polling" test was rewritten — that property is deliberately gone. `gcore-storage.test.sh` still passes untouched.

The new tests caught a real bug in this PR's own code: `jq . 2>/dev/null >&2` pointed stdout at `/dev/null` and swallowed the very body the fix exists to print.

## Production state

Not urgent to merge for prod safety. All 29 gcore regions currently hold an active `lantern-box-0.0.113` from 2026-08-18, including 18 and 68 — the two failed jobs still published to 27 and 22 regions respectively, and an earlier run covered the rest. Nothing is booting a stale datacap binary.

## Reviewer notes

- `MAX_INFLIGHT=6` is inferred from run-1 throughput (~7 concurrent), not documented by gcore. If a run shows no reaping and idle slots, it can go up.
- Bounded concurrency lengthens the publish, which lengthens the staged qcow2's public window (~45min -> ~90min typical). Revoke-first teardown, unguessable bucket name and the 1-day expiry backstop all still apply, but it is a real widening — worth a second opinion if that window was sized deliberately.
- `shellcheck` is not installed locally, so these scripts have `bash -n` and the suite behind them but no lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Image publishing now processes regions in controlled batches for more reliable deployments.
  - Failed or timed-out imports are automatically retried.
  - Publishing results now include per-region success and failure details.

- **Bug Fixes**
  - Improved handling of import errors and timeouts.
  - Deployments now clearly report when images are unavailable in specific regions.
  - Enhanced diagnostics make image import failures easier to investigate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->