### PR TITLE
twiddle: TLS-shaped transport from harvested ClientHellos

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -94,10 +94,11 @@ jobs:
           echo "reflex_cert_fp=$REFLEX_CERT_FP" >> "$GITHUB_OUTPUT"
 
           # Twiddle: the egress holds the ticket key, the client holds only the
-          # credential that key issued. cover=www.example.com so the ticket
-          # length matches what that identity's real server would send.
+          # credential that key issued. The cover must be a measured identity:
+          # its profile is what fixes the ticket length, binder length, cipher
+          # and ServerHello extension order on both sides.
           go run github.com/getlantern/twiddle/cmd/twiddlecred \
-            -client-id 1 -cover www.example.com > twiddle-creds.txt
+            -client-id 1 -cover www.cloudflare.com > twiddle-creds.txt
           echo "twiddle_ticket_key=$(grep ^ticket_key= twiddle-creds.txt | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
           echo "twiddle_ticket=$(grep ^ticket= twiddle-creds.txt | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
           echo "twiddle_psk=$(grep ^psk= twiddle-creds.txt | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
@@ -320,7 +321,7 @@ jobs:
               "listen": "::",
               "listen_port": 9005,
               "ticket_key": "${TWIDDLE_TICKET_KEY}",
-              "masquerade_upstream": "www.example.com:443",
+              "masquerade_upstream": "www.cloudflare.com:443",
               "ticket_max_age": "24h"
             }],
             "outbounds": [{
@@ -680,7 +681,7 @@ jobs:
               "server_port": 9005,
               "ticket": "${TWIDDLE_TICKET}",
               "psk": "${TWIDDLE_PSK}",
-              "cover_sni": "www.example.com"
+              "cover_sni": "www.cloudflare.com"
             }]
           }
           JSONEOF
@@ -736,8 +737,15 @@ jobs:
           # real TLS handshake back. If the egress answers with anything of its
           # own, an active prober has confirmed the transport.
           set +e
+          # The SNI is the cover's own: a prober testing whether this address is
+          # really the cover site asks for the cover site, and the answer has to
+          # be that site's real certificate. -verify_hostname is what makes that
+          # the assertion -- a chain that merely validates says only "some
+          # trusted site", which is not the claim being tested.
           OUT=$(echo | openssl s_client -connect "${DROPLET_IP}:9005" \
-                  -servername www.example.com -tls1_3 2>&1)
+                  -servername www.cloudflare.com \
+                  -verify_hostname www.cloudflare.com -verify_return_error \
+                  -tls1_3 2>&1)
           set -e
           if echo "$OUT" | grep -q "Verify return code: 0 (ok)"; then
             echo "Twiddle probe resistance PASSED (prober reached the cover site)"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -93,6 +93,15 @@ jobs:
           echo "wasm_hash=$WASM_HASH" >> "$GITHUB_OUTPUT"
           echo "reflex_cert_fp=$REFLEX_CERT_FP" >> "$GITHUB_OUTPUT"
 
+          # Twiddle: the egress holds the ticket key, the client holds only the
+          # credential that key issued. cover=www.example.com so the ticket
+          # length matches what that identity's real server would send.
+          go run github.com/getlantern/twiddle/cmd/twiddlecred \
+            -client-id 1 -cover www.example.com > twiddle-creds.txt
+          echo "twiddle_ticket_key=$(grep ^ticket_key= twiddle-creds.txt | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
+          echo "twiddle_ticket=$(grep ^ticket= twiddle-creds.txt | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
+          echo "twiddle_psk=$(grep ^psk= twiddle-creds.txt | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
+
       - name: Install doctl
         uses: digitalocean/action-doctl@v2
         with:
@@ -151,6 +160,7 @@ jobs:
           SAMIZDAT_SHORT_ID: ${{ steps.creds.outputs.samizdat_short_id }}
           WASM_HASH: ${{ steps.creds.outputs.wasm_hash }}
           REFLEX_CERT_FP: ${{ steps.creds.outputs.reflex_cert_fp }}
+          TWIDDLE_TICKET_KEY: ${{ steps.creds.outputs.twiddle_ticket_key }}
         run: |
           SSH_OPTS="-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -i e2e_key"
 
@@ -297,6 +307,30 @@ jobs:
           JSONEOF
           scp $SSH_OPTS /tmp/reflex-server.json root@"$DROPLET_IP":/root/reflex-server.json
 
+          # Twiddle server. masquerade_upstream is not optional hardening: the
+          # transport answers a harvested ClientHello with a synthesised
+          # ServerHello and cannot complete a real handshake, so anything that
+          # fails to authenticate must reach a genuine TLS site instead.
+          cat > /tmp/twiddle-server.json << JSONEOF
+          {
+            "log": {"level": "debug"},
+            "inbounds": [{
+              "type": "twiddle",
+              "tag": "twiddle-in",
+              "listen": "::",
+              "listen_port": 9005,
+              "ticket_key": "${TWIDDLE_TICKET_KEY}",
+              "masquerade_upstream": "www.example.com:443",
+              "ticket_max_age": "24h"
+            }],
+            "outbounds": [{
+              "type": "direct",
+              "tag": "direct"
+            }]
+          }
+          JSONEOF
+          scp $SSH_OPTS /tmp/twiddle-server.json root@"$DROPLET_IP":/root/twiddle-server.json
+
           # Start all 4 sing-box protocol servers + the Unbounded rig
           # (freddie signaling on 9000 + egress SOCKS5+QUIC/WS on 8000 +
           # in-process broflake widget)
@@ -305,6 +339,7 @@ jobs:
           nohup /root/lantern-box run --config /root/samizdat-server.json > /root/samizdat-server.log 2>&1 < /dev/null &
           nohup /root/lantern-box run --config /root/water-server.json > /root/water-server.log 2>&1 < /dev/null &
           nohup /root/lantern-box run --config /root/reflex-server.json > /root/reflex-server.log 2>&1 < /dev/null &
+          nohup /root/lantern-box run --config /root/twiddle-server.json > /root/twiddle-server.log 2>&1 < /dev/null &
           TLS_CERT_FILE=/root/unbounded-rig-cert.pem TLS_KEY_FILE=/root/unbounded-rig-key.pem FREDDIE_ADDR=:9000 EGRESS_ADDR=:8000 nohup /root/unbounded-rig > /root/unbounded-rig.log 2>&1 < /dev/null &
           sleep 1"
           echo "Servers launched"
@@ -314,7 +349,7 @@ jobs:
           echo "Checking port readiness..."
           # Note: must use bash explicitly since Ubuntu default shell is dash (no /dev/tcp support)
           ssh $SSH_OPTS root@"$DROPLET_IP" bash << 'READYEOF'
-            for port in 9001 9002 9003 9004 9000 8000; do
+            for port in 9001 9002 9003 9004 9005 9000 8000; do
               echo "Waiting for port $port to be ready..."
               for i in $(seq 1 60); do
                 if echo > /dev/tcp/127.0.0.1/$port 2>/dev/null; then
@@ -619,6 +654,99 @@ jobs:
 
           kill $CLIENT_PID 2>/dev/null || true
 
