### PR TITLE
fix(mutableautoselect): stop demotes bypassing switch hysteresis

### DIFF
--- a/option/group.go
+++ b/option/group.go
@@ -99,6 +99,11 @@ type MutableAutoSelectOutboundOptions struct {
 	// actually-broken cases. Default 4096.
 	DataPlaneProvedReadBytes uint32 `json:"data_plane_proved_read_bytes,omitempty"`
 
+	// DemoteOnlySelectedTag restricts data-plane stall and reset
+	// attribution to the tag currently selected for TCP or UDP. Default
+	// true; set false to count failures from every wrapped conn.
+	DemoteOnlySelectedTag *bool `json:"demote_only_selected_tag,omitempty"`
+
 	// ProbeConcurrency caps parallel member probes per batch. Default 6.
 	ProbeConcurrency uint32 `json:"probe_concurrency,omitempty"`
 }

--- a/protocol/group/mutableautoselect.go
+++ b/protocol/group/mutableautoselect.go
@@ -120,6 +120,7 @@ type mutableAutoSelectConfig struct {
 	ladderCooldown      time.Duration
 	dataPlaneIdle       time.Duration
 	dataPlaneProvedRead uint64
+	demoteOnlySelected  bool
 	maxPersistedAge     time.Duration
 	probeConcurrency    int
 }
@@ -134,6 +135,7 @@ func resolveMutableAutoSelectOptions(o option.MutableAutoSelectOutboundOptions) 
 		ladderCooldown:      time.Duration(o.LadderCooldownSeconds) * time.Second,
 		dataPlaneIdle:       time.Duration(o.DataPlaneIdleSeconds) * time.Second,
 		dataPlaneProvedRead: uint64(o.DataPlaneProvedReadBytes),
+		demoteOnlySelected:  o.DemoteOnlySelectedTag == nil || *o.DemoteOnlySelectedTag,
 		maxPersistedAge:     time.Duration(o.MaxPersistedAgeSeconds) * time.Second,
 		probeConcurrency:    int(o.ProbeConcurrency),
 	}
