### PR TITLE
fix(gcore): treat a 409 on image prune as in-use, not a failure

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -273,20 +273,33 @@ jobs:
             fi
             while IFS=$'\t' read -r created id name vis; do
               echo "Deleting ${name} (${id}, created ${created}, visibility ${vis}) in region ${region}..."
-              if ! http_code=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE -H "$AUTH" \
+              # Body kept, not sent to /dev/null: an unexpected status is undiagnosable
+              # without gcore's reason, which is how a 409 read as a mystery failure.
+              if ! resp=$(curl -sS -w $'\n%{http_code}' -X DELETE -H "$AUTH" \
                 "${API}/images/${GCORE_PROJECT_ID}/${region}/${id}"); then
                 echo "::error::Failed to reach gcore to delete ${name} (${id}) in region ${region}"
                 failures=$((failures + 1))
                 continue
               fi
+              http_code="${resp##*$'\n'}"
+              body="${resp%$'\n'*}"
               if [ "$http_code" = "404" ]; then
                 echo "  Already gone (404), skipping."
               elif [ "$http_code" = "403" ]; then
                 # The unfiltered pass can surface another project's public image that
                 # matches the prefix. Not ours to delete, not a failure.
                 echo "  Not ours to delete (403), skipping."
+              elif [ "$http_code" = "409" ]; then
+                # Still referenced by a live volume, so gcore refuses — and it is right
+                # to. These are the images the running VPS boxes booted from; the whole
+                # point of keeping them is that deleting one is destructive. An image
+                # becomes prunable on its own once those boxes are replaced, so this is a
+                # normal steady state for the oldest kept version, not a fault. Failing
+                # the job here blocked every image build (run 32238646926) while the
+                # correct action was to leave the image alone.
+                echo "  ::notice::Still in use by a live volume (409), skipping — it will prune once those boxes are replaced."
               elif [ "$http_code" -ge 400 ]; then
-                echo "::error::Failed to delete gcore image ${name} (${id}) in region ${region}: HTTP ${http_code}"
+                echo "::error::Failed to delete gcore image ${name} (${id}) in region ${region}: HTTP ${http_code}: ${body}"
                 failures=$((failures + 1))
               fi
             done < <(echo "$images" | tail -n +$((KEEP + 1)))

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -297,9 +297,18 @@ jobs:
                 # normal steady state for the oldest kept version, not a fault. Failing
                 # the job here blocked every image build (run 32238646926) while the
                 # correct action was to leave the image alone.
-                echo "  ::notice::Still in use by a live volume (409), skipping — it will prune once those boxes are replaced."
+                # Plain text, not ::notice::: a workflow command is only parsed at the
+                # start of a line, and this is routine steady state that would otherwise
+                # annotate every run for every in-use image. Matches the 404/403 lines.
+                echo "  Still in use by a live volume (409), skipping — it will prune once those boxes are replaced."
               elif [ "$http_code" -ge 400 ]; then
-                echo "::error::Failed to delete gcore image ${name} (${id}) in region ${region}: HTTP ${http_code}: ${body}"
+                # Body printed on its own indented lines rather than interpolated into
+                # the ::error::, which is a single line by definition: gcore's message
+                # could carry newlines, and any line of it starting with "::" would be
+                # read as another workflow command. The indent prefix makes that
+                # impossible.
+                echo "::error::Failed to delete gcore image ${name} (${id}) in region ${region}: HTTP ${http_code}"
+                printf '%s\n' "$body" | sed 's/^/    /'
                 failures=$((failures + 1))
               fi
             done < <(echo "$images" | tail -n +$((KEEP + 1)))


### PR DESCRIPTION
## Why

[Run 32238646926](https://github.com/getlantern/lantern-box/actions/runs/32238646926/job/96024196306) failed the whole build in **Prune old gcore images**, which **skipped every builder** — no images were produced at all. Five `lantern-box-0.0.106` images returned **HTTP 409** in regions 26, 124, 152, 164 and 180. Prune handled 404 and 403 but not 409, so it counted them as delete failures and exited 1.

**Gcore is right to refuse.** Each of those images still has live volumes booted from it:

| region | live volumes from the 409 image |
|---|---|
| 26 | 15 of 24 |
| 180 | 2 of 8 |
| 164 | 2 of 2 |
| 124 | 1 of 2 |
| 152 | 1 of 1 |

Those are the running VPS boxes. Deleting the image is destructive, and the 409 is gcore protecting them. This is the normal steady state for the oldest kept version, not a fault — the image becomes prunable on its own once those boxes are replaced.

## Why now, and not before

Not caused by the region-list changes in #303: every failing region is in the original publish list, and none is the 18/68 that PR added to the *prune* list.

It surfaced now because yesterday's three runs left exactly **3** fresh `0.0.113` images per region, pushing the single `0.0.106` past `KEEP=3` so prune attempted it for the first time. Region 92 has the same in-use situation but had only 3 images total, so it never reached the delete path. That is also why prune passed in runs 32154320626 and 32158844992.

## What changed

- **409 is a skip, not a failure** — logged as plain indented text explaining it will prune once those boxes are replaced, matching the sibling 404/403 lines.
- **Stop discarding the DELETE response body** (`-o /dev/null`), so an unexpected status carries gcore's reason instead of a bare code. Same lesson as the publish fix in #303, where reading only `state` off a task hid the real cause for two builds.

Steady-state effect: at most one stuck image per region, which self-clears as boxes are replaced. Newer images that nothing references still prune normally.

## Testing

The prune step is inline workflow shell with no harness, so I extracted the delete-handling loop and drove it with a fake curl across every status code:

```
204 -> failures=0                 404 -> "Already gone", failures=0
403 -> "Not ours to delete"       409 -> "Still in use by a live volume", failures=0
500 -> single-line ::error:: + indented body, failures=1
```

Re-verified after review with a deliberately hostile body containing a newline and a
line beginning with `::`, confirming it cannot be parsed as a workflow command.

`yaml.safe_load` clean.

## Reviewer notes

- The prune logic being inline YAML is why it has no unit tests, unlike `gcore-publish.sh` / `gcore-storage.sh`. Extracting it to `deploy/packer/gcore-prune.sh` with a test file would match the existing pattern — deliberately not done here to keep this fix minimal and reviewable while CI is red.
- Related finding while investigating, **not** addressed by this PR: 28 of 46 live gcore boxes are still booted from `lantern-box-0.0.106`, i.e. still running the pre-datacap binary that reports `bytesUsed=0` (region 26: 15, 92: 7, 180: 2, 164: 2, 124: 1, 152: 1). Every region now has a fresh `0.0.113` image and 18 boxes have already picked it up, so this drains via natural replacement — but it is not complete, and forcing replacement is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