+      - name: Test Twiddle
+        id: test_twiddle
+        continue-on-error: true
+        env:
+          DROPLET_IP: ${{ steps.droplet.outputs.droplet_ip }}
+          TWIDDLE_TICKET: ${{ steps.creds.outputs.twiddle_ticket }}
+          TWIDDLE_PSK: ${{ steps.creds.outputs.twiddle_psk }}
+        run: |
+          # cover_sni must agree with the egress's masquerade_upstream, or the
+          # SNI names one site while probes are answered by another.
+          cat > /tmp/twiddle-client.json << JSONEOF
+          {
+            "log": {"level": "debug"},
+            "inbounds": [{
+              "type": "mixed",
+              "tag": "mixed-in",
+              "listen": "127.0.0.1",
+              "listen_port": 1085
+            }],
+            "outbounds": [{
+              "type": "twiddle",
+              "tag": "twiddle-out",
+              "server": "${DROPLET_IP}",
+              "server_port": 9005,
+              "ticket": "${TWIDDLE_TICKET}",
+              "psk": "${TWIDDLE_PSK}",
+              "cover_sni": "www.example.com"
+            }]
+          }
+          JSONEOF
+
+          setsid ./lantern-box run --config /tmp/twiddle-client.json > /tmp/twiddle-client.log 2>&1 &
+          CLIENT_PID=$!
+          sleep 3
+
+          if ! kill -0 $CLIENT_PID 2>/dev/null; then
+            echo "Twiddle client failed to start"
+            cat /tmp/twiddle-client.log
+            exit 1
+          fi
+
+          for scheme in http https; do
+            set +e
+            RESPONSE=$(curl -sf -x socks5h://127.0.0.1:1085 -m 30 $scheme://example.com)
+            CURL_EXIT=$?
+            set -e
+            if echo "$RESPONSE" | grep -q "Example Domain"; then
+              echo "Twiddle $scheme test PASSED"
+            else
+              echo "Twiddle $scheme test FAILED (curl exit code: $CURL_EXIT)"
+              cat /tmp/twiddle-client.log
+              kill $CLIENT_PID 2>/dev/null || true
+              exit 1
+            fi
+          done
+
+          # Two connections in a row exercise ticket rotation: the egress issues
+          # the next credential in each flight, and a stale ticket would fail here.
+          set +e
+          curl -sf -x socks5h://127.0.0.1:1085 -m 30 https://example.com > /dev/null
+          SECOND=$?
+          set -e
+          if [ $SECOND -ne 0 ]; then
+            echo "Twiddle second-connection (ticket rotation) test FAILED"
+            cat /tmp/twiddle-client.log
+            kill $CLIENT_PID 2>/dev/null || true
+            exit 1
+          fi
+          echo "Twiddle ticket-rotation test PASSED"
+
+          kill $CLIENT_PID 2>/dev/null || true
+
+      - name: Test Twiddle probe resistance
+        id: test_twiddle_probe
+        continue-on-error: true
+        env:
+          DROPLET_IP: ${{ steps.droplet.outputs.droplet_ip }}
+        run: |
+          # An unauthenticated peer must be forwarded to the cover site and get a
+          # real TLS handshake back. If the egress answers with anything of its
+          # own, an active prober has confirmed the transport.
+          set +e
+          OUT=$(echo | openssl s_client -connect "${DROPLET_IP}:9005" \
+                  -servername www.example.com -tls1_3 2>&1)
+          set -e
+          if echo "$OUT" | grep -q "Verify return code: 0 (ok)"; then
+            echo "Twiddle probe resistance PASSED (prober reached the cover site)"
+          else
+            echo "Twiddle probe resistance FAILED — prober did not get a valid cover handshake"
+            echo "$OUT" | head -30
+            exit 1
+          fi
+
       - name: Test Unbounded
         id: test_unbounded
         continue-on-error: true
@@ -720,6 +848,18 @@ jobs:
             echo "WATER:     PASSED"
           else
             echo "WATER:     FAILED"
+            FAILED=1
+          fi
+          if [ "${{ steps.test_twiddle.outcome }}" = "success" ]; then
+            echo "| Twiddle | PASS |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Twiddle | FAIL |" >> $GITHUB_STEP_SUMMARY
+            FAILED=1
+          fi
+          if [ "${{ steps.test_twiddle_probe.outcome }}" = "success" ]; then
+            echo "| Twiddle probe resistance | PASS |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Twiddle probe resistance | FAIL |" >> $GITHUB_STEP_SUMMARY
             FAILED=1
           fi
           if [ "${{ steps.test_reflex.outcome }}" = "success" ]; then

--- a/constant/proxy.go
+++ b/constant/proxy.go
@@ -7,6 +7,7 @@ const (
 	TypeOutline   = "outline"
 	TypeReflex    = "reflex"
 	TypeSamizdat  = "samizdat"
+	TypeTwiddle   = "twiddle"
 	TypeUnbounded = "unbounded"
 	TypeWATER     = "water"
 )

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395
 	github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb
-	github.com/getlantern/twiddle v0.0.0-20260826224025-1f6cf44029c0
+	github.com/getlantern/twiddle v0.0.0-20260827024137-01de38879c31
 	github.com/gobwas/ws v1.4.0
 	github.com/pion/transport/v4 v4.0.1
 	github.com/refraction-networking/water v0.7.1-alpha

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395
 	github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb
-	github.com/getlantern/twiddle v0.0.0-20260902161425-894e99232116
+	github.com/getlantern/twiddle v0.0.0-20260903233256-43f3d2d3b625
 	github.com/gobwas/ws v1.4.0
 	github.com/pion/transport/v4 v4.0.1
 	github.com/refraction-networking/water v0.7.1-alpha

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395
 	github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb
-	github.com/getlantern/twiddle v0.0.0-20260827024137-01de38879c31
+	github.com/getlantern/twiddle v0.0.0-20260902161425-894e99232116
 	github.com/gobwas/ws v1.4.0
 	github.com/pion/transport/v4 v4.0.1
 	github.com/refraction-networking/water v0.7.1-alpha

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getlantern/lantern-box
 
-go 1.25
+go 1.26.2
 
 // replace github.com/sagernet/sing => github.com/getlantern/sing v0.7.18-lantern
 
@@ -29,6 +29,7 @@ require (
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395
 	github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb
+	github.com/getlantern/twiddle v0.0.0-20260826202959-3b9eac914d25
 	github.com/gobwas/ws v1.4.0
 	github.com/pion/transport/v4 v4.0.1
 	github.com/refraction-networking/water v0.7.1-alpha

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getlantern/lantern-box
 
-go 1.26.2
+go 1.25
 
 // replace github.com/sagernet/sing => github.com/getlantern/sing v0.7.18-lantern
 
@@ -29,7 +29,7 @@ require (
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395
 	github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb
-	github.com/getlantern/twiddle v0.0.0-20260826202959-3b9eac914d25
+	github.com/getlantern/twiddle v0.0.0-20260826224025-1f6cf44029c0
 	github.com/gobwas/ws v1.4.0
 	github.com/pion/transport/v4 v4.0.1
 	github.com/refraction-networking/water v0.7.1-alpha

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/getlantern/sing-box-minimal v1.13.19-lantern h1:dwVCskH9N3Q5a2wVELdyG
 github.com/getlantern/sing-box-minimal v1.13.19-lantern/go.mod h1:4E8WvF7Vi60N1NtPw1CeG994J/yiJZZkty5dKKwG+V0=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5 h1:6ITBYqNkLbVZ1tQNXwmH8N80rZtvyW6IZa8L6EAhBQo=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5/go.mod h1:gx3dPUhZtQszPX5C+TshhxPXQHlY5t4gMnOOMA+viPA=
-github.com/getlantern/twiddle v0.0.0-20260827024137-01de38879c31 h1:u2BIRRP8/73qtsheA+ZwMiusHXgvd5MjVnAo+WOmNqQ=
-github.com/getlantern/twiddle v0.0.0-20260827024137-01de38879c31/go.mod h1:aU9c2/kcZhCxXCOZMN/Vulc+baDNHecqlvgLXOIeyOY=
+github.com/getlantern/twiddle v0.0.0-20260902161425-894e99232116 h1:FFqn/8mrv7WCUJ+vEwxtzMttgXqJXuo8EePYFyv160w=
+github.com/getlantern/twiddle v0.0.0-20260902161425-894e99232116/go.mod h1:aU9c2/kcZhCxXCOZMN/Vulc+baDNHecqlvgLXOIeyOY=
 github.com/getlantern/water v0.7.1-alpha.0.20260309190745-bd547c14b4aa h1:goZee1cURbWPiqX1xyjfwLB/zByQ50hEwonnnyLmcJQ=
 github.com/getlantern/water v0.7.1-alpha.0.20260309190745-bd547c14b4aa/go.mod h1:Yo6Yk++Q9HRaCT+6/eYk3elNoNtjlJ3V5FufHY6ezto=
 github.com/getlantern/wazero v1.11.0-water.1 h1:mzUlaOoQKMDd16yL3mBIFrzg2nEK+gw7mdQgff1nOPQ=

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/getlantern/sing-box-minimal v1.13.19-lantern h1:dwVCskH9N3Q5a2wVELdyG
 github.com/getlantern/sing-box-minimal v1.13.19-lantern/go.mod h1:4E8WvF7Vi60N1NtPw1CeG994J/yiJZZkty5dKKwG+V0=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5 h1:6ITBYqNkLbVZ1tQNXwmH8N80rZtvyW6IZa8L6EAhBQo=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5/go.mod h1:gx3dPUhZtQszPX5C+TshhxPXQHlY5t4gMnOOMA+viPA=
-github.com/getlantern/twiddle v0.0.0-20260826202959-3b9eac914d25 h1:ICm28T2LUfdWqDPlH93sB33P5tJfgtF6K6NZBZQuOn4=
-github.com/getlantern/twiddle v0.0.0-20260826202959-3b9eac914d25/go.mod h1:ij/mt/8nykKcXfGO2BhdtclOdRd+c6x65oasgMln9v8=
+github.com/getlantern/twiddle v0.0.0-20260826224025-1f6cf44029c0 h1:RV3BpVT/TRL54JYq4mlZ40qW8xITJi/+mbSXcuHQ7/w=
+github.com/getlantern/twiddle v0.0.0-20260826224025-1f6cf44029c0/go.mod h1:aU9c2/kcZhCxXCOZMN/Vulc+baDNHecqlvgLXOIeyOY=
 github.com/getlantern/water v0.7.1-alpha.0.20260309190745-bd547c14b4aa h1:goZee1cURbWPiqX1xyjfwLB/zByQ50hEwonnnyLmcJQ=
 github.com/getlantern/water v0.7.1-alpha.0.20260309190745-bd547c14b4aa/go.mod h1:Yo6Yk++Q9HRaCT+6/eYk3elNoNtjlJ3V5FufHY6ezto=
 github.com/getlantern/wazero v1.11.0-water.1 h1:mzUlaOoQKMDd16yL3mBIFrzg2nEK+gw7mdQgff1nOPQ=

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,8 @@ github.com/getlantern/sing-box-minimal v1.13.19-lantern h1:dwVCskH9N3Q5a2wVELdyG
 github.com/getlantern/sing-box-minimal v1.13.19-lantern/go.mod h1:4E8WvF7Vi60N1NtPw1CeG994J/yiJZZkty5dKKwG+V0=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5 h1:6ITBYqNkLbVZ1tQNXwmH8N80rZtvyW6IZa8L6EAhBQo=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5/go.mod h1:gx3dPUhZtQszPX5C+TshhxPXQHlY5t4gMnOOMA+viPA=
+github.com/getlantern/twiddle v0.0.0-20260826202959-3b9eac914d25 h1:ICm28T2LUfdWqDPlH93sB33P5tJfgtF6K6NZBZQuOn4=
+github.com/getlantern/twiddle v0.0.0-20260826202959-3b9eac914d25/go.mod h1:ij/mt/8nykKcXfGO2BhdtclOdRd+c6x65oasgMln9v8=
 github.com/getlantern/water v0.7.1-alpha.0.20260309190745-bd547c14b4aa h1:goZee1cURbWPiqX1xyjfwLB/zByQ50hEwonnnyLmcJQ=
 github.com/getlantern/water v0.7.1-alpha.0.20260309190745-bd547c14b4aa/go.mod h1:Yo6Yk++Q9HRaCT+6/eYk3elNoNtjlJ3V5FufHY6ezto=
 github.com/getlantern/wazero v1.11.0-water.1 h1:mzUlaOoQKMDd16yL3mBIFrzg2nEK+gw7mdQgff1nOPQ=

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/getlantern/sing-box-minimal v1.13.19-lantern h1:dwVCskH9N3Q5a2wVELdyG
 github.com/getlantern/sing-box-minimal v1.13.19-lantern/go.mod h1:4E8WvF7Vi60N1NtPw1CeG994J/yiJZZkty5dKKwG+V0=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5 h1:6ITBYqNkLbVZ1tQNXwmH8N80rZtvyW6IZa8L6EAhBQo=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5/go.mod h1:gx3dPUhZtQszPX5C+TshhxPXQHlY5t4gMnOOMA+viPA=
-github.com/getlantern/twiddle v0.0.0-20260902161425-894e99232116 h1:FFqn/8mrv7WCUJ+vEwxtzMttgXqJXuo8EePYFyv160w=
-github.com/getlantern/twiddle v0.0.0-20260902161425-894e99232116/go.mod h1:aU9c2/kcZhCxXCOZMN/Vulc+baDNHecqlvgLXOIeyOY=
+github.com/getlantern/twiddle v0.0.0-20260903233256-43f3d2d3b625 h1:Q0yR4Upu295nNEInvs8eikg4c2rSxWNXwH2I70ZeO5E=
+github.com/getlantern/twiddle v0.0.0-20260903233256-43f3d2d3b625/go.mod h1:aU9c2/kcZhCxXCOZMN/Vulc+baDNHecqlvgLXOIeyOY=
 github.com/getlantern/water v0.7.1-alpha.0.20260309190745-bd547c14b4aa h1:goZee1cURbWPiqX1xyjfwLB/zByQ50hEwonnnyLmcJQ=
 github.com/getlantern/water v0.7.1-alpha.0.20260309190745-bd547c14b4aa/go.mod h1:Yo6Yk++Q9HRaCT+6/eYk3elNoNtjlJ3V5FufHY6ezto=
 github.com/getlantern/wazero v1.11.0-water.1 h1:mzUlaOoQKMDd16yL3mBIFrzg2nEK+gw7mdQgff1nOPQ=

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/getlantern/sing-box-minimal v1.13.19-lantern h1:dwVCskH9N3Q5a2wVELdyG
 github.com/getlantern/sing-box-minimal v1.13.19-lantern/go.mod h1:4E8WvF7Vi60N1NtPw1CeG994J/yiJZZkty5dKKwG+V0=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5 h1:6ITBYqNkLbVZ1tQNXwmH8N80rZtvyW6IZa8L6EAhBQo=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5/go.mod h1:gx3dPUhZtQszPX5C+TshhxPXQHlY5t4gMnOOMA+viPA=
-github.com/getlantern/twiddle v0.0.0-20260826224025-1f6cf44029c0 h1:RV3BpVT/TRL54JYq4mlZ40qW8xITJi/+mbSXcuHQ7/w=
-github.com/getlantern/twiddle v0.0.0-20260826224025-1f6cf44029c0/go.mod h1:aU9c2/kcZhCxXCOZMN/Vulc+baDNHecqlvgLXOIeyOY=
+github.com/getlantern/twiddle v0.0.0-20260827024137-01de38879c31 h1:u2BIRRP8/73qtsheA+ZwMiusHXgvd5MjVnAo+WOmNqQ=
+github.com/getlantern/twiddle v0.0.0-20260827024137-01de38879c31/go.mod h1:aU9c2/kcZhCxXCOZMN/Vulc+baDNHecqlvgLXOIeyOY=
 github.com/getlantern/water v0.7.1-alpha.0.20260309190745-bd547c14b4aa h1:goZee1cURbWPiqX1xyjfwLB/zByQ50hEwonnnyLmcJQ=
 github.com/getlantern/water v0.7.1-alpha.0.20260309190745-bd547c14b4aa/go.mod h1:Yo6Yk++Q9HRaCT+6/eYk3elNoNtjlJ3V5FufHY6ezto=
 github.com/getlantern/wazero v1.11.0-water.1 h1:mzUlaOoQKMDd16yL3mBIFrzg2nEK+gw7mdQgff1nOPQ=

--- a/option/twiddle.go
+++ b/option/twiddle.go
@@ -22,19 +22,15 @@ type TwiddleInboundOptions struct {
 	MasqueradeUpstream string `json:"masquerade_upstream"`
 
 	// TicketMaxAge bounds how long an issued ticket stays valid, as a Go
-	// duration. Empty disables the check.
+	// duration. Empty uses twiddle's default (24h). The check is never skipped.
 	TicketMaxAge string `json:"ticket_max_age,omitempty"`
 
-	// TicketLen is the ticket size this egress issues. It should match what the
-	// impersonated cover identity's real server issues, because the ticket
-	// travels inside pre_shared_key and so sets the client's ClientHello size:
-	// 176 bytes yields a 1711-byte hello, 230 yields 1761, 256 yields 1806.
-	TicketLen int `json:"ticket_len,omitempty"`
-
-	// PSKFirst places pre_shared_key before the other ServerHello extensions.
-	// Real servers differ but are each consistent -- google and cloudflare put it
-	// first, microsoft and amazon last -- so this should be stable per identity.
-	PSKFirst bool `json:"psk_first,omitempty"`
+	// CoverHost is the impersonated identity. Cipher, binder length, ticket
+	// length, ServerHello extension order and opening-flight sizes all come
+	// from the measured CoverProfile for this host, so they cannot be set
+	// individually and drift apart. Empty means the host of MasqueradeUpstream.
+	// Unknown hosts are rejected.
+	CoverHost string `json:"cover_host,omitempty"`
 }
 
 // TwiddleOutboundOptions configures the twiddle client.
@@ -49,9 +45,10 @@ type TwiddleOutboundOptions struct {
 	// PSK is the pre-shared key paired with Ticket, 32 bytes hex-encoded.
 	PSK string `json:"psk"`
 
-	// CoverSNI is the domain this egress masquerades as. It should agree with
-	// the egress's masquerade_upstream, or the SNI names one site while probes
-	// are answered by another.
+	// CoverSNI is the domain this egress masquerades as. It must be a measured
+	// cover identity (see twiddle.CoverFor) and should agree with the egress's
+	// masquerade_upstream, or the SNI names one site while probes are answered
+	// by another.
 	CoverSNI string `json:"cover_sni"`
 
 	// HelloPool carries a pool of harvested ClientHellos inline: one hex-encoded

--- a/option/twiddle.go
+++ b/option/twiddle.go
@@ -1,0 +1,64 @@
+package option
+
+import "github.com/sagernet/sing-box/option"
+
+// TwiddleInboundOptions configures the twiddle egress.
+//
+// twiddle answers a harvested Chrome ClientHello with a synthesised ServerHello
+// and then carries an AEAD tunnel framed as TLS application_data. It cannot
+// complete a genuine TLS handshake, so MasqueradeUpstream is load-bearing rather
+// than optional: every connection that fails to authenticate is forwarded there
+// verbatim, and that forwarding is the whole of its probe resistance.
+type TwiddleInboundOptions struct {
+	option.ListenOptions
+
+	// TicketKey is the server's long-term ticket-encryption key, 32 bytes
+	// hex-encoded. Clients never hold it; they hold only tickets it issued.
+	TicketKey string `json:"ticket_key"`
+
+	// MasqueradeUpstream is the real cover site unauthenticated connections are
+	// forwarded to, as host:port. Without it, an active prober gets a
+	// distinguishing reply and the transport is trivially confirmed.
+	MasqueradeUpstream string `json:"masquerade_upstream"`
+
+	// TicketMaxAge bounds how long an issued ticket stays valid, as a Go
+	// duration. Empty disables the check.
+	TicketMaxAge string `json:"ticket_max_age,omitempty"`
+
+	// TicketLen is the ticket size this egress issues. It should match what the
+	// impersonated cover identity's real server issues, because the ticket
+	// travels inside pre_shared_key and so sets the client's ClientHello size:
+	// 176 bytes yields a 1711-byte hello, 230 yields 1761, 256 yields 1806.
+	TicketLen int `json:"ticket_len,omitempty"`
+
+	// PSKFirst places pre_shared_key before the other ServerHello extensions.
+	// Real servers differ but are each consistent -- google and cloudflare put it
+	// first, microsoft and amazon last -- so this should be stable per identity.
+	PSKFirst bool `json:"psk_first,omitempty"`
+}
+
+// TwiddleOutboundOptions configures the twiddle client.
+type TwiddleOutboundOptions struct {
+	option.DialerOptions
+	option.ServerOptions
+
+	// Ticket is the provisioned ticket, base64. Replaced automatically by the
+	// one the egress issues in each connection's flight.
+	Ticket string `json:"ticket"`
+
+	// PSK is the pre-shared key paired with Ticket, 32 bytes hex-encoded.
+	PSK string `json:"psk"`
+
+	// CoverSNI is the domain this egress masquerades as. It should agree with
+	// the egress's masquerade_upstream, or the SNI names one site while probes
+	// are answered by another.
+	CoverSNI string `json:"cover_sni"`
+
+	// HelloPool overrides the built-in pool of harvested ClientHellos: one
+	// hex-encoded record per line. The built-in pool is a snapshot of one Chrome
+	// version and ages into a signal, so shipping a refreshed pool here is the
+	// intended path.
+	HelloPool string `json:"hello_pool,omitempty"`
+
+	ConnectTimeout string `json:"connect_timeout,omitempty"`
+}

--- a/option/twiddle.go
+++ b/option/twiddle.go
@@ -54,11 +54,31 @@ type TwiddleOutboundOptions struct {
 	// are answered by another.
 	CoverSNI string `json:"cover_sni"`
 
-	// HelloPool overrides the built-in pool of harvested ClientHellos: one
-	// hex-encoded record per line. The built-in pool is a snapshot of one Chrome
-	// version and ages into a signal, so shipping a refreshed pool here is the
-	// intended path.
+	// HelloPool carries a pool of harvested ClientHellos inline: one hex-encoded
+	// record per line. This is the config-delivered tier -- it beats the pool
+	// compiled into the twiddle module, which is a snapshot of one Chrome version
+	// and ages into a positive signal, but it loses to HelloPoolDevicePath.
 	HelloPool string `json:"hello_pool,omitempty"`
+
+	// HelloPoolPath is a config-written pool file, in the same form as
+	// HelloPool. It ranks in the same tier and takes precedence within it, so a
+	// config fetcher may deliver hellos either way.
+	HelloPoolPath string `json:"hello_pool_path,omitempty"`
+
+	// HelloPoolDevicePath is a pool tapped from this device's OWN outbound TLS
+	// traffic, and it outranks both of the above.
+	//
+	// It is the only source that cannot go stale: by construction it holds what
+	// the browser installed on this device emits right now, with this device's
+	// Chrome version and field-trial state. Every other source is somebody
+	// else's snapshot -- the twiddle module's built-in pool already reproduces no
+	// Chrome that exists, having been captured before Chrome dropped
+	// server_padding (0x12e0) and added 0xca34.
+	//
+	// Whatever writes this file MUST pass each hello through twiddle.Sanitize
+	// first. A tapped hello names a site the user actually visited, and a
+	// resumption hello also carries that site's session ticket.
+	HelloPoolDevicePath string `json:"hello_pool_device_path,omitempty"`
 
 	ConnectTimeout string `json:"connect_timeout,omitempty"`
 }

--- a/protocol/internal/masquerade/masquerade.go
+++ b/protocol/internal/masquerade/masquerade.go
@@ -1,4 +1,11 @@
-package reflex
+// Package masquerade implements the splitting egress: a connection that fails
+// to authenticate is forwarded verbatim to a real cover site, which answers it.
+//
+// For protocols that cannot complete a genuine handshake with an unauthenticated
+// peer -- reflex, and twiddle, whose TLS opening is synthesised -- this is not an
+// optional hardening. It is the only thing standing between an active prober and
+// a distinguishing reply.
+package masquerade
 
 import (
 	"context"
@@ -9,12 +16,11 @@ import (
 	"time"
 )
 
-// masqueradeDialTimeout is the timeout for dialing the upstream cover site.
-const masqueradeDialTimeout = 10 * time.Second
+// dialTimeout is the timeout for dialing the upstream cover site.
+const dialTimeout = 10 * time.Second
 
-// forwardToMasquerade transparently forwards conn to upstream (host:port),
-// prepending prefix bytes (which were already consumed from conn during the
-// silence probe) before the client's stream.
+// Blocks until both copy directions return. Returns the first non-EOF copy
+// error, or the dial/replay error, or nil on clean close.
 //
 // Blocks until both copy directions return. Returns the first non-EOF copy
 // error, or the dial/replay error, or nil on clean close.
@@ -22,12 +28,14 @@ const masqueradeDialTimeout = 10 * time.Second
 // To unblock the copy loops on context cancellation and when either
 // direction finishes, this function may close both the upstream connection
 // and conn. Callers should treat conn as possibly-closed after return.
-func forwardToMasquerade(ctx context.Context, conn net.Conn, upstream string, prefix []byte) error {
+// Forward transparently forwards conn to upstream (host:port), prepending any
+// prefix bytes already consumed from conn.
+func Forward(ctx context.Context, conn net.Conn, upstream string, prefix []byte) error {
 	if upstream == "" {
 		return fmt.Errorf("masquerade upstream not configured")
 	}
 
-	dctx, cancel := context.WithTimeout(ctx, masqueradeDialTimeout)
+	dctx, cancel := context.WithTimeout(ctx, dialTimeout)
 	defer cancel()
 
 	var d net.Dialer
@@ -65,13 +73,11 @@ func forwardToMasquerade(ctx context.Context, conn net.Conn, upstream string, pr
 		_ = conn.Close()
 		errCh <- err
 	}()
-	return firstRealError(<-errCh, <-errCh)
+	return FirstRealError(<-errCh, <-errCh)
 }
 
-// firstRealError returns the first non-nil, non-EOF, non-closed-network error
-// from the two copy directions. EOF and use-of-closed-connection are expected
-// on clean shutdown.
-func firstRealError(errs ...error) error {
+// FirstRealError returns the first non-nil, non-EOF, non-closed-network error.
+func FirstRealError(errs ...error) error {
 	for _, err := range errs {
 		if err == nil || errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
 			continue

--- a/protocol/internal/masquerade/masquerade_test.go
+++ b/protocol/internal/masquerade/masquerade_test.go
@@ -1,4 +1,4 @@
-package reflex
+package masquerade
 
 import (
 	"context"
@@ -56,7 +56,7 @@ func TestForwardToMasquerade_ReplayPrefixAndForward(t *testing.T) {
 
 	forwardErrCh := make(chan error, 1)
 	go func() {
-		forwardErrCh <- forwardToMasquerade(context.Background(), serverSide, upstream, prefix)
+		forwardErrCh <- Forward(context.Background(), serverSide, upstream, prefix)
 	}()
 
 	// Client writes the rest of "X" + "HELLO" — total stream sent to upstream
@@ -79,7 +79,7 @@ func TestForwardToMasquerade_ReplayPrefixAndForward(t *testing.T) {
 	clientSide.Close()
 	select {
 	case err := <-forwardErrCh:
-		// EOF / closed-pipe is expected; firstRealError suppresses it to nil.
+		// EOF / closed-pipe is expected; FirstRealError suppresses it to nil.
 		if err != nil {
 			t.Logf("forward returned (acceptable on close): %v", err)
 		}
@@ -94,7 +94,7 @@ func TestForwardToMasquerade_DialFailure(t *testing.T) {
 	defer serverSide.Close()
 
 	// Port 1 on localhost should refuse connections quickly.
-	err := forwardToMasquerade(context.Background(), serverSide, "127.0.0.1:1", []byte{'X'})
+	err := Forward(context.Background(), serverSide, "127.0.0.1:1", []byte{'X'})
 	if err == nil {
 		t.Fatal("expected dial error, got nil")
 	}
@@ -105,24 +105,24 @@ func TestForwardToMasquerade_EmptyUpstream(t *testing.T) {
 	defer clientSide.Close()
 	defer serverSide.Close()
 
-	err := forwardToMasquerade(context.Background(), serverSide, "", []byte{'X'})
+	err := Forward(context.Background(), serverSide, "", []byte{'X'})
 	if err == nil {
 		t.Fatal("expected error for empty upstream, got nil")
 	}
 }
 
 func TestFirstRealError(t *testing.T) {
-	if err := firstRealError(nil, nil); err != nil {
+	if err := FirstRealError(nil, nil); err != nil {
 		t.Errorf("expected nil for all-nil, got %v", err)
 	}
-	if err := firstRealError(io.EOF, io.EOF); err != nil {
+	if err := FirstRealError(io.EOF, io.EOF); err != nil {
 		t.Errorf("expected nil for all-EOF, got %v", err)
 	}
 	real := io.ErrUnexpectedEOF
-	if err := firstRealError(io.EOF, real); err != real {
+	if err := FirstRealError(io.EOF, real); err != real {
 		t.Errorf("expected %v, got %v", real, err)
 	}
-	if err := firstRealError(real, io.EOF); err != real {
+	if err := FirstRealError(real, io.EOF); err != real {
 		t.Errorf("expected %v, got %v", real, err)
 	}
 }

--- a/protocol/reflex/inbound.go
+++ b/protocol/reflex/inbound.go
@@ -18,6 +18,7 @@ import (
 	N "github.com/sagernet/sing/common/network"
 
 	"github.com/getlantern/lantern-box/constant"
+	"github.com/getlantern/lantern-box/protocol/internal/masquerade"
 	"github.com/getlantern/lantern-box/option"
 )
 
@@ -138,7 +139,7 @@ func (i *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata a
 		}
 		if len(prefix) > 0 {
 			i.logger.DebugContext(ctx, "reflex: client spoke during silence window from ", metadata.Source, "; masquerading to ", i.masqueradeUpstream)
-			ferr := forwardToMasquerade(ctx, conn, i.masqueradeUpstream, prefix)
+			ferr := masquerade.Forward(ctx, conn, i.masqueradeUpstream, prefix)
 			if ferr != nil {
 				i.logger.DebugContext(ctx, "reflex: masquerade forward error: ", ferr)
 			}

--- a/protocol/register.go
+++ b/protocol/register.go
@@ -21,6 +21,7 @@ import (
 	"github.com/getlantern/lantern-box/protocol/outline"
 	"github.com/getlantern/lantern-box/protocol/reflex"
 	"github.com/getlantern/lantern-box/protocol/samizdat"
+	"github.com/getlantern/lantern-box/protocol/twiddle"
 	"github.com/getlantern/lantern-box/protocol/unbounded"
 	"github.com/getlantern/lantern-box/protocol/water"
 )
@@ -90,6 +91,7 @@ func registerInbounds(registry *inbound.Registry) {
 	meek.RegisterInbound(registry)
 	reflex.RegisterInbound(registry)
 	samizdat.RegisterInbound(registry)
+	twiddle.RegisterInbound(registry)
 	water.RegisterInbound(registry)
 }
 
@@ -100,6 +102,7 @@ func registerOutbounds(registry *outbound.Registry) {
 	outline.RegisterOutbound(registry)
 	reflex.RegisterOutbound(registry)
 	samizdat.RegisterOutbound(registry)
+	twiddle.RegisterOutbound(registry)
 	unbounded.RegisterOutbound(registry)
 	water.RegisterOutbound(registry)
 

--- a/protocol/register_test.go
+++ b/protocol/register_test.go
@@ -28,3 +28,16 @@ func TestSupportedProtocolsIncludesUnbounded(t *testing.T) {
 	t.Error(`protocol.SupportedProtocols() does not include "unbounded" — ` +
 		`add it to the supportedProtocols slice in protocol/register.go`)
 }
+
+// TestSupportedProtocolsIncludesTwiddle guards the same regression for twiddle:
+// registering with the sing-box registry but omitting the protocol from the
+// advertised slice leaves the client negotiator unaware it exists.
+func TestSupportedProtocolsIncludesTwiddle(t *testing.T) {
+	for _, p := range protocol.SupportedProtocols() {
+		if p == "twiddle" {
+			return
+		}
+	}
+	t.Error(`protocol.SupportedProtocols() does not include "twiddle" — ` +
+		`add it to the supportedProtocols slice in protocol/register.go`)
+}

--- a/protocol/twiddle/inbound.go
+++ b/protocol/twiddle/inbound.go
@@ -51,7 +51,24 @@ func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger
 		return nil, errors.New("twiddle: masquerade_upstream is required; without it an active prober gets a distinguishing reply")
 	}
 
-	var maxAge time.Duration
+	// The cover identity is derived rather than configured field by field: the
+	// cipher, binder length, ticket length and ServerHello extension order are
+	// one measured profile, and a config that could set them individually could
+	// name microsoft while emitting cloudflare's binder.
+	coverHost := options.CoverHost
+	if coverHost == "" {
+		var herr error
+		coverHost, _, herr = net.SplitHostPort(options.MasqueradeUpstream)
+		if herr != nil {
+			return nil, fmt.Errorf("twiddle: masquerade_upstream %q is not host:port: %w", options.MasqueradeUpstream, herr)
+		}
+	}
+	cover, err := tw.CoverFor(coverHost)
+	if err != nil {
+		return nil, err
+	}
+
+	maxAge := tw.DefaultTicketMaxAge
 	if options.TicketMaxAge != "" {
 		if maxAge, err = time.ParseDuration(options.TicketMaxAge); err != nil {
 			return nil, fmt.Errorf("twiddle: invalid ticket_max_age: %w", err)
@@ -65,10 +82,13 @@ func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger
 		router:  router,
 		cfg: tw.ServerConfig{
 			TicketKey: key,
+			Cover:     cover,
 			MaxAge:    maxAge,
-			TicketLen: options.TicketLen,
-			PSKFirst:  options.PSKFirst,
-			Shaper:    tw.BrowsingShaper(true),
+			// One cache for the whole egress: a ticket is single-use, and a
+			// per-connection gate would spend nothing. Its horizon is maxAge
+			// because eviction is only sound where MaxAge refuses the ticket first.
+			Replay: tw.NewReplayCache(0, maxAge),
+			Shaper: tw.BrowsingShaper(true),
 		},
 		masqueradeUpstream: options.MasqueradeUpstream,
 	}

--- a/protocol/twiddle/inbound.go
+++ b/protocol/twiddle/inbound.go
@@ -1,0 +1,163 @@
+package twiddle
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/inbound"
+	"github.com/sagernet/sing-box/common/listener"
+	"github.com/sagernet/sing-box/log"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+
+	"github.com/getlantern/lantern-box/constant"
+	"github.com/getlantern/lantern-box/option"
+	"github.com/getlantern/lantern-box/protocol/internal/masquerade"
+	tw "github.com/getlantern/twiddle"
+)
+
+func RegisterInbound(registry *inbound.Registry) {
+	inbound.Register[option.TwiddleInboundOptions](registry, constant.TypeTwiddle, NewInbound)
+}
+
+type Inbound struct {
+	inbound.Adapter
+	ctx                context.Context
+	logger             log.ContextLogger
+	router             adapter.Router
+	listener           *listener.Listener
+	cfg                tw.ServerConfig
+	masqueradeUpstream string
+}
+
+func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger, tag string, options option.TwiddleInboundOptions) (adapter.Inbound, error) {
+	raw, err := hex.DecodeString(options.TicketKey)
+	if err != nil {
+		return nil, fmt.Errorf("twiddle: bad ticket_key: %w", err)
+	}
+	key, err := tw.TicketKeyFromWire(raw)
+	if err != nil {
+		return nil, err
+	}
+	if options.MasqueradeUpstream == "" {
+		return nil, errors.New("twiddle: masquerade_upstream is required; without it an active prober gets a distinguishing reply")
+	}
+
+	var maxAge time.Duration
+	if options.TicketMaxAge != "" {
+		if maxAge, err = time.ParseDuration(options.TicketMaxAge); err != nil {
+			return nil, fmt.Errorf("twiddle: invalid ticket_max_age: %w", err)
+		}
+	}
+
+	ib := &Inbound{
+		Adapter: inbound.NewAdapter(constant.TypeTwiddle, tag),
+		ctx:     ctx,
+		logger:  lg,
+		router:  router,
+		cfg: tw.ServerConfig{
+			TicketKey: key,
+			MaxAge:    maxAge,
+			TicketLen: options.TicketLen,
+			Shaper:    tw.BrowsingShaper(true),
+		},
+		masqueradeUpstream: options.MasqueradeUpstream,
+	}
+	ib.listener = listener.New(listener.Options{
+		Context: ctx, Logger: lg, Network: []string{N.NetworkTCP},
+		Listen: options.ListenOptions, ConnectionHandler: ib,
+	})
+	return ib, nil
+}
+
+// NewConnectionEx authenticates the opening, or hands the connection to the
+// cover site.
+//
+// twiddle answers a harvested ClientHello with a synthesised ServerHello, so it
+// cannot complete a genuine handshake with a peer it does not recognise. Every
+// unauthenticated connection therefore MUST reach a real server -- an active
+// prober that gets anything else has confirmed the transport.
+func (i *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	peeked := &peekConn{Conn: conn}
+	tconn, err := tw.Server(peeked, i.cfg)
+	if err != nil {
+		i.logger.DebugContext(ctx, "twiddle: unauthenticated connection from ", metadata.Source,
+			"; masquerading to ", i.masqueradeUpstream)
+		ferr := masquerade.Forward(ctx, conn, i.masqueradeUpstream, peeked.seen)
+		if ferr != nil {
+			i.logger.DebugContext(ctx, "twiddle: masquerade forward error: ", ferr)
+		}
+		conn.Close()
+		if onClose != nil {
+			onClose(ferr)
+		}
+		return
+	}
+
+	dest, err := readDestination(tconn)
+	if err != nil {
+		N.CloseOnHandshakeFailure(tconn, onClose, err)
+		return
+	}
+	destination := M.ParseSocksaddr(dest)
+	i.logger.TraceContext(ctx, "twiddle connection from ", metadata.Source, " to ", destination)
+
+	metadata.Inbound = i.Tag()
+	metadata.InboundType = constant.TypeTwiddle
+	metadata.Destination = destination
+	i.router.RouteConnectionEx(ctx, tconn, metadata, onClose)
+}
+
+func readDestination(r io.Reader) (string, error) {
+	var lenBuf [2]byte
+	if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
+		return "", fmt.Errorf("twiddle: read destination length: %w", err)
+	}
+	n := binary.BigEndian.Uint16(lenBuf[:])
+	if n == 0 || n > 4096 {
+		return "", fmt.Errorf("twiddle: invalid destination length %d", n)
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return "", fmt.Errorf("twiddle: read destination: %w", err)
+	}
+	return string(buf), nil
+}
+
+// peekConn records everything read from the connection so that a failed
+// authentication can be replayed to the cover site byte for byte. A prober must
+// see its own bytes arrive at a real server, not a truncated stream.
+type peekConn struct {
+	net.Conn
+	seen []byte
+	done bool
+}
+
+func (c *peekConn) Read(b []byte) (int, error) {
+	n, err := c.Conn.Read(b)
+	if n > 0 && !c.done {
+		c.seen = append(c.seen, b[:n]...)
+	}
+	return n, err
+}
+
+func (i *Inbound) Start(stage adapter.StartStage) error {
+	if stage != adapter.StartStateStart {
+		return nil
+	}
+	return i.listener.Start()
+}
+
+func (i *Inbound) Close() error {
+	if i.listener != nil {
+		return i.listener.Close()
+	}
+	return nil
+}

--- a/protocol/twiddle/inbound.go
+++ b/protocol/twiddle/inbound.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/sagernet/sing-box/adapter"
@@ -66,6 +67,7 @@ func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger
 			TicketKey: key,
 			MaxAge:    maxAge,
 			TicketLen: options.TicketLen,
+			PSKFirst:  options.PSKFirst,
 			Shaper:    tw.BrowsingShaper(true),
 		},
 		masqueradeUpstream: options.MasqueradeUpstream,
@@ -87,10 +89,14 @@ func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger
 func (i *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
 	peeked := &peekConn{Conn: conn}
 	tconn, err := tw.Server(peeked, i.cfg)
+	// Stop recording either way. On success the session continues reading through
+	// peekConn, and without this every byte of an authenticated connection would
+	// be buffered for the lifetime of the session.
+	peeked.stop()
 	if err != nil {
 		i.logger.DebugContext(ctx, "twiddle: unauthenticated connection from ", metadata.Source,
 			"; masquerading to ", i.masqueradeUpstream)
-		ferr := masquerade.Forward(ctx, conn, i.masqueradeUpstream, peeked.seen)
+		ferr := masquerade.Forward(ctx, conn, i.masqueradeUpstream, peeked.replay())
 		if ferr != nil {
 			i.logger.DebugContext(ctx, "twiddle: masquerade forward error: ", ferr)
 		}
@@ -131,21 +137,52 @@ func readDestination(r io.Reader) (string, error) {
 	return string(buf), nil
 }
 
-// peekConn records everything read from the connection so that a failed
-// authentication can be replayed to the cover site byte for byte. A prober must
-// see its own bytes arrive at a real server, not a truncated stream.
+// peekConn records what is read during authentication so a failed attempt can be
+// replayed to the cover site byte for byte. A prober must see its own bytes
+// arrive at a real server, not a truncated stream.
+//
+// Recording is bounded twice over. stop() ends it as soon as authentication
+// resolves -- otherwise an authenticated session would buffer its entire
+// lifetime's traffic -- and maxPeek caps what an unauthenticated peer can make
+// us hold before it resolves, since a prober controls how much it sends.
 type peekConn struct {
+	mu      sync.Mutex
+	stopped bool
+	seen    []byte
 	net.Conn
-	seen []byte
-	done bool
 }
+
+// maxPeek bounds the replay buffer. A ClientHello is ~2 KB; 64 KB leaves room
+// for a peer whose opening spans several records without letting one hold
+// unbounded memory.
+const maxPeek = 64 << 10
 
 func (c *peekConn) Read(b []byte) (int, error) {
 	n, err := c.Conn.Read(b)
-	if n > 0 && !c.done {
-		c.seen = append(c.seen, b[:n]...)
+	if n > 0 {
+		c.mu.Lock()
+		if !c.stopped && len(c.seen) < maxPeek {
+			room := maxPeek - len(c.seen)
+			if room > n {
+				room = n
+			}
+			c.seen = append(c.seen, b[:room]...)
+		}
+		c.mu.Unlock()
 	}
 	return n, err
+}
+
+func (c *peekConn) stop() {
+	c.mu.Lock()
+	c.stopped = true
+	c.mu.Unlock()
+}
+
+func (c *peekConn) replay() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.seen
 }
 
 func (i *Inbound) Start(stage adapter.StartStage) error {

--- a/protocol/twiddle/outbound.go
+++ b/protocol/twiddle/outbound.go
@@ -40,14 +40,25 @@ type Outbound struct {
 	port    uint16
 	timeout time.Duration
 
-	// mu guards cred, which rotates on every connection: the egress issues the
-	// next credential inside each flight. sing-box dials concurrently, so
-	// without this two dials could race and either lose a rotation or present
-	// the same single-use ticket twice.
-	mu   sync.Mutex
-	cred *tw.Credential
-	cfg  tw.ClientConfig
+	// mu guards creds, the pool of credentials not yet spent. The egress issues
+	// a fresh one inside every flight, so a completed connection returns more
+	// than it took only in the sense that it replaces what it consumed.
+	//
+	// sing-box dials concurrently, which is why this is a pool and not a single
+	// slot: each dial claims a distinct credential when one is available, so
+	// sequential and moderately concurrent traffic never presents the same
+	// ticket twice. Under a burst wider than the pool, dials fall back to
+	// reusing the last credential rather than failing -- TLS 1.3 asks clients
+	// not to reuse tickets, but a dead connection is worse than a reused one,
+	// and the egress does not currently enforce single use. Eliminating reuse
+	// entirely would need the egress to issue several credentials per flight.
+	mu    sync.Mutex
+	creds []*tw.Credential
+	cfg   tw.ClientConfig
 }
+
+// maxCredPool bounds credential accumulation on a long-lived outbound.
+const maxCredPool = 32
 
 func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogger, tag string, options option.TwiddleOutboundOptions) (adapter.Outbound, error) {
 	ticket, err := base64.StdEncoding.DecodeString(options.Ticket)
@@ -91,7 +102,7 @@ func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogge
 		server:  options.Server,
 		port:    options.ServerPort,
 		timeout: timeout,
-		cred:    cred,
+		creds:   []*tw.Credential{cred},
 		cfg: tw.ClientConfig{
 			Pool:     pool,
 			CoverSNI: options.CoverSNI,
@@ -113,9 +124,7 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 	raw.SetDeadline(time.Now().Add(o.timeout))
 
 	cfg := o.cfg
-	o.mu.Lock()
-	cfg.Credential = o.cred
-	o.mu.Unlock()
+	cfg.Credential = o.takeCredential()
 
 	conn, next, err := tw.Client(raw, cfg)
 	if err != nil {
@@ -125,12 +134,9 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 	raw.SetDeadline(time.Time{})
 
 	// The egress issues the next credential inside its flight, exactly as
-	// NewSessionTicket does. Rotating here keeps every ticket single-use, which
-	// is what TLS 1.3 expects of a real client.
+	// NewSessionTicket does.
 	if next != nil {
-		o.mu.Lock()
-		o.cred = next
-		o.mu.Unlock()
+		o.putCredential(next)
 	}
 
 	if err := writeDestination(conn, destination.String()); err != nil {
@@ -138,6 +144,28 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 		return nil, err
 	}
 	return conn, nil
+}
+
+// takeCredential claims a credential for one dial. The last one is reused
+// rather than removed, so a dial never fails for want of a credential.
+func (o *Outbound) takeCredential() *tw.Credential {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	last := len(o.creds) - 1
+	c := o.creds[last]
+	if last > 0 {
+		o.creds = o.creds[:last]
+	}
+	return c
+}
+
+func (o *Outbound) putCredential(c *tw.Credential) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.creds = append(o.creds, c)
+	if len(o.creds) > maxCredPool {
+		o.creds = o.creds[len(o.creds)-maxCredPool:]
+	}
 }
 
 func writeDestination(conn net.Conn, dest string) error {

--- a/protocol/twiddle/outbound.go
+++ b/protocol/twiddle/outbound.go
@@ -1,0 +1,147 @@
+// Package twiddle adapts the twiddle transport to sing-box.
+//
+// The transport itself lives in github.com/getlantern/twiddle and carries no
+// sing-box dependency; this package is the thin layer that registers it,
+// parses options and wires the dialer, following the samizdat and algeneva
+// pattern rather than reflex's fully in-tree one.
+package twiddle
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/outbound"
+	"github.com/sagernet/sing-box/common/dialer"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing/common/logger"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+
+	"github.com/getlantern/lantern-box/constant"
+	"github.com/getlantern/lantern-box/option"
+	tw "github.com/getlantern/twiddle"
+)
+
+func RegisterOutbound(registry *outbound.Registry) {
+	outbound.Register[option.TwiddleOutboundOptions](registry, constant.TypeTwiddle, NewOutbound)
+}
+
+type Outbound struct {
+	outbound.Adapter
+	logger  logger.ContextLogger
+	dialer  N.Dialer
+	server  string
+	port    uint16
+	timeout time.Duration
+	cfg     tw.ClientConfig
+}
+
+func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogger, tag string, options option.TwiddleOutboundOptions) (adapter.Outbound, error) {
+	ticket, err := base64.StdEncoding.DecodeString(options.Ticket)
+	if err != nil {
+		return nil, fmt.Errorf("twiddle: bad ticket: %w", err)
+	}
+	psk, err := hex.DecodeString(options.PSK)
+	if err != nil {
+		return nil, fmt.Errorf("twiddle: bad psk: %w", err)
+	}
+	cred, err := tw.CredentialFromWire(ticket, psk)
+	if err != nil {
+		return nil, err
+	}
+
+	pool := tw.DefaultPool()
+	if options.HelloPool != "" {
+		if pool, err = tw.ParsePool(options.HelloPool); err != nil {
+			return nil, err
+		}
+	}
+	if options.CoverSNI == "" {
+		return nil, fmt.Errorf("twiddle: cover_sni is required; it must agree with the egress's masquerade_upstream")
+	}
+
+	timeout := 15 * time.Second
+	if options.ConnectTimeout != "" {
+		if timeout, err = time.ParseDuration(options.ConnectTimeout); err != nil {
+			return nil, fmt.Errorf("twiddle: invalid connect_timeout: %w", err)
+		}
+	}
+	outboundDialer, err := dialer.New(ctx, options.DialerOptions, options.ServerIsDomain())
+	if err != nil {
+		return nil, err
+	}
+
+	return &Outbound{
+		Adapter: outbound.NewAdapterWithDialerOptions(constant.TypeTwiddle, tag, []string{N.NetworkTCP}, options.DialerOptions),
+		logger:  lg,
+		dialer:  outboundDialer,
+		server:  options.Server,
+		port:    options.ServerPort,
+		timeout: timeout,
+		cfg: tw.ClientConfig{
+			Pool:       pool,
+			CoverSNI:   options.CoverSNI,
+			Credential: cred,
+			Shaper:     tw.BrowsingShaper(false),
+		},
+	}, nil
+}
+
+func (o *Outbound) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
+	if network != N.NetworkTCP {
+		return nil, fmt.Errorf("twiddle: only TCP is supported")
+	}
+	o.logger.TraceContext(ctx, "dialing twiddle connection to ", o.server, ":", o.port)
+
+	raw, err := o.dialer.DialContext(ctx, N.NetworkTCP, M.ParseSocksaddrHostPort(o.server, o.port))
+	if err != nil {
+		return nil, fmt.Errorf("twiddle: TCP dial failed: %w", err)
+	}
+	raw.SetDeadline(time.Now().Add(o.timeout))
+
+	conn, next, err := tw.Client(raw, o.cfg)
+	if err != nil {
+		raw.Close()
+		return nil, fmt.Errorf("twiddle: opening failed: %w", err)
+	}
+	raw.SetDeadline(time.Time{})
+
+	// The egress issues the next credential inside its flight, exactly as
+	// NewSessionTicket does. Rotating here keeps every connection's ticket
+	// single-use, which is what TLS 1.3 expects of a real client.
+	if next != nil {
+		o.cfg.Credential = next
+	}
+
+	if err := writeDestination(conn, destination.String()); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+func writeDestination(conn net.Conn, dest string) error {
+	if len(dest) == 0 || len(dest) > 4096 {
+		return fmt.Errorf("twiddle: destination length %d out of range", len(dest))
+	}
+	buf := make([]byte, 2+len(dest))
+	buf[0] = byte(len(dest) >> 8)
+	buf[1] = byte(len(dest))
+	copy(buf[2:], dest)
+	if _, err := conn.Write(buf); err != nil {
+		return fmt.Errorf("twiddle: failed to send destination: %w", err)
+	}
+	return nil
+}
+
+func (o *Outbound) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
+	return nil, fmt.Errorf("twiddle: UDP not supported")
+}
+
+func (o *Outbound) Network() []string { return []string{N.NetworkTCP} }
+func (o *Outbound) Close() error      { return nil }

--- a/protocol/twiddle/outbound.go
+++ b/protocol/twiddle/outbound.go
@@ -55,6 +55,10 @@ type Outbound struct {
 	mu    sync.Mutex
 	creds []*tw.Credential
 	cfg   tw.ClientConfig
+
+	// poolOrigin records which tier the hellos came from, so a client that has
+	// quietly degraded to the built-in pool is diagnosable after the fact.
+	poolOrigin tw.Origin
 }
 
 // maxCredPool bounds credential accumulation on a long-lived outbound.
@@ -74,12 +78,24 @@ func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogge
 		return nil, err
 	}
 
-	pool := tw.DefaultPool()
-	if options.HelloPool != "" {
-		if pool, err = tw.ParsePool(options.HelloPool); err != nil {
-			return nil, err
-		}
+	// Hello sourcing is twiddle's policy, not ours: it owns the precedence
+	// (device tap, then config, then its built-in pool), the per-entry screening
+	// and the partitioning of a source that mixes browser builds. Reimplementing
+	// any of that here would let the two drift apart.
+	pool, err := tw.LoadPool(tw.Sources{
+		Device:       options.HelloPoolDevicePath,
+		Config:       options.HelloPoolPath,
+		ConfigInline: options.HelloPool,
+	})
+	if err != nil {
+		return nil, err
 	}
+	// A client that silently drops to the built-in pool still connects, so this
+	// has to be visible or a stale fingerprint ships unnoticed.
+	for _, skipped := range pool.Skipped {
+		lg.Warn("twiddle: ", skipped)
+	}
+	lg.Info("twiddle: ", len(pool.Hellos), " hellos from the ", pool.Origin, " pool")
 	if options.CoverSNI == "" {
 		return nil, fmt.Errorf("twiddle: cover_sni is required; it must agree with the egress's masquerade_upstream")
 	}
@@ -96,15 +112,16 @@ func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogge
 	}
 
 	return &Outbound{
-		Adapter: outbound.NewAdapterWithDialerOptions(constant.TypeTwiddle, tag, []string{N.NetworkTCP}, options.DialerOptions),
-		logger:  lg,
-		dialer:  outboundDialer,
-		server:  options.Server,
-		port:    options.ServerPort,
-		timeout: timeout,
-		creds:   []*tw.Credential{cred},
+		Adapter:    outbound.NewAdapterWithDialerOptions(constant.TypeTwiddle, tag, []string{N.NetworkTCP}, options.DialerOptions),
+		logger:     lg,
+		dialer:     outboundDialer,
+		server:     options.Server,
+		port:       options.ServerPort,
+		timeout:    timeout,
+		creds:      []*tw.Credential{cred},
+		poolOrigin: pool.Origin,
 		cfg: tw.ClientConfig{
-			Pool:     pool,
+			Pool:     pool.Hellos,
 			CoverSNI: options.CoverSNI,
 			Shaper:   tw.BrowsingShaper(false),
 		},

--- a/protocol/twiddle/outbound.go
+++ b/protocol/twiddle/outbound.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/sagernet/sing-box/adapter"
@@ -38,7 +39,14 @@ type Outbound struct {
 	server  string
 	port    uint16
 	timeout time.Duration
-	cfg     tw.ClientConfig
+
+	// mu guards cred, which rotates on every connection: the egress issues the
+	// next credential inside each flight. sing-box dials concurrently, so
+	// without this two dials could race and either lose a rotation or present
+	// the same single-use ticket twice.
+	mu   sync.Mutex
+	cred *tw.Credential
+	cfg  tw.ClientConfig
 }
 
 func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogger, tag string, options option.TwiddleOutboundOptions) (adapter.Outbound, error) {
@@ -83,11 +91,11 @@ func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogge
 		server:  options.Server,
 		port:    options.ServerPort,
 		timeout: timeout,
+		cred:    cred,
 		cfg: tw.ClientConfig{
-			Pool:       pool,
-			CoverSNI:   options.CoverSNI,
-			Credential: cred,
-			Shaper:     tw.BrowsingShaper(false),
+			Pool:     pool,
+			CoverSNI: options.CoverSNI,
+			Shaper:   tw.BrowsingShaper(false),
 		},
 	}, nil
 }
@@ -104,7 +112,12 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 	}
 	raw.SetDeadline(time.Now().Add(o.timeout))
 
-	conn, next, err := tw.Client(raw, o.cfg)
+	cfg := o.cfg
+	o.mu.Lock()
+	cfg.Credential = o.cred
+	o.mu.Unlock()
+
+	conn, next, err := tw.Client(raw, cfg)
 	if err != nil {
 		raw.Close()
 		return nil, fmt.Errorf("twiddle: opening failed: %w", err)
@@ -112,10 +125,12 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 	raw.SetDeadline(time.Time{})
 
 	// The egress issues the next credential inside its flight, exactly as
-	// NewSessionTicket does. Rotating here keeps every connection's ticket
-	// single-use, which is what TLS 1.3 expects of a real client.
+	// NewSessionTicket does. Rotating here keeps every ticket single-use, which
+	// is what TLS 1.3 expects of a real client.
 	if next != nil {
-		o.cfg.Credential = next
+		o.mu.Lock()
+		o.cred = next
+		o.mu.Unlock()
 	}
 
 	if err := writeDestination(conn, destination.String()); err != nil {

--- a/protocol/twiddle/outbound.go
+++ b/protocol/twiddle/outbound.go
@@ -78,6 +78,23 @@ func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogge
 		return nil, err
 	}
 
+	if options.CoverSNI == "" {
+		return nil, fmt.Errorf("twiddle: cover_sni is required; it must agree with the egress's masquerade_upstream")
+	}
+	// An unmeasured cover is refused rather than approximated. Emitting a
+	// plausible-looking profile for a host nobody measured is the failure this
+	// is meant to prevent, not a degraded mode worth having.
+	cover, err := tw.CoverFor(options.CoverSNI)
+	if err != nil {
+		return nil, err
+	}
+	// Ticket length is one of the cover's measured parameters, and the ticket
+	// rides inside pre_shared_key, so a credential minted for another identity
+	// produces a hello of the wrong size for the SNI it carries.
+	if len(cred.Ticket) != cover.TicketLen {
+		return nil, fmt.Errorf("twiddle: credential ticket length %d does not match cover %d", len(cred.Ticket), cover.TicketLen)
+	}
+
 	// Hello sourcing is twiddle's policy, not ours: it owns the precedence
 	// (device tap, then config, then its built-in pool), the per-entry screening
 	// and the partitioning of a source that mixes browser builds. Reimplementing
@@ -86,6 +103,12 @@ func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogge
 		Device:       options.HelloPoolDevicePath,
 		Config:       options.HelloPoolPath,
 		ConfigInline: options.HelloPool,
+		// The built-in pool is opt-in in the core because it is stale by
+		// construction. It is enabled here for the reason argued at
+		// TestOutboundDegradesToEmbeddedOnACorruptPool: a stale fingerprint on
+		// every client beats no outbound on every client, and both need the same
+		// config push to clear.
+		AllowEmbedded: true,
 	})
 	if err != nil {
 		return nil, err
@@ -96,10 +119,6 @@ func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogge
 		lg.Warn("twiddle: ", skipped)
 	}
 	lg.Info("twiddle: ", len(pool.Hellos), " hellos from the ", pool.Origin, " pool")
-	if options.CoverSNI == "" {
-		return nil, fmt.Errorf("twiddle: cover_sni is required; it must agree with the egress's masquerade_upstream")
-	}
-
 	timeout := 15 * time.Second
 	if options.ConnectTimeout != "" {
 		if timeout, err = time.ParseDuration(options.ConnectTimeout); err != nil {
@@ -121,9 +140,9 @@ func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogge
 		creds:      []*tw.Credential{cred},
 		poolOrigin: pool.Origin,
 		cfg: tw.ClientConfig{
-			Pool:     pool.Hellos,
-			CoverSNI: options.CoverSNI,
-			Shaper:   tw.BrowsingShaper(false),
+			Pool:   pool.Hellos,
+			Cover:  cover,
+			Shaper: tw.BrowsingShaper(false),
 		},
 	}, nil
 }

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -1,12 +1,15 @@
 package twiddle
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/sagernet/sing-box/log"
@@ -189,34 +192,135 @@ func TestPeekConnReplayIsFaithful(t *testing.T) {
 	}
 }
 
-// TestConcurrentDialsDoNotRaceOnCredential covers the data race review found:
-// DialContext rotated o.cfg.Credential in place, and sing-box dials
-// concurrently. Run with -race.
-func TestConcurrentDialsDoNotRaceOnCredential(t *testing.T) {
-	_, ticket, psk := creds(t)
+// TestConcurrentDialsExerciseTheCredentialPath replaces an earlier version that
+// pointed at port 1. Review caught that the TCP dial fails before DialContext
+// ever reaches the credential code, so the test asserted nothing about the path
+// it named -- a vacuous test that would have passed with the pool removed.
+//
+// This one stands up a real twiddle egress, so every dial completes an opening
+// and actually claims and returns a credential. Run under -race.
+func TestConcurrentDialsExerciseTheCredentialPath(t *testing.T) {
+	key, err := tw.NewTicketKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cred, err := key.Issue(1, tw.DefaultTicketLen)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	var served int64
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				tc, err := tw.Server(c, tw.ServerConfig{TicketKey: key})
+				if err != nil {
+					return
+				}
+				if _, err := readDestination(tc); err == nil {
+					atomic.AddInt64(&served, 1)
+				}
+			}(c)
+		}
+	}()
+
+	host, portStr, _ := net.SplitHostPort(ln.Addr().String())
+	port, _ := strconv.Atoi(portStr)
 	ob, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
 		option.TwiddleOutboundOptions{
-			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 1},
-			Ticket:        ticket, PSK: psk, CoverSNI: "www.example.com",
+			ServerOptions: boxoption.ServerOptions{Server: host, ServerPort: uint16(port)},
+			Ticket:        base64.StdEncoding.EncodeToString(cred.Ticket),
+			PSK:           hex.EncodeToString(cred.PSK[:]),
+			CoverSNI:      "www.example.com",
 		})
 	if err != nil {
 		t.Fatal(err)
 	}
 	o := ob.(*Outbound)
 
+	const n = 24
 	var wg sync.WaitGroup
-	for i := 0; i < 32; i++ {
+	var ok int64
+	for i := 0; i < n; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			// dials fail (port 1), but the credential read/rotate path still runs
-			o.DialContext(context.Background(), "tcp", M.ParseSocksaddr("example.com:443"))
-			o.mu.Lock()
-			_ = o.cred
-			o.mu.Unlock()
+			c, err := o.DialContext(context.Background(), "tcp", M.ParseSocksaddr("example.com:443"))
+			if err == nil {
+				atomic.AddInt64(&ok, 1)
+				c.Close()
+			}
 		}()
 	}
 	wg.Wait()
+
+	if ok == 0 {
+		t.Fatal("no dial completed — the credential path was never exercised")
+	}
+	o.mu.Lock()
+	pooled := len(o.creds)
+	o.mu.Unlock()
+	if pooled == 0 {
+		t.Error("credential pool is empty; a dial consumed the last credential")
+	}
+	t.Logf("%d/%d dials completed, %d openings served, %d credentials pooled",
+		ok, n, atomic.LoadInt64(&served), pooled)
+}
+
+// TestCredentialPoolHandsOutDistinctCredentials: sequential connections must
+// never present the same ticket twice, which is what the pool is for.
+func TestCredentialPoolHandsOutDistinctCredentials(t *testing.T) {
+	key, _ := tw.NewTicketKey()
+	c1, _ := key.Issue(1, tw.DefaultTicketLen)
+	c2, _ := key.Issue(1, tw.DefaultTicketLen)
+	o := &Outbound{creds: []*tw.Credential{c1, c2}}
+
+	a := o.takeCredential()
+	b := o.takeCredential()
+	if bytes.Equal(a.Ticket, b.Ticket) {
+		t.Error("two takes returned the same credential while the pool held two")
+	}
+	// the last credential is reused rather than removed, so a dial never starves
+	c := o.takeCredential()
+	if c == nil {
+		t.Fatal("takeCredential returned nil on an exhausted pool")
+	}
+	o.putCredential(c1)
+	o.mu.Lock()
+	got := len(o.creds)
+	o.mu.Unlock()
+	if got != 2 {
+		t.Errorf("pool has %d credentials after a put, want 2", got)
+	}
+}
+
+// TestCredentialPoolIsBounded guards against unbounded growth on a long-lived
+// outbound.
+func TestCredentialPoolIsBounded(t *testing.T) {
+	key, _ := tw.NewTicketKey()
+	seed, _ := key.Issue(1, tw.DefaultTicketLen)
+	o := &Outbound{creds: []*tw.Credential{seed}}
+	for i := 0; i < maxCredPool*3; i++ {
+		c, _ := key.Issue(1, tw.DefaultTicketLen)
+		o.putCredential(c)
+	}
+	o.mu.Lock()
+	got := len(o.creds)
+	o.mu.Unlock()
+	if got > maxCredPool {
+		t.Errorf("pool grew to %d, past the %d cap", got, maxCredPool)
+	}
 }
 
 // TestPSKFirstReachesServerConfig covers the dead option review found.

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -377,8 +377,14 @@ func TestConcurrentDialsExerciseTheCredentialPath(t *testing.T) {
 	o.mu.Lock()
 	pooled := len(o.creds)
 	o.mu.Unlock()
-	if pooled == 0 {
-		t.Error("credential pool is empty; a dial consumed the last credential")
+	// > 1, not > 0: takeCredential deliberately never removes the final
+	// credential, so len(creds) can never reach zero and an "is it empty"
+	// assertion holds even if putCredential is never called at all. Growth
+	// past the single seeded credential is the thing worth asserting -- it can
+	// only happen if the egress's issued credential came back in the flight and
+	// was stored.
+	if pooled <= 1 {
+		t.Errorf("credential pool did not grow past the seeded credential (%d) after %d successful openings; rotation is not being stored", pooled, ok)
 	}
 	t.Logf("%d/%d dials completed, %d openings served, %d credentials pooled",
 		ok, n, atomic.LoadInt64(&served), pooled)

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"net"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/sagernet/sing-box/log"
 	boxoption "github.com/sagernet/sing-box/option"
+	M "github.com/sagernet/sing/common/metadata"
 
 	"github.com/getlantern/lantern-box/option"
 	tw "github.com/getlantern/twiddle"
@@ -127,5 +130,108 @@ func TestOutboundRejectsACorruptPool(t *testing.T) {
 		})
 	if err == nil {
 		t.Fatal("outbound accepted a corrupt hello pool")
+	}
+}
+
+// TestPeekConnStopsAndIsBounded covers the leak review found: peekConn recorded
+// every byte read and never stopped, so an authenticated session buffered its
+// entire lifetime's traffic. It must stop once authentication resolves, and stay
+// bounded before that, since an unauthenticated peer chooses how much it sends.
+func TestPeekConnStopsAndIsBounded(t *testing.T) {
+	server, client := net.Pipe()
+	pc := &peekConn{Conn: server}
+
+	go func() {
+		buf := make([]byte, 4096)
+		for i := 0; i < 40; i++ {
+			client.Write(buf)
+		}
+		client.Close()
+	}()
+
+	buf := make([]byte, 4096)
+	for i := 0; i < 20; i++ {
+		if _, err := pc.Read(buf); err != nil {
+			break
+		}
+	}
+	if got := len(pc.replay()); got > maxPeek {
+		t.Errorf("replay buffer grew to %d, past the %d cap", got, maxPeek)
+	}
+
+	// after stop() nothing more is recorded, however much arrives
+	pc.stop()
+	before := len(pc.replay())
+	for i := 0; i < 20; i++ {
+		if _, err := pc.Read(buf); err != nil {
+			break
+		}
+	}
+	if after := len(pc.replay()); after != before {
+		t.Errorf("recording continued after stop(): %d -> %d", before, after)
+	}
+	server.Close()
+}
+
+// TestPeekConnReplayIsFaithful: what a prober sent must reach the cover site
+// intact, so the recorded prefix has to match the bytes byte for byte.
+func TestPeekConnReplayIsFaithful(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	pc := &peekConn{Conn: server}
+	want := []byte("\x16\x03\x01\x00\x05hello-prober")
+	go func() { client.Write(want); client.Close() }()
+
+	buf := make([]byte, 64)
+	n, _ := pc.Read(buf)
+	if got := pc.replay(); string(got) != string(want[:n]) {
+		t.Errorf("replay is %q, want %q", got, want[:n])
+	}
+}
+
+// TestConcurrentDialsDoNotRaceOnCredential covers the data race review found:
+// DialContext rotated o.cfg.Credential in place, and sing-box dials
+// concurrently. Run with -race.
+func TestConcurrentDialsDoNotRaceOnCredential(t *testing.T) {
+	_, ticket, psk := creds(t)
+	ob, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleOutboundOptions{
+			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 1},
+			Ticket:        ticket, PSK: psk, CoverSNI: "www.example.com",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	o := ob.(*Outbound)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// dials fail (port 1), but the credential read/rotate path still runs
+			o.DialContext(context.Background(), "tcp", M.ParseSocksaddr("example.com:443"))
+			o.mu.Lock()
+			_ = o.cred
+			o.mu.Unlock()
+		}()
+	}
+	wg.Wait()
+}
+
+// TestPSKFirstReachesServerConfig covers the dead option review found.
+func TestPSKFirstReachesServerConfig(t *testing.T) {
+	keyHex, _, _ := creds(t)
+	for _, want := range []bool{false, true} {
+		ib, err := NewInbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+			option.TwiddleInboundOptions{
+				TicketKey: keyHex, MasqueradeUpstream: "www.example.com:443", PSKFirst: want,
+			})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := ib.(*Inbound).cfg.PSKFirst; got != want {
+			t.Errorf("psk_first=%v did not reach ServerConfig (got %v)", want, got)
+		}
 	}
 }

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"net"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -123,16 +125,120 @@ func TestOutboundUsesTheEmbeddedPoolByDefault(t *testing.T) {
 	}
 }
 
-func TestOutboundRejectsACorruptPool(t *testing.T) {
+// A corrupt configured pool must DEGRADE to the built-in one, not fail the
+// outbound.
+//
+// This reverses the earlier contract deliberately. A pool arrives by config
+// push, so a bad one reaches every client at once; the two candidate failure
+// modes are "every client emits a stale fingerprint" and "every client has no
+// outbound at all". The first risks detection, probabilistically and
+// recoverably; the second is a certain outage. Both are fixed by pushing new
+// config, so the interim state is the whole of the difference, and staleness is
+// the better interim state.
+//
+// The compensating requirement is that the degradation be visible, which is
+// what poolOrigin and the logged Skipped errors are for.
+func TestOutboundDegradesToEmbeddedOnACorruptPool(t *testing.T) {
 	_, ticket, psk := creds(t)
-	_, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+	ob, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
 		option.TwiddleOutboundOptions{
 			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
 			Ticket:        ticket, PSK: psk, CoverSNI: "a.example",
 			HelloPool: "not hex at all",
 		})
-	if err == nil {
-		t.Fatal("outbound accepted a corrupt hello pool")
+	if err != nil {
+		t.Fatalf("a corrupt pool must not brick the outbound: %v", err)
+	}
+	o := ob.(*Outbound)
+	if o.poolOrigin != tw.OriginEmbedded {
+		t.Errorf("pool origin is %v, want embedded", o.poolOrigin)
+	}
+	if len(o.cfg.Pool) == 0 {
+		t.Error("degraded outbound has no hellos at all")
+	}
+}
+
+// The device tap outranks both config tiers, and an inline config pool outranks
+// the built-in one. This is the precedence the whole three-tier arrangement
+// exists for, so it is asserted here and not just in the twiddle module.
+func TestOutboundPoolPrecedence(t *testing.T) {
+	_, ticket, psk := creds(t)
+
+	// One real hello, rewritten so each tier is distinguishable by SNI.
+	poolFor := func(t *testing.T, name string) string {
+		t.Helper()
+		h, err := tw.ParseClientHello(tw.DefaultPool()[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := h.SetSNI(name); err != nil {
+			t.Fatal(err)
+		}
+		return tw.FormatPool([][]byte{h.Marshal()})
+	}
+	write := func(t *testing.T, body string) string {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "pool.hex")
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	devicePath := write(t, poolFor(t, "device.example"))
+	configPath := write(t, poolFor(t, "configfile.example"))
+	inline := poolFor(t, "inline.example")
+
+	for _, tc := range []struct {
+		name       string
+		opts       option.TwiddleOutboundOptions
+		wantOrigin tw.Origin
+		wantSNI    string
+	}{
+		{
+			name:       "device beats everything",
+			opts:       option.TwiddleOutboundOptions{HelloPoolDevicePath: devicePath, HelloPoolPath: configPath, HelloPool: inline},
+			wantOrigin: tw.OriginDevice, wantSNI: "device.example",
+		},
+		{
+			name:       "config file beats inline",
+			opts:       option.TwiddleOutboundOptions{HelloPoolPath: configPath, HelloPool: inline},
+			wantOrigin: tw.OriginConfig, wantSNI: "configfile.example",
+		},
+		{
+			name:       "inline beats embedded",
+			opts:       option.TwiddleOutboundOptions{HelloPool: inline},
+			wantOrigin: tw.OriginConfig, wantSNI: "inline.example",
+		},
+		{
+			name:       "nothing configured falls back",
+			opts:       option.TwiddleOutboundOptions{},
+			wantOrigin: tw.OriginEmbedded,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			o := tc.opts
+			o.ServerOptions = boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443}
+			o.Ticket, o.PSK, o.CoverSNI = ticket, psk, "www.microsoft.com"
+			ob, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t", o)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out := ob.(*Outbound)
+			if out.poolOrigin != tc.wantOrigin {
+				t.Errorf("origin = %v, want %v", out.poolOrigin, tc.wantOrigin)
+			}
+			if tc.wantSNI == "" {
+				return
+			}
+			h, err := tw.ParseClientHello(out.cfg.Pool[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if h.SNI() != tc.wantSNI {
+				t.Errorf("loaded the wrong tier: SNI %q, want %q", h.SNI(), tc.wantSNI)
+			}
+		})
 	}
 }
 

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -64,15 +64,45 @@ func TestInboundAcceptsAValidConfig(t *testing.T) {
 	ib, err := NewInbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
 		option.TwiddleInboundOptions{
 			TicketKey:          keyHex,
-			MasqueradeUpstream: "www.example.com:443",
+			MasqueradeUpstream: "www.microsoft.com:443",
 			TicketMaxAge:       "24h",
-			TicketLen:          256,
 		})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if ib == nil {
 		t.Fatal("nil inbound")
+	}
+	if ib.(*Inbound).cfg.Cover.Host != "www.microsoft.com" {
+		t.Errorf("cover is %q", ib.(*Inbound).cfg.Cover.Host)
+	}
+	if ib.(*Inbound).cfg.Cover.BinderLen != 48 {
+		t.Errorf("microsoft binder %d, want 48", ib.(*Inbound).cfg.Cover.BinderLen)
+	}
+}
+
+func TestInboundAppliesDefaultTicketMaxAge(t *testing.T) {
+	keyHex, _, _ := creds(t)
+	ib, err := NewInbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleInboundOptions{
+			TicketKey: keyHex, MasqueradeUpstream: "www.cloudflare.com:443",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ib.(*Inbound).cfg.MaxAge; got != tw.DefaultTicketMaxAge {
+		t.Fatalf("default ticket max age is %v, want %v", got, tw.DefaultTicketMaxAge)
+	}
+}
+
+func TestInboundRejectsUnknownCover(t *testing.T) {
+	keyHex, _, _ := creds(t)
+	_, err := NewInbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleInboundOptions{
+			TicketKey: keyHex, MasqueradeUpstream: "www.example.com:443",
+		})
+	if err == nil {
+		t.Fatal("inbound accepted an unmeasured cover")
 	}
 }
 
@@ -111,7 +141,7 @@ func TestOutboundUsesTheEmbeddedPoolByDefault(t *testing.T) {
 	ob, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
 		option.TwiddleOutboundOptions{
 			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
-			Ticket:        ticket, PSK: psk, CoverSNI: "www.microsoft.com",
+			Ticket:        ticket, PSK: psk, CoverSNI: "www.cloudflare.com",
 		})
 	if err != nil {
 		t.Fatal(err)
@@ -120,8 +150,35 @@ func TestOutboundUsesTheEmbeddedPoolByDefault(t *testing.T) {
 	if len(o.cfg.Pool) == 0 {
 		t.Fatal("outbound has an empty hello pool")
 	}
-	if o.cfg.CoverSNI != "www.microsoft.com" {
-		t.Errorf("cover SNI is %q", o.cfg.CoverSNI)
+	if o.cfg.Cover.Host != "www.cloudflare.com" {
+		t.Errorf("cover is %q", o.cfg.Cover.Host)
+	}
+}
+
+func TestOutboundRejectsUnknownCover(t *testing.T) {
+	_, ticket, psk := creds(t)
+	_, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleOutboundOptions{
+			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
+			Ticket:        ticket, PSK: psk, CoverSNI: "www.example.com",
+		})
+	if err == nil {
+		t.Fatal("outbound accepted an unmeasured cover")
+	}
+}
+
+// Ticket length is a fidelity parameter of the cover, so a credential minted for
+// one identity cannot be presented as another: the hello would be the wrong size
+// for the SNI it carries.
+func TestOutboundRejectsCredentialForAnotherCover(t *testing.T) {
+	_, ticket, psk := creds(t)
+	_, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleOutboundOptions{
+			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
+			Ticket:        ticket, PSK: psk, CoverSNI: "www.microsoft.com",
+		})
+	if err == nil {
+		t.Fatal("outbound accepted a credential with the wrong ticket length for its cover")
 	}
 }
 
@@ -143,7 +200,7 @@ func TestOutboundDegradesToEmbeddedOnACorruptPool(t *testing.T) {
 	ob, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
 		option.TwiddleOutboundOptions{
 			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
-			Ticket:        ticket, PSK: psk, CoverSNI: "a.example",
+			Ticket:        ticket, PSK: psk, CoverSNI: "www.cloudflare.com",
 			HelloPool: "not hex at all",
 		})
 	if err != nil {
@@ -219,7 +276,7 @@ func TestOutboundPoolPrecedence(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			o := tc.opts
 			o.ServerOptions = boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443}
-			o.Ticket, o.PSK, o.CoverSNI = ticket, psk, "www.microsoft.com"
+			o.Ticket, o.PSK, o.CoverSNI = ticket, psk, "www.cloudflare.com"
 			ob, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t", o)
 			if err != nil {
 				t.Fatal(err)
@@ -310,10 +367,17 @@ func TestConcurrentDialsExerciseTheCredentialPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cred, err := key.Issue(1, tw.DefaultTicketLen)
+	cover, err := tw.CoverFor("www.cloudflare.com")
 	if err != nil {
 		t.Fatal(err)
 	}
+	cred, err := key.Issue(1, cover.TicketLen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// One gate for the whole egress: tickets are single-use, so a per-connection
+	// cache would spend nothing.
+	replay := tw.NewReplayCache(64, 0)
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -330,7 +394,9 @@ func TestConcurrentDialsExerciseTheCredentialPath(t *testing.T) {
 			}
 			go func(c net.Conn) {
 				defer c.Close()
-				tc, err := tw.Server(c, tw.ServerConfig{TicketKey: key})
+				tc, err := tw.Server(c, tw.ServerConfig{
+					TicketKey: key, Cover: cover, Replay: replay,
+				})
 				if err != nil {
 					return
 				}
@@ -348,7 +414,7 @@ func TestConcurrentDialsExerciseTheCredentialPath(t *testing.T) {
 			ServerOptions: boxoption.ServerOptions{Server: host, ServerPort: uint16(port)},
 			Ticket:        base64.StdEncoding.EncodeToString(cred.Ticket),
 			PSK:           hex.EncodeToString(cred.PSK[:]),
-			CoverSNI:      "www.example.com",
+			CoverSNI:      cover.Host,
 		})
 	if err != nil {
 		t.Fatal(err)
@@ -435,19 +501,20 @@ func TestCredentialPoolIsBounded(t *testing.T) {
 	}
 }
 
-// TestPSKFirstReachesServerConfig covers the dead option review found.
-func TestPSKFirstReachesServerConfig(t *testing.T) {
+// TestCoverProfileReachesServerConfig covers the dead option review found. The
+// individual knobs it replaced could name one identity and emit another's
+// parameters, so what is pinned now is that the whole measured profile arrives.
+func TestCoverProfileReachesServerConfig(t *testing.T) {
 	keyHex, _, _ := creds(t)
-	for _, want := range []bool{false, true} {
-		ib, err := NewInbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
-			option.TwiddleInboundOptions{
-				TicketKey: keyHex, MasqueradeUpstream: "www.example.com:443", PSKFirst: want,
-			})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got := ib.(*Inbound).cfg.PSKFirst; got != want {
-			t.Errorf("psk_first=%v did not reach ServerConfig (got %v)", want, got)
-		}
+	ib, err := NewInbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleInboundOptions{
+			TicketKey: keyHex, MasqueradeUpstream: "www.google.com:443",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := ib.(*Inbound).cfg.Cover
+	if !got.PSKFirst || got.TicketLen != 230 || got.BinderLen != 32 {
+		t.Errorf("google profile not applied: %+v", got)
 	}
 }

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -1,0 +1,131 @@
+package twiddle
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/sagernet/sing-box/log"
+	boxoption "github.com/sagernet/sing-box/option"
+
+	"github.com/getlantern/lantern-box/option"
+	tw "github.com/getlantern/twiddle"
+)
+
+func creds(t *testing.T) (keyHex, ticketB64, pskHex string) {
+	t.Helper()
+	k, err := tw.NewTicketKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := k.Issue(1, tw.DefaultTicketLen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(k[:]), base64.StdEncoding.EncodeToString(c.Ticket), hex.EncodeToString(c.PSK[:])
+}
+
+func TestInboundRequiresMasqueradeUpstream(t *testing.T) {
+	keyHex, _, _ := creds(t)
+	_, err := NewInbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleInboundOptions{TicketKey: keyHex})
+	if err == nil {
+		t.Fatal("inbound accepted a config with no masquerade_upstream")
+	}
+	// twiddle cannot complete a real handshake with an unrecognised peer, so an
+	// egress without a cover site hands probes a distinguishing reply.
+	if !strings.Contains(err.Error(), "masquerade_upstream") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestInboundRejectsBadTicketKey(t *testing.T) {
+	for _, k := range []string{"", "zz", hex.EncodeToString(make([]byte, 16))} {
+		_, err := NewInbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+			option.TwiddleInboundOptions{TicketKey: k, MasqueradeUpstream: "www.example.com:443"})
+		if err == nil {
+			t.Errorf("inbound accepted ticket_key %q", k)
+		}
+	}
+}
+
+func TestInboundAcceptsAValidConfig(t *testing.T) {
+	keyHex, _, _ := creds(t)
+	ib, err := NewInbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleInboundOptions{
+			TicketKey:          keyHex,
+			MasqueradeUpstream: "www.example.com:443",
+			TicketMaxAge:       "24h",
+			TicketLen:          256,
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ib == nil {
+		t.Fatal("nil inbound")
+	}
+}
+
+func TestOutboundRequiresCoverSNI(t *testing.T) {
+	_, ticket, psk := creds(t)
+	_, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleOutboundOptions{
+			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
+			Ticket:        ticket, PSK: psk,
+		})
+	if err == nil {
+		t.Fatal("outbound accepted a config with no cover_sni")
+	}
+	if !strings.Contains(err.Error(), "cover_sni") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestOutboundRejectsBadCredentials(t *testing.T) {
+	_, ticket, psk := creds(t)
+	bad := []option.TwiddleOutboundOptions{
+		{Ticket: "not base64!!", PSK: psk, CoverSNI: "a.example"},
+		{Ticket: ticket, PSK: "zz", CoverSNI: "a.example"},
+		{Ticket: ticket, PSK: hex.EncodeToString(make([]byte, 16)), CoverSNI: "a.example"},
+	}
+	for i, o := range bad {
+		o.ServerOptions = boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443}
+		if _, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t", o); err == nil {
+			t.Errorf("case %d: outbound accepted bad credentials", i)
+		}
+	}
+}
+
+func TestOutboundUsesTheEmbeddedPoolByDefault(t *testing.T) {
+	_, ticket, psk := creds(t)
+	ob, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleOutboundOptions{
+			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
+			Ticket:        ticket, PSK: psk, CoverSNI: "www.microsoft.com",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	o := ob.(*Outbound)
+	if len(o.cfg.Pool) == 0 {
+		t.Fatal("outbound has an empty hello pool")
+	}
+	if o.cfg.CoverSNI != "www.microsoft.com" {
+		t.Errorf("cover SNI is %q", o.cfg.CoverSNI)
+	}
+}
+
+func TestOutboundRejectsACorruptPool(t *testing.T) {
+	_, ticket, psk := creds(t)
+	_, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleOutboundOptions{
+			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
+			Ticket:        ticket, PSK: psk, CoverSNI: "a.example",
+			HelloPool: "not hex at all",
+		})
+	if err == nil {
+		t.Fatal("outbound accepted a corrupt hello pool")
+	}
+}


### PR DESCRIPTION
Adds `twiddle` as a registered lantern-box protocol: outbound, inbound, and E2E coverage.

The transport core lives in [`getlantern/twiddle`](https://github.com/getlantern/twiddle) and carries **no sing-box dependency**, so this PR is the thin adapter layer — registration, option parsing, dialer wiring — following the `samizdat`/`algeneva` pattern rather than `reflex`'s fully in-tree one.

### What the transport does

The opening bytes are a **genuine ClientHello harvested from a real browser**, minimally modified. The reply is a synthesised ServerHello, and everything after is an AEAD tunnel framed as TLS `application_data`. It works because every TLS 1.3 handshake message after the ServerHello is already an opaque `0x17` record — so only the opening needs fidelity.

Authentication is TLS 1.3 `psk_dhe_ke`, using the fields TLS already provides:

| | carries |
|---|---|
| `key_share[X25519]` | a real ephemeral — forward secrecy |
| ticket (PSK identity) | `AEAD(k_server, client_id ‖ psk ‖ issued_at)` — uniform by construction |
| binder | HMAC over the truncated hello, keyed from the psk |

### The splitting egress is load-bearing

twiddle cannot complete a genuine handshake with a peer it does not recognise, so **every unauthenticated connection must reach a real TLS site**. That is the whole of its probe resistance, not optional hardening — the inbound refuses to start without `masquerade_upstream`, and a test asserts it.

```mermaid
sequenceDiagram
    autonumber
    participant C as client<br/>protocol/twiddle/outbound.go
    participant E as egress<br/>protocol/twiddle/inbound.go
    participant M as cover site<br/>masquerade_upstream

    C->>E: outbound.go:165<br/>harvested ClientHello + ticket + binder
    Note over E: inbound.go:111<br/>tw.Server() verifies the binder ⚠️

    alt authenticated
        E-->>C: synthesised ServerHello + flight<br/>(flight carries the NEXT ticket)
        Note over C: outbound.go:175<br/>credential rotates, single-use
        C->>E: destination, then the AEAD tunnel
    else ErrNotOurs
        Note over E: inbound.go:119<br/>peekConn replayed byte-for-byte
        E->>M: masquerade.Forward()
        M-->>C: a REAL TLS handshake
        Note over C,M: a prober must never see anything of ours 🐛
    end
```

### The cover identity is one measured profile, not a set of knobs

Cipher suite, binder length, ticket length, ServerHello extension order and opening-flight sizes are all measurements of **one real server**. They are taken together from `twiddle.CoverFor`, so a config cannot name microsoft while emitting cloudflare's binder:

- The inbound derives its profile from `cover_host`, defaulting to the host of `masquerade_upstream`.
- The outbound refuses an unmeasured `cover_sni` rather than approximating one, and refuses a credential whose ticket length belongs to a different identity — the ticket rides inside `pre_shared_key`, so it would size the hello wrongly for the SNI beside it.

Two things follow from the core rather than from choice: `tw.Server` now requires a shared `ReplayCache`, so the egress holds one whose horizon is `MaxAge` (horizon eviction is only sound where `MaxAge` refuses the ticket first); and the built-in hello pool became opt-in, so `AllowEmbedded` is set — see below.

### Changes

- **`protocol/internal/masquerade/`** — lifts `forwardToMasquerade` out of `protocol/reflex/` so both protocols share one implementation instead of a copy. Test moved with it; reflex behaviour unchanged and its suite still passes.
- **`option/twiddle.go`** — `cover_host` on the inbound, `cover_sni` on the outbound. The old `ticket_len` and `psk_first` knobs are gone: they were the two parameters a config could set inconsistently with the identity it named.
- **`.github/workflows/e2e.yaml`** — a twiddle server on 9005 plus two steps: HTTP/HTTPS through it followed by a **second connection** (which exercises ticket rotation, since a stale ticket would fail there), and a **probe-resistance** check where an unauthenticated `openssl s_client` must get a valid handshake from the cover site. The probe presents the cover's own SNI and pins it with `-verify_hostname`: a chain that merely validates proves only "some trusted site", which is not the claim being tested.

### Where the hellos come from

The pool is **data read off disk**, not a compiled-in constant. `LoadPool` tries three sources in descending order of preference, and the outbound records which tier won:

| Option | Source | Why it ranks here |
|---|---|---|
| `hello_pool_device_path` | tapped from this device's own outbound TLS | The only source that cannot go stale: it holds what the browser installed *here* emits right now, with this device's Chrome version and field-trial state |
| `hello_pool_path` | a config-written file | Refreshable without shipping a binary |
| `hello_pool` | the same, inline, as config already delivers it | Same tier as the file; the file wins within it |
| — | twiddle's built-in pool | Works without provisioning; decays as Chrome moves |

The decay is measured, not hypothetical: the built-in pool carries BoringSSL's `server_padding` (`0x12e0`) and runs 1725–1827 B, while Chrome 152 has **dropped `0x12e0`, added `0xca34`, and runs 1919–2015 B**. It reproduces no Chrome that exists.

Sources are never merged — a pool blending two browser builds would have the client alternating fingerprints between TCP connections, which no browser does and which is a sharper signal than a stale pool alone.

**One contract reversed deliberately.** A corrupt configured pool now *degrades* to the built-in pool instead of failing `NewOutbound`. The core made this opt-in (`Sources.AllowEmbedded`), and this adapter opts in. A pool arrives by config push, so a bad one reaches every client at once, and the choice is between every client emitting a stale fingerprint and every client having **no outbound at all**. The first risks detection — probabilistically, and recoverably; the second is a certain outage. Both need the same config push to fix, so the interim state is the whole of the difference. `poolOrigin` and the logged `Skipped` errors are what keep the degradation visible.

*(#319, stacked on this branch, reverses that judgement once the device tap is actually operational — at which point failing closed lets autoselect pick another transport instead.)*

### Dependency impact

One line. `twiddle` has **zero external dependencies** — its `go.sum` is empty.

```
+ github.com/getlantern/twiddle v0.0.0-20260903233256-43f3d2d3b625
```

### Testing

`go build ./...`, `go vet ./...` and `go test -race ./...` clean, including `otel` and `test/e2e` (both need Docker).

`TestOutboundPoolPrecedence` covers all four tiers; `TestOutboundDegradesToEmbeddedOnACorruptPool` pins the reversed contract above; `TestCoverProfileReachesServerConfig`, `TestInboundRejectsUnknownCover`, `TestOutboundRejectsUnknownCover` and `TestOutboundRejectsCredentialForAnotherCover` pin the cover model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gn6KuHUL766qQNn8m1fu1
