### PR TITLE
packer: fetch datacap nightly instead of building

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -327,7 +327,7 @@ jobs:
 
       - name: Download and extract datacap packages
         env:
-          GH_TOKEN: ${{ secrets.CI_PRIVATE_REPOS_GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: bash deploy/packer/download-datacap-nightly.sh /tmp
 
       - name: Upload datacap binaries

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -318,34 +318,17 @@ jobs:
             exit 1
           fi
 
-  build-datacap:
-    name: Build datacap binaries
+  fetch-datacap:
+    name: Fetch latest datacap nightly
     runs-on: ubuntu-latest
-    needs: prepare
-    timeout-minutes: 15
+    timeout-minutes: 5
     steps:
-      - name: Checkout lantern-cloud
-        uses: actions/checkout@v6
-        with:
-          repository: getlantern/lantern-cloud
-          path: lantern-cloud
-          token: ${{ secrets.CI_PRIVATE_REPOS_GH_TOKEN }}
+      - uses: actions/checkout@v6
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: lantern-cloud/go.mod
-
-      - name: Install cross-compilers
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y -q gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-
-      - name: Build datacap binaries
-        working-directory: lantern-cloud
-        run: |
-          CGO_ENABLED=1 go build -o /tmp/datacap-amd64 github.com/getlantern/lantern-cloud/cmd/datacap
-          GOARCH=arm64 CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ CGO_ENABLED=1 go build -o /tmp/datacap-arm64 github.com/getlantern/lantern-cloud/cmd/datacap
+      - name: Download and extract datacap packages
+        env:
+          GH_TOKEN: ${{ secrets.CI_PRIVATE_REPOS_GH_TOKEN }}
+        run: bash deploy/packer/download-datacap-nightly.sh /tmp
 
       - name: Upload datacap binaries
         uses: actions/upload-artifact@v5
@@ -359,7 +342,7 @@ jobs:
   build:
     name: Build ${{ matrix.builder }}
     runs-on: ubuntu-latest
-    needs: [prepare, prune, build-datacap]
+    needs: [prepare, prune, fetch-datacap]
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/release-datacap.yaml
+++ b/.github/workflows/release-datacap.yaml
@@ -1,0 +1,90 @@
+name: Release Datacap Nightly
+
+on:
+  repository_dispatch:
+    types: [datacap-nightly]
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Full lantern-cloud commit SHA to build
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: datacap-nightly-${{ github.event.client_payload.source_sha || inputs.source_sha }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate source revision
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      source_sha: ${{ steps.source.outputs.sha }}
+      short_sha: ${{ steps.source.outputs.short_sha }}
+    steps:
+      - id: source
+        name: Validate lantern-cloud commit SHA
+        env:
+          SOURCE_SHA: ${{ github.event.client_payload.source_sha || inputs.source_sha }}
+        run: |
+          if [[ ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::source_sha must be a full lowercase commit SHA"
+            exit 1
+          fi
+          echo "sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SOURCE_SHA:0:8}" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build datacap (${{ matrix.arch }})
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - name: Check out lantern-cloud source
+        uses: actions/checkout@v6
+        with:
+          repository: getlantern/lantern-cloud
+          ref: ${{ needs.validate.outputs.source_sha }}
+          token: ${{ secrets.CI_PRIVATE_REPOS_GH_TOKEN }}
+          path: source
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: source/go.mod
+          cache-dependency-path: source/go.sum
+      - name: Install arm64 cross compiler
+        if: matrix.arch == 'arm64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+      - name: Build Debian package
+        working-directory: source
+        run: bash .github/scripts/build-datacap-deb "${{ matrix.arch }}" "${{ needs.validate.outputs.short_sha }}" ../dist
+      - uses: actions/upload-artifact@v6
+        with:
+          name: datacap-${{ matrix.arch }}
+          path: dist/*.deb
+          if-no-files-found: error
+
+  release:
+    name: Publish immutable nightly
+    needs: [validate, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v6
+        with:
+          pattern: datacap-*
+          merge-multiple: true
+          path: dist
+      - name: Create GitHub prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash deploy/packer/release-datacap-nightly.sh "${{ needs.validate.outputs.source_sha }}" dist

--- a/.github/workflows/release-datacap.yaml
+++ b/.github/workflows/release-datacap.yaml
@@ -24,7 +24,6 @@ jobs:
     timeout-minutes: 5
     outputs:
       source_sha: ${{ steps.source.outputs.sha }}
-      short_sha: ${{ steps.source.outputs.short_sha }}
     steps:
       - id: source
         name: Validate lantern-cloud commit SHA
@@ -36,7 +35,6 @@ jobs:
             exit 1
           fi
           echo "sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
-          echo "short_sha=${SOURCE_SHA:0:8}" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build datacap (${{ matrix.arch }})
@@ -54,6 +52,7 @@ jobs:
           ref: ${{ needs.validate.outputs.source_sha }}
           token: ${{ secrets.CI_PRIVATE_REPOS_GH_TOKEN }}
           path: source
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version-file: source/go.mod
@@ -65,7 +64,7 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
       - name: Build Debian package
         working-directory: source
-        run: bash .github/scripts/build-datacap-deb "${{ matrix.arch }}" "${{ needs.validate.outputs.short_sha }}" ../dist
+        run: bash .github/scripts/build-datacap-deb "${{ matrix.arch }}" "${{ needs.validate.outputs.source_sha }}" ../dist
       - uses: actions/upload-artifact@v6
         with:
           name: datacap-${{ matrix.arch }}

--- a/deploy/packer/README.md
+++ b/deploy/packer/README.md
@@ -56,7 +56,7 @@ packer build \
 
 ### Datacap fallback
 
-CI downloads the newest immutable `datacap-nightly-*` Debian packages from
+CI downloads the newest immutable `datacap-nightly-<full-source-sha>` Debian packages from
 the public `getlantern/lantern-box` release feed, extracts their binaries, and bakes them into the
 image as a first-boot fallback. It does not compile lantern-cloud. The active
 version is selected and updated independently by lantern-cloud's cloud-init and

--- a/deploy/packer/README.md
+++ b/deploy/packer/README.md
@@ -54,9 +54,18 @@ packer build \
   .
 ```
 
-### Datacap (optional, closed-source)
+### Datacap fallback
 
-In CI, the `datacap` binary is built from `getlantern/lantern-cloud` and baked into the image. For local builds, empty placeholders are created automatically so the build succeeds without it. To include datacap locally, place the pre-built binaries at `/tmp/datacap-amd64` and `/tmp/datacap-arm64` before running `packer build`.
+CI downloads the newest immutable `datacap-nightly-*` Debian packages from
+`getlantern/lantern-cloud`, extracts their binaries, and bakes them into the
+image as a first-boot fallback. It does not compile lantern-cloud. The active
+version is selected and updated independently by lantern-cloud's cloud-init and
+SSH hotswap workers, so a datacap release does not trigger a Packer rebuild.
+
+For local builds, empty placeholders are created automatically so the build
+succeeds without datacap. To include it locally, run
+`bash deploy/packer/download-datacap-nightly.sh /tmp` or place pre-built binaries at
+`/tmp/datacap-amd64` and `/tmp/datacap-arm64` before `packer build`.
 
 ## Environment variables
 

--- a/deploy/packer/README.md
+++ b/deploy/packer/README.md
@@ -57,7 +57,7 @@ packer build \
 ### Datacap fallback
 
 CI downloads the newest immutable `datacap-nightly-*` Debian packages from
-`getlantern/lantern-cloud`, extracts their binaries, and bakes them into the
+the public `getlantern/lantern-box` release feed, extracts their binaries, and bakes them into the
 image as a first-boot fallback. It does not compile lantern-cloud. The active
 version is selected and updated independently by lantern-cloud's cloud-init and
 SSH hotswap workers, so a datacap release does not trigger a Packer rebuild.

--- a/deploy/packer/download-datacap-nightly.sh
+++ b/deploy/packer/download-datacap-nightly.sh
@@ -20,7 +20,8 @@ require_command dpkg-deb "install the dpkg package (for example: sudo apt-get in
 
 readonly output_directory="$1"
 readonly repository="getlantern/lantern-box"
-readonly package_directory="$(mktemp -d)"
+package_directory="$(mktemp -d)"
+readonly package_directory
 trap 'rm -rf "$package_directory"' EXIT
 
 tag="$(gh release list --repo "$repository" --limit 1000 --json tagName,isDraft \

--- a/deploy/packer/download-datacap-nightly.sh
+++ b/deploy/packer/download-datacap-nightly.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <output-directory>" >&2
+  exit 2
+fi
+
+readonly output_directory="$1"
+readonly repository="getlantern/lantern-cloud"
+readonly package_directory="$(mktemp -d)"
+trap 'rm -rf "$package_directory"' EXIT
+
+tag="$(gh release list --repo "$repository" --limit 50 --json tagName,isDraft \
+  --jq 'map(select(.isDraft == false and (.tagName | startswith("datacap-nightly-"))))[0].tagName // ""')"
+if [[ -z "$tag" ]]; then
+  echo "no published datacap-nightly-* release found in $repository" >&2
+  exit 1
+fi
+
+mkdir -p "$output_directory"
+for arch in amd64 arm64; do
+  asset="datacap_${tag#datacap-nightly-}_linux_${arch}.deb"
+  extract_directory="$package_directory/$arch"
+  mkdir -p "$extract_directory"
+  gh release download "$tag" --repo "$repository" --pattern "$asset" --dir "$package_directory"
+  dpkg-deb -x "$package_directory/$asset" "$extract_directory"
+  install -m 0755 "$extract_directory/usr/local/bin/datacap" "$output_directory/datacap-$arch"
+done
+
+echo "downloaded datacap $tag for amd64 and arm64"

--- a/deploy/packer/download-datacap-nightly.sh
+++ b/deploy/packer/download-datacap-nightly.sh
@@ -6,12 +6,24 @@ if [[ $# -ne 1 ]]; then
   exit 2
 fi
 
+require_command() {
+  local command="$1"
+  local install_hint="$2"
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "missing required command '$command'; $install_hint" >&2
+    exit 1
+  fi
+}
+
+require_command gh "install GitHub CLI: https://cli.github.com/"
+require_command dpkg-deb "install the dpkg package (for example: sudo apt-get install dpkg)"
+
 readonly output_directory="$1"
 readonly repository="getlantern/lantern-cloud"
 readonly package_directory="$(mktemp -d)"
 trap 'rm -rf "$package_directory"' EXIT
 
-tag="$(gh release list --repo "$repository" --limit 50 --json tagName,isDraft \
+tag="$(gh release list --repo "$repository" --limit 1000 --json tagName,isDraft \
   --jq 'map(select(.isDraft == false and (.tagName | startswith("datacap-nightly-"))))[0].tagName // ""')"
 if [[ -z "$tag" ]]; then
   echo "no published datacap-nightly-* release found in $repository" >&2

--- a/deploy/packer/download-datacap-nightly.sh
+++ b/deploy/packer/download-datacap-nightly.sh
@@ -19,7 +19,7 @@ require_command gh "install GitHub CLI: https://cli.github.com/"
 require_command dpkg-deb "install the dpkg package (for example: sudo apt-get install dpkg)"
 
 readonly output_directory="$1"
-readonly repository="getlantern/lantern-cloud"
+readonly repository="getlantern/lantern-box"
 readonly package_directory="$(mktemp -d)"
 trap 'rm -rf "$package_directory"' EXIT
 

--- a/deploy/packer/lantern-box.pkr.hcl
+++ b/deploy/packer/lantern-box.pkr.hcl
@@ -1073,7 +1073,7 @@ build {
   ]
 
   # Ensure datacap placeholder files exist so the file provisioner never fails.
-  # In CI, the real binaries are downloaded from the build-datacap job artifact.
+  # In CI, the real binaries come from the fetch-datacap nightly artifact.
   # For local/OSS builds, these will be empty (and skipped at install time).
   provisioner "shell-local" {
     inline = [

--- a/deploy/packer/release-datacap-nightly.sh
+++ b/deploy/packer/release-datacap-nightly.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <source-commit-sha> <asset-directory>" >&2
+  exit 2
+fi
+
+readonly source_sha="$1"
+readonly asset_directory="$2"
+readonly short_sha="${source_sha:0:8}"
+readonly tag="datacap-nightly-${short_sha}"
+
+if [[ ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "invalid source commit SHA: $source_sha" >&2
+  exit 2
+fi
+
+if gh release view "$tag" >/dev/null 2>&1; then
+  echo "release $tag already exists"
+  exit 0
+fi
+
+gh release create "$tag" "$asset_directory"/*.deb \
+  --title "Datacap nightly ${short_sha}" \
+  --notes "Immutable datacap VPS build from https://github.com/getlantern/lantern-cloud/commit/${source_sha}." \
+  --prerelease

--- a/deploy/packer/release-datacap-nightly.sh
+++ b/deploy/packer/release-datacap-nightly.sh
@@ -8,8 +8,7 @@ fi
 
 readonly source_sha="$1"
 readonly asset_directory="$2"
-readonly short_sha="${source_sha:0:8}"
-readonly tag="datacap-nightly-${short_sha}"
+readonly tag="datacap-nightly-${source_sha}"
 
 if [[ ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
   echo "invalid source commit SHA: $source_sha" >&2
@@ -22,6 +21,6 @@ if gh release view "$tag" >/dev/null 2>&1; then
 fi
 
 gh release create "$tag" "$asset_directory"/*.deb \
-  --title "Datacap nightly ${short_sha}" \
+  --title "Datacap nightly ${source_sha}" \
   --notes "Immutable datacap VPS build from https://github.com/getlantern/lantern-cloud/commit/${source_sha}." \
   --prerelease


### PR DESCRIPTION
## What changed

- replace the Packer `build-datacap` job with a fast public release download/extract job
- add a dedicated workflow that receives a `lantern-cloud` source SHA, checks out that exact private revision, builds amd64/arm64 Debian packages, and publishes them in the public lantern-box release feed
- use the complete 40-character source SHA in release tags, package versions, and asset names
- preserve the existing `/tmp/datacap-{amd64,arm64}` Packer artifact contract
- document that the baked copy is only a first-boot fallback; lantern-cloud selects and hotswaps the active version independently

## Why

Compiling lantern-cloud and installing cross-compilers in every Packer build adds avoidable time and couples image creation to datacap source changes. Lantern-cloud now dispatches the dedicated release workflow only when `cmd/datacap/**` or `go.mod` changes. Datacap releases do not trigger a Packer rebuild.

## Dependency

Companion change: getlantern/lantern-cloud#3202.

## Validation

- shell syntax checks for both helper scripts
- YAML parsing for both changed workflows
- built and inspected both architecture packages through the lantern-cloud build helper
- published temporary full-SHA prerelease `datacap-nightly-71337914c54c83ee45a556d61d4eb6d21081b169`
- lantern-cloud staging discovered and installed the public artifacts
- `git diff --check`
