### PR TITLE
build: bump samizdat for DialContext conn-fatal retry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952
 	github.com/getlantern/geo v0.0.0-20241129152027-2fc88c10f91e
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395
-	github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830
+	github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb
 	github.com/gobwas/ws v1.4.0
 	github.com/pion/transport/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNi
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534/go.mod h1:ZsLfOY6gKQOTyEcPYNA9ws5/XHZQFroxqCOhHjGcs9Y=
 github.com/getlantern/quic-go-unbounded-fork v0.59.0-unbounded h1:1vTizA6U8YdyvZT0RIsEaY5fuhuZumnR8myyCF3qiZs=
 github.com/getlantern/quic-go-unbounded-fork v0.59.0-unbounded/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
-github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
-github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
+github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064 h1:NhCyQAWGEWjok/jg4gRD6fzCZvyOQy/4dVSFYhzU5xk=
+github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb/go.mod h1:GkPT5P9JoOTIRXRmFWxYgu1hhXgTFFTNc2hoG7WQc3g=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=


### PR DESCRIPTION
## What

Bumps `github.com/getlantern/samizdat` to `v0.0.3-0.20260819153658-ebc74116a064`, picking up [getlantern/samizdat#15](https://github.com/getlantern/samizdat/pull/15).

Dependency bump only — no lantern-box code changes. The samizdat fix is internal to `Client.DialContext`; the public API is unchanged.

## Why

On adversarial ISPs, DPI resets the shared TLS+H2 connection to a Samizdat server. `connPool.getTransport` could hand back a pooled transport whose underlying conn was already dead but not yet marked closed. `openTunnel` then failed with a conn-fatal error (`net.ErrClosed` etc.) and retired that transport — but `DialContext` surfaced this as a hard dial failure, even though the very next `getTransport` would have created a fresh, working transport.

The observed signature was sustained bursts of `use of closed network connection` dial failures against otherwise-usable servers, each needlessly failing a dial that an immediate redial would complete. From lantern-box's perspective this made healthy samizdat outbounds look flaky, which feeds into group/autoselect health decisions.

```mermaid
sequenceDiagram
    autonumber
    participant LB as lantern-box outbound<br/>protocol/samizdat
    participant CL as samizdat Client<br/>client.go
    participant POOL as connPool<br/>h2transport.go
    participant SRV as Samizdat server

    Note over SRV: DPI resets the shared TLS+H2 conn ⚠️
    LB->>CL: client.go<br/>DialContext(dest)
    CL->>POOL: getTransport()
    POOL-->>CL: pooled transport<br/>(conn dead, not yet marked closed)
    CL->>SRV: openTunnel() → CONNECT
    SRV-->>CL: net.ErrClosed (conn-fatal)
    Note over POOL: transport retired here 🧹
    rect rgba(255, 200, 200, 0.3)
        Note over CL: before: returned the error to the caller 🐛<br/>a fresh getTransport would have worked
    end
    CL-->>LB: dial failure
    Note over CL: after: retry up to maxDialAttempts (3)<br/>on a fresh transport ✅
```

Non-conn-fatal errors (caller cancellation, a non-200 CONNECT response) still break immediately — no retry.

## Verification

```
go build ./...                                              # ok
go test ./protocol/samizdat/... ./tracker/clientcontext/...  # ok (both packages)
go mod tidy                                                 # no incidental changes; diff is go.mod + go.sum only
```

## Follow-ups

Same bump lands in `radiance` and then `lantern` in subsequent PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version for improved maintenance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
