### PR TITLE
packer(alicloud): copy images to eu-central-1 and eu-west-1

### DIFF
--- a/deploy/packer/lantern-box.pkr.hcl
+++ b/deploy/packer/lantern-box.pkr.hcl
@@ -959,7 +959,7 @@ source "alicloud-ecs" "lantern-box" {
   ssh_username         = "root"
   ssh_password         = var.alicloud_ssh_password
 
-  wait_copying_image_ready_timeout = 7200 # seconds (2h) — copying to 8 regions can be slow
+  wait_copying_image_ready_timeout = 7200 # seconds (2h) — copying to 10 regions can be slow
 
   image_copy_regions = [
     "ap-southeast-1",  # Singapore
@@ -970,6 +970,8 @@ source "alicloud-ecs" "lantern-box" {
     "ap-northeast-1",  # Japan (Tokyo)
     "ap-northeast-2",  # South Korea (Seoul)
     "cn-hongkong",     # Hong Kong
+    "eu-central-1",    # Germany (Frankfurt)
+    "eu-west-1",       # UK (London)
   ]
   image_copy_names = [
     "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Singapore
@@ -980,6 +982,8 @@ source "alicloud-ecs" "lantern-box" {
     "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Japan
     "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # South Korea
     "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Hong Kong
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # Germany
+    "lantern-box-${var.lantern_box_version}-{{timestamp}}",  # UK
   ]
 }
 


### PR DESCRIPTION
Fixes #305.

`image_copy_regions` listed 8 Alicloud regions; the api provisions into 10.
Boxes booted in **eu-central-1** or **eu-west-1** came up on whatever stale
image copy still sat in the region, and no build could report it — Packer
copies to every region it is handed and exits 0.

Those two regions carry **59 live prod routes**, ~20% of the Alicloud fleet:

| region | live routes | was copied |
|---|---|---|
| ap-southeast-1 | 248 | yes |
| **eu-central-1** | **50** | **no** |
| ap-northeast-1 | 26 | yes |
| cn-hongkong | 20 | yes |
| ap-southeast-7 | 15 | yes |
| **eu-west-1** | **9** | **no** |
| ap-southeast-6 | 6 | yes |

## How it surfaced

Two eu-central-1 boxes provisioned during the getlantern/engineering#3813
datacap rollout were the only hosts in the fleet emitting
`failed to sync device state: … code = Unknown desc = device does not exist`
at ERROR, with none of the benign `device missing upstream` INFO lines the
current code emits. Their `datacap` binary was `dfb8f429` — **2026-06-12**,
predating the negative-cache fix. Sweeping `vcs.revision` across all 32
post-flip boxes gave a perfect correlation: eu-central-1 2/2 stale, every
copied region 0/7.

## Verification

- `packer validate -syntax-only deploy/packer/` passes.
- `packer fmt -check` is **not** clean on `main` either (exit 3 before this
  change) — the file uses aligned trailing comments throughout, which `fmt`
  would collapse. This change matches the surrounding style rather than
  reformatting the file.

## Note on scope

This adds the two missing strings. #305 also suggests the durable fix —
collapse `image_copy_regions`/`image_copy_names` into one source of truth
(every name entry is byte-identical today, so the parallel array only
enforces positional parity) and fail the build when a region carrying live
routes is absent. Left for a follow-up; the silent 20% gap is the real
defect, and this PR only closes today's instance of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Germany and the United Kingdom as supported image-copy destinations.
  * Increased the documented copy target count from 8 to 10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->