### PR TITLE
deps: bump metacubex/utls v1.8.4 -> v1.8.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -175,7 +175,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mdlayher/netlink v1.9.0 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
-	github.com/metacubex/utls v1.8.4 // indirect
+	github.com/metacubex/utls v1.8.7 // indirect
 	github.com/mholt/acmez/v3 v3.1.6 // indirect
 	github.com/mholt/archives v0.1.5 // indirect
 	github.com/miekg/dns v1.1.72 // indirect

--- a/go.sum
+++ b/go.sum
@@ -477,8 +477,8 @@ github.com/mdlayher/netlink v1.9.0 h1:G8+GLq2x3v4D4MVIqDdNUhTUC7TKiCy/6MDkmItfKc
 github.com/mdlayher/netlink v1.9.0/go.mod h1:YBnl5BXsCoRuwBjKKlZ+aYmEoq0r12FDA/3JC+94KDg=
 github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=
 github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
-github.com/metacubex/utls v1.8.4 h1:HmL9nUApDdWSkgUyodfwF6hSjtiwCGGdyhaSpEejKpg=
-github.com/metacubex/utls v1.8.4/go.mod h1:kncGGVhFaoGn5M3pFe3SXhZCzsbCJayNOH4UEqTKTko=
+github.com/metacubex/utls v1.8.7 h1:Cp+yWkNTFkSihETgGWq34hlVFds5HpYWVOR1xovUVTs=
+github.com/metacubex/utls v1.8.7/go.mod h1:kncGGVhFaoGn5M3pFe3SXhZCzsbCJayNOH4UEqTKTko=
 github.com/mholt/acmez/v3 v3.1.6 h1:eGVQNObP0pBN4sxqrXeg7MYqTOWyoiYpQqITVWlrevk=
 github.com/mholt/acmez/v3 v3.1.6/go.mod h1:5nTPosTGosLxF3+LU4ygbgMRFDhbAVpqMI4+a4aHLBY=
 github.com/mholt/archives v0.1.5 h1:Fh2hl1j7VEhc6DZs2DLMgiBNChUux154a1G+2esNvzQ=


### PR DESCRIPTION
Bumps the pinned `github.com/metacubex/utls` from v1.8.4 to v1.8.7.

### Why

`metacubex/utls` supplies the ClientHello for **`algeneva`** and for **`sing-box/common/tls`**. Keeping it current matters for mimicry: uTLS presets track real Chrome, and a stale preset emits a hello no shipping browser produces.

Worth noting what this does *not* affect — **`samizdat` uses `refraction-networking/utls`**, a different fork, so it is untouched by this bump.

### Scope

`metacubex/utls` is an indirect dependency, so this is a `go get` plus `go mod tidy` with `go.mod` and `go.sum` committed together. No source changes.

```
- github.com/metacubex/utls v1.8.4 // indirect
+ github.com/metacubex/utls v1.8.7 // indirect
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gPSMV42nWXEZZmU7SiLHv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying networking dependency to improve compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->