### PR TITLE
fix(mutableautoselect): gate ladder winner on this cycle's successes

### DIFF
--- a/protocol/group/mock_outbound_test.go
+++ b/protocol/group/mock_outbound_test.go
@@ -17,8 +17,9 @@ type mockOutbound struct {
 	networks []string
 	// dial, when set, supersedes the mock expectation so each call gets
 	// its own conn; runProbe closes what it dials, so a shared one breaks
-	// on the second probe.
-	dial func() (net.Conn, error)
+	// on the second probe. It receives the caller's context so a stub can
+	// honor the probe deadline the way a real outbound does.
+	dial func(context.Context) (net.Conn, error)
 }
 
 func (m *mockOutbound) Tag() string { return m.tag }
@@ -31,7 +32,7 @@ func (m *mockOutbound) Network() []string {
 
 func (m *mockOutbound) DialContext(ctx context.Context, network string, destination metadata.Socksaddr) (net.Conn, error) {
 	if m.dial != nil {
-		return m.dial()
+		return m.dial(ctx)
 	}
 	args := m.Called()
 	conn, _ := args.Get(0).(net.Conn)

--- a/protocol/group/mock_outbound_test.go
+++ b/protocol/group/mock_outbound_test.go
@@ -15,6 +15,10 @@ type mockOutbound struct {
 	tag      string
 	typeName string
 	networks []string
+	// dial, when set, supersedes the mock expectation so each call gets
+	// its own conn; runProbe closes what it dials, so a shared one breaks
+	// on the second probe.
+	dial func() (net.Conn, error)
 }
 
 func (m *mockOutbound) Tag() string { return m.tag }
@@ -26,6 +30,9 @@ func (m *mockOutbound) Network() []string {
 }
 
 func (m *mockOutbound) DialContext(ctx context.Context, network string, destination metadata.Socksaddr) (net.Conn, error) {
+	if m.dial != nil {
+		return m.dial()
+	}
 	args := m.Called()
 	conn, _ := args.Get(0).(net.Conn)
 	return conn, args.Error(1)

--- a/protocol/group/mutableautoselect.go
+++ b/protocol/group/mutableautoselect.go
@@ -804,10 +804,11 @@ type preCandidate struct {
 }
 
 // rankLocked builds the candidate set for selection. A non-zero freshSince
-// restricts to members with a recorded outcome at or after freshSince
-// and drops those without a fresh success (lastSuccessDelayMs==0); the
-// probe-cycle ranker uses this so the "is there a winner this cycle?"
-// check can't see stale outcomes. Caller must hold s.access.
+// restricts to members with a recorded outcome at or after freshSince that
+// have a recorded success from any cycle. A fresh failure still qualifies,
+// because recordProbeFailure preserves lastSuccessDelayMs, so a caller
+// asking "did anything succeed this cycle?" must gate on that itself.
+// Caller must hold s.access.
 func (s *MutableAutoSelect) rankLocked(now time.Time, freshSince time.Time) []rankedCandidate {
 	clear(s.scratchPres)
 	pres := s.scratchPres[:0]
@@ -1056,11 +1057,23 @@ func (s *MutableAutoSelect) runLadder(target string) {
 	fullCtx, cancel := context.WithTimeout(s.ctx, s.cfg.ladderTotalBudget)
 	defer cancel()
 	cycleStart := time.Now()
-	s.internalProbe(fullCtx, nil)
+	// A probe failure advances lastOutcomeAt while leaving
+	// lastSuccessDelayMs intact, so the ranked set alone cannot tell a
+	// member that succeeded this cycle from one that only failed in it.
+	// Rank still orders the winner; this decides whether one exists. The
+	// map needs no lock of its own: probeAll serializes onSuccess, and
+	// internalProbe returns only after its workers finish.
+	succeeded := make(map[string]struct{})
+	s.internalProbe(fullCtx, func(res probeResult) {
+		succeeded[res.tag] = struct{}{}
+	})
 	var winner A.Outbound
 	s.access.Lock()
-	if ranked := s.rankLocked(time.Now(), cycleStart); len(ranked) > 0 {
-		winner = ranked[0].outbound
+	for _, c := range s.rankLocked(time.Now(), cycleStart) {
+		if _, ok := succeeded[c.tag]; ok {
+			winner = c.outbound
+			break
+		}
 	}
 	s.access.Unlock()
 	s.probeMu.Unlock()

--- a/protocol/group/mutableautoselect_test.go
+++ b/protocol/group/mutableautoselect_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -1250,19 +1252,66 @@ func TestSetURLOverrides_ClearsPersistedEntryOnChange(t *testing.T) {
 }
 
 func TestExhaustionSignal_FiresOnFullLadderFailure(t *testing.T) {
-	s, obs := newTestMUR(t, "a", "b")
+	// seedPriorSuccess leaves lastSuccessDelayMs set so the cycle's own
+	// failures advance lastOutcomeAt past freshSince while a stale delay
+	// remains — the combination that previously let a fully-failing
+	// ladder report a winner and stay silent.
+	tests := []struct {
+		name             string
+		seedPriorSuccess bool
+	}{
+		{"no history", false},
+		{"prior success", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, obs := newTestMUR(t, "a", "b")
+			s.defaultURL = "http://probe.test/"
+			if tt.seedPriorSuccess {
+				recordSuccess(s, "a", 100)
+				recordSuccess(s, "b", 200)
+			}
+			obs["a"].On("DialContext").Return(nil, errors.New("dial denied"))
+			obs["b"].On("DialContext").Return(nil, errors.New("dial denied"))
+
+			sig := s.ExhaustionSignal()
+			s.runLadder("a")
+
+			select {
+			case _, ok := <-sig:
+				assert.True(t, ok, "exhaustion channel should deliver a value, not be closed")
+			case <-time.After(2 * time.Second):
+				require.FailNow(t, "exhaustion signal not delivered within timeout")
+			}
+		})
+	}
+}
+
+// Guards the opposite direction from the exhaustion tests: the winner gate
+// must not be so tight that a live member is missed, which would signal
+// exhaustion every cycle and drive a /config-new refetch each time.
+func TestRunLadder_StaysSilentWhenAMemberSucceeds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(srv.Close)
+
+	s, obs := newTestMUR(t, "dead", "live")
 	s.defaultURL = "http://probe.test/"
-	obs["a"].On("DialContext").Return(nil, errors.New("dial denied"))
-	obs["b"].On("DialContext").Return(nil, errors.New("dial denied"))
+	s.cfg.ladderTotalBudget = 10 * time.Second
+	recordSuccess(s, "dead", 100)
+	recordSuccess(s, "live", 200)
+
+	obs["dead"].On("DialContext").Return(nil, errors.New("dial denied"))
+	obs["live"].dial = func() (net.Conn, error) {
+		return net.Dial("tcp", srv.Listener.Addr().String())
+	}
 
 	sig := s.ExhaustionSignal()
-	s.runLadder("a")
+	s.runLadder("dead")
 
 	select {
-	case _, ok := <-sig:
-		assert.True(t, ok, "exhaustion channel should deliver a value, not be closed")
-	case <-time.After(2 * time.Second):
-		require.FailNow(t, "exhaustion signal not delivered within timeout")
+	case <-sig:
+		require.FailNow(t, "a cycle with a live member must not signal exhaustion")
+	default:
 	}
 }
 

--- a/protocol/group/mutableautoselect_test.go
+++ b/protocol/group/mutableautoselect_test.go
@@ -1301,8 +1301,9 @@ func TestRunLadder_StaysSilentWhenAMemberSucceeds(t *testing.T) {
 	recordSuccess(s, "live", 200)
 
 	obs["dead"].On("DialContext").Return(nil, errors.New("dial denied"))
-	obs["live"].dial = func() (net.Conn, error) {
-		return net.Dial("tcp", srv.Listener.Addr().String())
+	obs["live"].dial = func(ctx context.Context) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", srv.Listener.Addr().String())
 	}
 
 	sig := s.ExhaustionSignal()


### PR DESCRIPTION
## Problem

`recordProbeFailure` advances `lastOutcomeAt` but deliberately preserves `lastSuccessDelayMs`, so a member that only *failed* during the ladder's cycle still cleared `rankLocked`'s `freshSince` filter while carrying a stale success delay.

`runLadder` took `ranked[0]` as its winner. A cycle in which every probe failed therefore still produced a winner, so `winner == nil` never held and the exhaustion signal never fired.

## Change

`runLadder` collects the tags that actually succeeded through `probeAll`'s existing `onSuccess` hook — which it had been passing `nil` to — and picks the winner from that set. Rank still orders the winner; the success set decides whether one exists.

The map needs no lock of its own: `probeAll` serializes `onSuccess` under its own mutex, and `internalProbe` returns only after its workers finish.

`runLadder` is the only caller passing a non-zero `freshSince`; the other call site passes `time.Time{}` and is unaffected.

## Doc correction

`rankLocked`'s doc claimed it "drops those without a fresh success (lastSuccessDelayMs==0)", which it never did — that conflates *ever succeeded* with *freshly succeeded*, and is the trap this bug fell into. It now states that a fresh failure still qualifies, so a caller asking "did anything succeed this cycle?" must gate on that itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection probing so each attempt uses an independent connection.
  * Prevented failed probe cycles from incorrectly selecting a winner.
  * Preserved prior successful timing information while accurately reporting current failures.
  * Corrected exhaustion signaling so it remains quiet when at least one member succeeds.

* **Tests**
  * Added coverage for probe connection handling, prior success history, and mixed success/failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->