@@ -476,7 +478,7 @@ func (s *MutableAutoSelect) DialContext(ctx context.Context, network string, des
 	outerTag := o.Tag()
 	conn, err := o.DialContext(ctx, network, destination)
 	if err == nil {
-		return s.wrapStream(conn, o), nil
+		return s.wrapStream(conn, o, primaryRoute), nil
 	}
 	s.logger.ErrorContext(ctx, err)
 	// Attribute the failure to the outer (member) tag so rankLocked and
@@ -494,7 +496,7 @@ func (s *MutableAutoSelect) DialContext(ctx context.Context, network string, des
 		conn, err = alt.DialContext(ctx, network, destination)
 		if err == nil {
 			go s.runLadder(outerTag)
-			return s.wrapStream(conn, alt), nil
+			return s.wrapStream(conn, alt, fallbackRoute), nil
 		}
 		s.logger.ErrorContext(ctx, err)
 		s.recordUserFailure(altTag, adapter.UserFailureDial)
@@ -523,7 +525,7 @@ func (s *MutableAutoSelect) ListenPacket(ctx context.Context, destination M.Sock
 	outerTag := o.Tag()
 	conn, err := o.ListenPacket(ctx, destination)
 	if err == nil {
-		return s.wrapPacket(conn, o), nil
+		return s.wrapPacket(conn, o, primaryRoute), nil
 	}
 	s.logger.ErrorContext(ctx, err)
 	s.recordUserFailure(outerTag, adapter.UserFailureDial)
@@ -534,7 +536,7 @@ func (s *MutableAutoSelect) ListenPacket(ctx context.Context, destination M.Sock
 		conn, err = alt.ListenPacket(ctx, destination)
 		if err == nil {
 			go s.runLadder(outerTag)
-			return s.wrapPacket(conn, alt), nil
+			return s.wrapPacket(conn, alt, fallbackRoute), nil
 		}
 		s.logger.ErrorContext(ctx, err)
 		s.recordUserFailure(altTag, adapter.UserFailureDial)
@@ -546,14 +548,31 @@ func (s *MutableAutoSelect) ListenPacket(ctx context.Context, destination M.Sock
 	return nil, err
 }
 
-func (s *MutableAutoSelect) wrapStream(conn net.Conn, o A.Outbound) net.Conn {
-	onStall, onActivity := s.makeHooks(o.Tag())
+// routeKind records whether a conn used the selected member or a
+// fast-failover alternate.
+type routeKind uint8
+
+const (
+	primaryRoute routeKind = iota
+	fallbackRoute
+)
+
+// chargeable reports whether a data-plane failure should count against tag.
+// Primary-route failures are counted only while tag is selected for TCP or
+// UDP; fallback-route failures are always counted as fresh failover traffic.
+func (s *MutableAutoSelect) chargeable(tag string, route routeKind) bool {
+	return !s.cfg.demoteOnlySelected || route == fallbackRoute ||
+		loadString(&s.stickyTag.tcp) == tag || loadString(&s.stickyTag.udp) == tag
+}
+
+func (s *MutableAutoSelect) wrapStream(conn net.Conn, o A.Outbound, route routeKind) net.Conn {
+	onStall, onActivity := s.makeHooks(o.Tag(), route)
 	wrapped := newDataPlaneStream(conn, s.cfg.dataPlaneIdle, s.cfg.dataPlaneProvedRead, onStall, onActivity)
 	return adapter.NewTaggedConn(wrapped, realTag(o))
 }
 
-func (s *MutableAutoSelect) wrapPacket(conn net.PacketConn, o A.Outbound) net.PacketConn {
-	onStall, onActivity := s.makeHooks(o.Tag())
+func (s *MutableAutoSelect) wrapPacket(conn net.PacketConn, o A.Outbound, route routeKind) net.PacketConn {
+	onStall, onActivity := s.makeHooks(o.Tag(), route)
 	wrapped := newDataPlanePacket(conn, s.cfg.dataPlaneIdle, s.cfg.dataPlaneProvedRead, onStall, onActivity)
 	return adapter.NewTaggedPacketConn(wrapped, realTag(o))
 }
@@ -595,7 +614,7 @@ func (s *MutableAutoSelect) selectForExcluding(network, excludeTag string) (A.Ou
 			return c.tag == excludeTag
 		})
 	}
-	pool := s.splitHealthyForLocked(ranked, network)
+	pool, forNetwork := s.splitHealthyForLocked(ranked, network)
 	if len(pool) == 0 {
 		s.access.Unlock()
 		if excludeTag == "" {
@@ -607,7 +626,7 @@ func (s *MutableAutoSelect) selectForExcluding(network, excludeTag string) (A.Ou
 	}
 	var winner rankedCandidate
 	if excludeTag == "" {
-		winner = s.applyStickiness(network, slot, pool)
+		winner = s.applyStickiness(network, slot, pool, forNetwork)
 		prev := loadString(slot)
 		if prev != winner.tag {
 			slot.Store(winner.tag)
@@ -622,28 +641,53 @@ func (s *MutableAutoSelect) selectForExcluding(network, excludeTag string) (A.Ou
 	return winner.outbound, nil
 }
 
-// applyStickiness applies the spec's switch-tolerance hysteresis: keep
-// the sticky tag if it's in pool and the rank winner doesn't beat it by
-// at least switchTolerance. Caller must hold s.access.
-func (s *MutableAutoSelect) applyStickiness(network string, slot *atomic.Value, pool []rankedCandidate) rankedCandidate {
+// applyStickiness applies switch-tolerance hysteresis. It looks for the
+// sticky tag across every demotion tier, not just pool, so soft demotion
+// still goes through the normal comparison instead of looking like removal.
+//
+// Retention is capped at softFailLimit failures; beyond that, continuing
+// failures release the sticky even if it remains much faster.
+//
+// Caller must hold s.access.
+func (s *MutableAutoSelect) applyStickiness(network string, slot *atomic.Value, pool, forNetwork []rankedCandidate) rankedCandidate {
 	best := pool[0]
 	sticky := loadString(slot)
 	if sticky == "" || sticky == best.tag {
 		return best
 	}
-	for _, c := range pool {
-		if c.tag != sticky {
-			continue
-		}
-		tolMs := uint64(s.cfg.switchTolerance / time.Millisecond)
-		if uint64(best.delayMs)+tolMs <= uint64(c.delayMs) {
-			s.logger.Info(network, " switch: ", c.tag, "(", c.delayMs, "ms) -> ", best.tag, "(", best.delayMs, "ms)")
-			return best
-		}
+	idx := slices.IndexFunc(forNetwork, func(c rankedCandidate) bool {
+		return c.tag == sticky
+	})
+	if idx < 0 {
+		s.logSwitch(network, sticky, best, "not a candidate")
+		return best
+	}
+	c := forNetwork[idx]
+	switch {
+	case c.kind != best.kind:
+		// The tolerance comparison only means something between measurements
+		// of the same nature: kindUnknown carries delayMs 0 and
+		// kindSubstituted a synthetic constant, so comparing across kinds
+		// would let a never-probed sticky's 0ms retain it against a real
+		// measurement. rankLocked already sorts demote, then kind, then
+		// delay, so defer to that ordering.
+		s.logSwitch(network, sticky, best, "kind outranked")
+	case c.demote == demoteHard && best.demote < demoteHard:
+		s.logSwitch(network, sticky, best, "hard-demoted")
+	case c.demote > best.demote && c.userFails > s.hist.softFailLimit:
+		s.logSwitch(network, sticky, best, "failures past retention")
+	case uint64(best.delayMs)+uint64(s.cfg.switchTolerance/time.Millisecond) <= uint64(c.delayMs):
+		s.logSwitch(network, sticky, best, "beaten on delay")
+	default:
 		return c
 	}
-	s.logger.Info(network, " switch: ", sticky, " -> ", best.tag, " (sticky not in pool)")
 	return best
+}
+
+// logSwitch records which rule moved the group off sticky; a churn report is
+// only actionable if the logs say that.
+func (s *MutableAutoSelect) logSwitch(network, sticky string, best rankedCandidate, reason string) {
+	s.logger.Info(network, " switch: ", sticky, " -> ", best.tag, " (", reason, ")")
 }
 
 // clearStickyTagLocked drops the sticky tag for any network where it
@@ -749,23 +793,22 @@ const (
 )
 
 type rankedCandidate struct {
-	outbound A.Outbound
-	tag      string
-	delayMs  uint32
-	demote   demoteLevel
-	kind     candidateKind
+	outbound  A.Outbound
+	tag       string
+	delayMs   uint32
+	demote    demoteLevel
+	kind      candidateKind
+	userFails uint32
 }
 
-// splitHealthyForLocked restricts ranked to candidates supporting network,
-// then returns the cleanest non-empty subset: clean if any exist, else
-// soft-demoted, else the network-filtered slice (hard-demoted as last
-// resort). Per-network so a soft-only UDP candidate isn't drowned out
-// by a clean TCP-only peer.
+// splitHealthyForLocked filters ranked to network and returns the cleanest
+// non-empty tier as pool (clean, then soft, then hard). forNetwork contains
+// all filtered candidates so stickiness can evaluate a demoted tag outside
+// pool.
 //
-// ranked must be demote-sorted ascending (clean < soft < hard), as rankLocked returns it,
-// so each tier is contiguous. Requires access held: the result aliases s.scratchSplit
-// until the caller releases the lock.
-func (s *MutableAutoSelect) splitHealthyForLocked(ranked []rankedCandidate, network string) []rankedCandidate {
+// ranked must be sorted by demote level, as rankLocked returns it. Requires
+// s.access; both returned slices alias s.scratchSplit.
+func (s *MutableAutoSelect) splitHealthyForLocked(ranked []rankedCandidate, network string) (pool, forNetwork []rankedCandidate) {
 	clear(s.scratchSplit)
 	out := s.scratchSplit[:0]
 	var nClean, nSoft int
@@ -784,11 +827,11 @@ func (s *MutableAutoSelect) splitHealthyForLocked(ranked []rankedCandidate, netw
 	s.scratchSplit = out
 	switch {
 	case nClean > 0:
-		return out[:nClean]
+		return out[:nClean], out
 	case nSoft > 0:
-		return out[nClean : nClean+nSoft]
+		return out[nClean : nClean+nSoft], out
 	default:
-		return out
+		return out, out
 	}
 }
 
@@ -911,7 +954,7 @@ func (s *MutableAutoSelect) rankLocked(now time.Time, freshSince time.Time) []ra
 		case soft:
 			level = demoteSoft
 		}
-		out = append(out, rankedCandidate{outbound: p.o, tag: p.tag, delayMs: p.delayMs, kind: p.kind, demote: level})
+		out = append(out, rankedCandidate{outbound: p.o, tag: p.tag, delayMs: p.delayMs, kind: p.kind, demote: level, userFails: p.userFails})
 	}
 	s.scratchRanked = out
 	sort.SliceStable(out, func(i, j int) bool {

--- a/protocol/group/mutableautoselect_dataplane.go
+++ b/protocol/group/mutableautoselect_dataplane.go
@@ -12,15 +12,14 @@ import (
 	"github.com/getlantern/lantern-box/adapter"
 )
 
-// makeHooks returns the (onFailure, onActivity) callback pair wired into
-// the data-plane wrappers. Callbacks re-look-up the member's history
-// at fire time so a Remove+Add cycle can't strand writes on a stale
-// entry. The failure callback short-circuits when recordUserFailure
-// reports a dedup/non-member, so a single broken outbound with N
-// orphan idle conns doesn't trigger N redundant full-fleet probe
-// sweeps.
-func (s *MutableAutoSelect) makeHooks(outerTag string) (onFailure func(adapter.UserFailureKind), onActivity func()) {
+// makeHooks returns callbacks wired into data-plane wrappers. Failure
+// handling re-checks membership at fire time, drops non-chargeable or
+// deduped events, and starts a ladder only for recorded failures.
+func (s *MutableAutoSelect) makeHooks(outerTag string, route routeKind) (onFailure func(adapter.UserFailureKind), onActivity func()) {
 	onFailure = func(kind adapter.UserFailureKind) {
+		if !s.chargeable(outerTag, route) {
+			return
+		}
 		if !s.recordUserFailure(outerTag, kind) {
 			return
 		}

--- a/protocol/group/mutableautoselect_test.go
+++ b/protocol/group/mutableautoselect_test.go
@@ -16,6 +16,7 @@ import (
 	sbAdapter "github.com/sagernet/sing-box/adapter"
 	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing/common/metadata"
 	"github.com/sagernet/sing/common/x/list"
 	"github.com/sagernet/sing/service"
 	"github.com/sagernet/sing/service/pause"
@@ -46,14 +47,15 @@ func newTestMUR(t *testing.T, tags ...string) (*MutableAutoSelect, map[string]*m
 		urlOverrides: map[string]string{},
 		histories:    map[string]*localHistory{},
 		cfg: mutableAutoSelectConfig{
-			switchTolerance:   50 * time.Millisecond,
-			activeInterval:    time.Hour,
-			idleInterval:      4 * time.Hour,
-			idleThreshold:     10 * time.Minute,
-			ladderTotalBudget: 100 * time.Millisecond,
-			dataPlaneIdle:     time.Hour,
-			maxPersistedAge:   defaultMaxPersistedAge,
-			probeConcurrency:  defaultProbeConcurrency,
+			switchTolerance:    50 * time.Millisecond,
+			activeInterval:     time.Hour,
+			idleInterval:       4 * time.Hour,
+			idleThreshold:      10 * time.Minute,
+			ladderTotalBudget:  100 * time.Millisecond,
+			dataPlaneIdle:      time.Hour,
+			demoteOnlySelected: true,
+			maxPersistedAge:    defaultMaxPersistedAge,
+			probeConcurrency:   defaultProbeConcurrency,
 		},
 		hist:         defaultHistoryParams(),
 		history:      adapter.NewAutoSelectHistoryStorage(),
@@ -376,9 +378,21 @@ func TestRank_SwitchPenaltyOnlyAppliesToRealSeeded(t *testing.T) {
 		"unknown-mid must not be rescued — its 0ms self-delay is a sentinel, not a measurement")
 }
 
-// addUserFailureN appends n failures to tag's in-memory history.
-// Passes dedupe=0 so the helper can deterministically seed any count
-// without depending on the dedupe window.
+// userFailures copies a member's user-failure window under the history's
+// lock. Tests avoid direct localHistory reads because probe goroutines mutate
+// entries through locked methods.
+func userFailures(s *MutableAutoSelect, tag string) ([]adapter.UserFailure, bool) {
+	s.access.Lock()
+	h, ok := s.peekHistoryLocked(tag)
+	s.access.Unlock()
+	if !ok {
+		return nil, false
+	}
+	_, _, _, uf := h.snapshot(time.Now(), s.hist.userFailureWindow)
+	return uf, true
+}
+
+// addUserFailureN appends n failures to tag's history with dedupe disabled.
 func addUserFailureN(s *MutableAutoSelect, tag string, n int) {
 	s.access.Lock()
 	defer s.access.Unlock()
@@ -760,47 +774,44 @@ func TestMakeHooks_StallAppendsSingleUserFailure(t *testing.T) {
 	// error. The demote rule hits hard at three failures in window, not
 	// one. (Spec change from earlier "one-shot hard demote.")
 	s, _ := newTestMUR(t, "a")
-	onStall, _ := s.makeHooks("a")
+	s.stickyTag.tcp.Store("a")
+	onStall, _ := s.makeHooks("a", primaryRoute)
 	onStall(adapter.UserFailureStall)
-	s.access.Lock()
-	h, ok := s.peekHistoryLocked("a")
-	s.access.Unlock()
+	uf, ok := userFailures(s, "a")
 	require.True(t, ok)
-	assert.Equal(t, uint32(1), h.userFailureCount(time.Now(), s.hist.userFailureWindow),
+	require.Len(t, uf, 1,
 		"a single stall must contribute exactly one user-failure timestamp")
-	require.Len(t, h.userFailures, 1)
-	assert.Equal(t, adapter.UserFailureStall, h.userFailures[0].Kind,
+	assert.Equal(t, adapter.UserFailureStall, uf[0].Kind,
 		"the stall hook must record the failure as a stall")
 }
 
 func TestMakeHooks_PropagatesFailureKind(t *testing.T) {
 	s, _ := newTestMUR(t, "a")
-	onStall, _ := s.makeHooks("a")
+	s.stickyTag.tcp.Store("a")
+	onStall, _ := s.makeHooks("a", primaryRoute)
 	onStall(adapter.UserFailureReset)
-	s.access.Lock()
-	h, ok := s.peekHistoryLocked("a")
-	s.access.Unlock()
+	uf, ok := userFailures(s, "a")
 	require.True(t, ok)
-	require.Len(t, h.userFailures, 1)
-	assert.Equal(t, adapter.UserFailureReset, h.userFailures[0].Kind,
+	require.Len(t, uf, 1)
+	assert.Equal(t, adapter.UserFailureReset, uf[0].Kind,
 		"makeHooks must record the failure under the kind the watchdog reports")
 }
 
 func TestRecordUserFailure_AttributesDialKind(t *testing.T) {
 	s, _ := newTestMUR(t, "a")
 	require.True(t, s.recordUserFailure("a", adapter.UserFailureDial))
-	s.access.Lock()
-	h, ok := s.peekHistoryLocked("a")
-	s.access.Unlock()
+	uf, ok := userFailures(s, "a")
 	require.True(t, ok)
-	require.Len(t, h.userFailures, 1)
-	assert.Equal(t, adapter.UserFailureDial, h.userFailures[0].Kind,
+	require.Len(t, uf, 1)
+	assert.Equal(t, adapter.UserFailureDial, uf[0].Kind,
 		"a dial-site failure must record the failure as a dial error")
 }
 
-func TestRecordUserFailure_DemotesTagInNextSelectFor(t *testing.T) {
+func TestRecordUserFailure_SoftDemotedStickyStillLosesOnDelay(t *testing.T) {
+	// Retention is not immunity: a soft-demoted sticky within its failure
+	// budget is still judged by the ordinary switchTolerance comparison.
 	s, _ := newTestMUR(t, "a", "b")
-	recordSuccess(s, "a", 50)
+	recordSuccess(s, "a", 200)
 	recordSuccess(s, "b", 100)
 	s.stickyTag.tcp.Store("a")
 
@@ -812,7 +823,76 @@ func TestRecordUserFailure_DemotesTagInNextSelectFor(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "b", got.Tag(),
-		"soft-demoted a must lose to clean b on the next selectFor")
+		"a soft-demoted sticky beaten by the tolerance must still hand over")
+}
+
+func TestRecordUserFailure_SoftDemotedStickyKeptOverSlowerPeer(t *testing.T) {
+	// Regression guard: soft demotion must use hysteresis, not look like a
+	// departed sticky just because the tag is outside the clean pool.
+	s, _ := newTestMUR(t, "a", "b")
+	recordSuccess(s, "a", 50)
+	recordSuccess(s, "b", 100)
+	s.stickyTag.tcp.Store("a")
+
+	addUserFailureN(s, "a", int(s.hist.softFailLimit))
+
+	got, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "a", got.Tag(),
+		"soft-demoted sticky must be kept over a strictly slower clean peer")
+}
+
+func TestRecordUserFailure_HardDemotedStickyDropsRegardlessOfDelay(t *testing.T) {
+	// A hard demote is evidence the member is broken, not evidence about
+	// latency, so no amount of measured speed advantage retains it.
+	s, _ := newTestMUR(t, "a", "b")
+	// Delays stay within switchPenaltyAltFactor of each other so the
+	// hard-demote limit is not doubled; see the boost case below.
+	recordSuccess(s, "a", 100)
+	recordSuccess(s, "b", 200)
+	s.stickyTag.tcp.Store("a")
+
+	addUserFailureN(s, "a", int(s.hist.consecutiveFailLimit))
+
+	got, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "b", got.Tag(),
+		"hard-demoted sticky must be dropped even for a slower clean peer")
+}
+
+func TestRecordUserFailure_RetentionBoundedBySoftLimit(t *testing.T) {
+	// Speed-based soft-demote boosts must not extend sticky retention past
+	// softFailLimit.
+	s, _ := newTestMUR(t, "a", "b")
+	recordSuccess(s, "a", 10)
+	recordSuccess(s, "b", 900)
+	s.stickyTag.tcp.Store("a")
+
+	addUserFailureN(s, "a", int(s.hist.softFailLimit))
+	got, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	require.Equal(t, "a", got.Tag(),
+		"retention must absorb the failure count that trips the soft demote")
+
+	addUserFailureN(s, "a", 1)
+	got, err = s.selectFor("tcp")
+	require.NoError(t, err)
+	assert.Equal(t, "b", got.Tag(),
+		"one failure past softFailLimit must release the sticky regardless of speed")
+}
+
+func TestApplyStickiness_DepartedStickyFallsToBest(t *testing.T) {
+	s, _ := newTestMUR(t, "b")
+	recordSuccess(s, "b", 100)
+	s.stickyTag.tcp.Store("gone")
+
+	got, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "b", got.Tag(),
+		"a sticky that is no longer a candidate must fall through to the rank winner")
 }
 
 func TestSplitHealthyFor_PrefersCleanOverSoftOverHard(t *testing.T) {
@@ -823,15 +903,16 @@ func TestSplitHealthyFor_PrefersCleanOverSoftOverHard(t *testing.T) {
 
 	s := &MutableAutoSelect{}
 	// ranked must be demote-sorted (clean < soft < hard), as rankLocked returns it.
-	pool := s.splitHealthyForLocked([]rankedCandidate{mk("clean", demoteClean), mk("soft", demoteSoft), mk("hard", demoteHard)}, "tcp")
+	pool, forNetwork := s.splitHealthyForLocked([]rankedCandidate{mk("clean", demoteClean), mk("soft", demoteSoft), mk("hard", demoteHard)}, "tcp")
 	require.Len(t, pool, 1)
 	assert.Equal(t, "clean", pool[0].tag)
+	assert.Len(t, forNetwork, 3, "forNetwork keeps every tier so applyStickiness can find a demoted sticky")
 
-	pool = s.splitHealthyForLocked([]rankedCandidate{mk("soft", demoteSoft), mk("hard", demoteHard)}, "tcp")
+	pool, _ = s.splitHealthyForLocked([]rankedCandidate{mk("soft", demoteSoft), mk("hard", demoteHard)}, "tcp")
 	require.Len(t, pool, 1)
 	assert.Equal(t, "soft", pool[0].tag)
 
-	pool = s.splitHealthyForLocked([]rankedCandidate{mk("hard", demoteHard)}, "tcp")
+	pool, _ = s.splitHealthyForLocked([]rankedCandidate{mk("hard", demoteHard)}, "tcp")
 	assert.Len(t, pool, 1)
 }
 
@@ -843,11 +924,11 @@ func TestSplitHealthyFor_KeepsSoftWhenCleanIsOtherNetwork(t *testing.T) {
 		{outbound: bothSoft, tag: "both-soft", demote: demoteSoft, delayMs: 50},
 	}
 	s := &MutableAutoSelect{}
-	tcpPool := s.splitHealthyForLocked(ranked, "tcp")
+	tcpPool, _ := s.splitHealthyForLocked(ranked, "tcp")
 	require.Len(t, tcpPool, 1, "tcp pool should be clean-only")
 	assert.Equal(t, "tcp-only", tcpPool[0].tag)
 
-	udpPool := s.splitHealthyForLocked(ranked, "udp")
+	udpPool, _ := s.splitHealthyForLocked(ranked, "udp")
 	require.Len(t, udpPool, 1, "udp pool should fall through to soft when no clean udp candidate exists")
 	assert.Equal(t, "both-soft", udpPool[0].tag)
 }
@@ -1567,4 +1648,119 @@ func TestClose_RaceWithEmitExhaustionDoesNotPanic(t *testing.T) {
 		}()
 		wg.Wait()
 	}
+}
+
+func TestMakeHooks_IgnoresFailureFromUnselectedTag(t *testing.T) {
+	// Stale conns from a tag that is no longer selected should not keep that
+	// tag demoted after traffic has moved elsewhere.
+	s, _ := newTestMUR(t, "a", "b")
+	s.stickyTag.tcp.Store("b")
+	s.stickyTag.udp.Store("b")
+
+	onStall, _ := s.makeHooks("a", primaryRoute)
+	onStall(adapter.UserFailureStall)
+
+	s.access.Lock()
+	_, ok := s.peekHistoryLocked("a")
+	s.access.Unlock()
+	assert.False(t, ok,
+		"a stall on a member that is no longer selected must not be recorded")
+}
+
+func TestMakeHooks_RecordsFailureFromUDPSelectionOnly(t *testing.T) {
+	// The gate spans both networks: a member carrying UDP is still
+	// selected even when TCP has moved elsewhere.
+	s, _ := newTestMUR(t, "a", "b")
+	s.stickyTag.tcp.Store("b")
+	s.stickyTag.udp.Store("a")
+
+	onStall, _ := s.makeHooks("a", primaryRoute)
+	onStall(adapter.UserFailureStall)
+
+	uf, ok := userFailures(s, "a")
+	require.True(t, ok, "the udp selection must still be chargeable")
+	assert.Len(t, uf, 1)
+}
+
+func TestMakeHooks_UnselectedGateDisabledByConfig(t *testing.T) {
+	s, _ := newTestMUR(t, "a", "b")
+	s.cfg.demoteOnlySelected = false
+	s.stickyTag.tcp.Store("b")
+
+	onStall, _ := s.makeHooks("a", primaryRoute)
+	onStall(adapter.UserFailureStall)
+
+	uf, ok := userFailures(s, "a")
+	require.True(t, ok, "the gate must be defeatable for rollback")
+	assert.Len(t, uf, 1)
+}
+
+func TestMakeHooks_ChargesFallbackRouteEvenWhenUnselected(t *testing.T) {
+	// Fast-failover conns are fresh traffic and remain chargeable even though
+	// selectForExcluding does not make them sticky.
+	s, _ := newTestMUR(t, "a", "b")
+	s.stickyTag.tcp.Store("a")
+
+	onStall, _ := s.makeHooks("b", fallbackRoute)
+	onStall(adapter.UserFailureReset)
+
+	uf, ok := userFailures(s, "b")
+	require.True(t, ok, "a fallback-route conn must stay chargeable")
+	require.Len(t, uf, 1)
+	assert.Equal(t, adapter.UserFailureReset, uf[0].Kind)
+}
+
+func TestDialContext_FastFailoverConnStaysChargeable(t *testing.T) {
+	// End-to-end fallback attribution: b's reset is charged to b even though
+	// a remains sticky.
+	s, obs := newTestMUR(t, "a", "b")
+	recordSuccess(s, "a", 10)
+	recordSuccess(s, "b", 20)
+	obs["a"].dial = func(context.Context) (net.Conn, error) {
+		return nil, errors.New("dial refused")
+	}
+	obs["b"].dial = func(context.Context) (net.Conn, error) {
+		return &failingConn{err: connResetErr(), failWrite: true}, nil
+	}
+
+	conn, err := s.DialContext(context.Background(), "tcp", metadata.Socksaddr{})
+	require.NoError(t, err, "fast failover should have produced b's conn")
+	require.Equal(t, "a", loadString(&s.stickyTag.tcp),
+		"fast failover must not move the sticky tag")
+
+	_, err = conn.Write([]byte("x"))
+	require.Error(t, err, "the fallback conn should fail the write")
+
+	require.Eventually(t, func() bool {
+		uf, _ := userFailures(s, "b")
+		return len(uf) == 1
+	}, time.Second, 5*time.Millisecond,
+		"a reset on the fallback conn must be charged to b")
+}
+
+func TestApplyStickiness_UnmeasuredStickyLosesToMeasuredPeer(t *testing.T) {
+	// Unknown delay is a sentinel, not a 0ms measurement; a measured clean
+	// peer should outrank an unmeasured soft-demoted sticky.
+	s, _ := newTestMUR(t, "a", "b")
+	recordSuccess(s, "b", 300)
+	s.stickyTag.tcp.Store("a")
+	addUserFailureN(s, "a", int(s.hist.softFailLimit))
+
+	got, err := s.selectFor("tcp")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "b", got.Tag(),
+		"an unmeasured, soft-demoted sticky must lose to a measured clean peer")
+}
+
+func TestChargeable_Policy(t *testing.T) {
+	s, _ := newTestMUR(t, "a", "b")
+	s.stickyTag.tcp.Store("a")
+
+	assert.True(t, s.chargeable("a", primaryRoute), "the selection is chargeable")
+	assert.False(t, s.chargeable("b", primaryRoute), "an unselected primary conn is not")
+	assert.True(t, s.chargeable("b", fallbackRoute), "a fallback route is exempt from the gate")
+
+	s.cfg.demoteOnlySelected = false
+	assert.True(t, s.chargeable("b", primaryRoute), "the gate off makes everything chargeable")
 }


### PR DESCRIPTION
## Problem

A user reported their exit location changing constantly. Over a 92-minute log capture:

- **42 TCP exit changes**, median dwell **104s**, 23 distinct exits with **19 revisits** — cycling, not converging
- **57 of 57** switches logged `(sticky not in pool)`; **0** went through the `switchTolerance` hysteresis
- 99 `user failure: kind=stall`, vs 3 `dial` and 14 `reset`
- 38 of 99 stalls charged to a tag that was **no longer the selected outbound**
- 11 of 44 ladder runs kicked by a "stall" on tag T returned `ladder found winner: T` — the "stalled" server won a full re-probe seconds later
- 59 of 60 members had a fresh successful probe

## Root cause

`applyStickiness` searched for the sticky tag in the `pool` returned by `splitHealthyForLocked`, which is **only the cleanest demote tier**. A soft demote — `softFailLimit` (default 2) user failures in the window — removes the current selection from that set. The miss was then read as "this member is gone" and handed traffic straight to the rank winner, never consulting `switchTolerance`.

On a fleet where nearly every member has a fresh probe, the clean tier is always populated, so this was reachable on **every** soft demote. Two transient stalls were enough to move the user, and the replacement then soft-demoted in turn.

## Fix

Look the sticky up in `forNetwork` (every tier) and keep the tolerance comparison.

**Retention is bounded to `softFailLimit` failures.** Sizing this came from the capture rather than judgment — distribution of failures the outgoing member had at switch time:

| failures | switches | cumulative |
|---:|---:|---:|
| 1 | 2 | 3% |
| **2** | **44** | **80%** |
| 3 | 6 | 91% |
| 4 | 2 | 94% |
| 5 | 3 | 100% |

**77% fired at exactly `softFailLimit`.** The churn was the threshold trip, not sustained failure — so retention only needs to absorb that trip. Releasing one failure past it keeps a genuinely failing member from being defended, and stops `demoted()`'s switch-penalty boost (which doubles the hard limit for a much faster member) from compounding into a long stay on a dead-but-fast tunnel.

### Two further fixes in the same path

**Cross-kind comparisons no longer decide retention.** `kindUnknown` carries `delayMs 0` and `kindSubstituted` a synthetic constant, so a never-probed sticky's 0ms would outlast real measurements once the soft path made that reachable. Defers to `rankLocked`'s demote/kind/delay ordering instead.

**Data-plane failures are no longer charged to an unselected member.** Conns outlive the switch away from their member and keep firing idle watchdogs, keeping it demoted exactly while it carried no new traffic and could not age back into the pool. The dial site's fast-failover alternate is exempt — `selectForExcluding` leaves it out of the sticky slot by design while routing fresh traffic to it, so its failures are real evidence. Gated by `demote_only_selected_tag` (default on) so the change to what the selector learns can be disabled without a release.

## Detection latency

Deliberately held near baseline, because data-plane stalls are the dominant real failure mode in some regions and any added stickiness is paid on every genuine outage. Measured failures-to-escape a bad sticky, against `main`:

| scenario | main | this PR |
|---|---:|---:|
| fast sticky 50ms, peers 6× slower | 2 | 3 |
| fast sticky 50ms, peers 2× slower | 2 | 3 |
| sticky and peer equal | 2 | 3 |

A flat +1 failure (~30s at the 30s dedupe window) in exchange for suppressing ~80% of the churn. The RST and dial-failure paths are untouched and still immediate: `fireResetFailure` skips the proven/`lastWasWrite` gates, and dial failures are recorded directly rather than through `makeHooks`.

## Testing

New coverage: retention absorbs the threshold trip and releases past it (including against a 90× slower peer, where the switch-penalty boost would otherwise apply); soft sticky still loses on plain tolerance; hard demote hands over immediately; departed sticky; unmeasured sticky loses to a measured peer; the unselected-tag gate across both networks plus its config off-switch; and the fast-failover conn staying chargeable end-to-end through `DialContext`.

Also fixed a **pre-existing** test race, not introduced here: several tests read `localHistory.userFailures` after releasing `s.access`, while `runLadder`'s probe goroutines mutate the same entry. Present on `main` (`require.Len(t, h.userFailures, 1)` in `TestMakeHooks_StallAppendsSingleUserFailure`), so `-race` has been intermittently flaky. All 7 sites now go through a helper that copies under `h.mu`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration to attribute connection failures only to the currently selected TCP or UDP route by default.
  * Preserved failure attribution for fallback and fast-failover traffic when applicable.
  * Improved route selection stability using demotion tiers, failure retention, and measured performance.

* **Bug Fixes**
  * Prevented failures from unselected routes from incorrectly influencing future selections.
  * Improved handling of demoted, departed, and unmeasured routes during reselection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->