### PR TITLE
refactor(probe): extract runProbe into internal/probe

### DIFF
--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -5,6 +5,8 @@ package probe
 import (
 	"context"
 	"crypto/tls"
+	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -18,29 +20,29 @@ import (
 	"github.com/sagernet/sing/common/ntp"
 )
 
-// Result is one attempt's outcome. Delay is meaningful only when Success: it
-// spans the handshake and the request, plus the dial for an outbound that does
-// not defer its handshake to first use.
-type Result struct {
-	Success bool
-	Delay   time.Duration
-}
+// ErrUnusableInput wraps a failure caused by Run's own arguments: an unusable
+// probeURL, or a non-positive timeout. It means the arguments cannot produce a
+// probe, not that the outbound or the target failed.
+var ErrUnusableInput = errors.New("unusable probe input")
 
-// Run dials out and completes an HTTP GET to probeURL over that one
-// connection, discarding the body. Success means the request completed,
-// whatever status it returned; when probeURL's handler confirms receipt, it
-// also means the handler was reached.
-//
-// timeout bounds the whole attempt: a non-positive timeout, or a probeURL that
-// is empty or unparsable, fails without dialing. The connection is closed
+// Run dials out, completes an HTTP GET to probeURL over that one connection,
+// discarding the body, and reports how long it took. A request that completes
+// is a success whatever status it returned; when probeURL's handler confirms
+// receipt, success also means the handler was reached. The connection is closed
 // before Run returns.
-func Run(ctx context.Context, out A.Outbound, probeURL string, timeout time.Duration) Result {
-	if probeURL == "" || timeout <= 0 {
-		return Result{}
+//
+// The reported duration spans the handshake and the request, plus the dial for
+// an outbound that does not defer its handshake to first use.
+func Run(ctx context.Context, out A.Outbound, probeURL string, timeout time.Duration) (time.Duration, error) {
+	if probeURL == "" {
+		return 0, fmt.Errorf("%w: empty probe URL", ErrUnusableInput)
+	}
+	if timeout <= 0 {
+		return 0, fmt.Errorf("%w: non-positive timeout %s", ErrUnusableInput, timeout)
 	}
 	linkURL, err := url.Parse(probeURL)
 	if err != nil {
-		return Result{}
+		return 0, fmt.Errorf("%w: %w", ErrUnusableInput, err)
 	}
 	hostname := linkURL.Hostname()
 	port := linkURL.Port()
@@ -52,6 +54,9 @@ func Run(ctx context.Context, out A.Outbound, probeURL string, timeout time.Dura
 			port = "443"
 		}
 	}
+	if hostname == "" || port == "" {
+		return 0, fmt.Errorf("%w: no host or port in probe URL %q", ErrUnusableInput, probeURL)
+	}
 
 	probeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -59,7 +64,7 @@ func Run(ctx context.Context, out A.Outbound, probeURL string, timeout time.Dura
 	start := time.Now()
 	conn, err := out.DialContext(probeCtx, "tcp", M.ParseSocksaddrHostPortStr(hostname, port))
 	if err != nil {
-		return Result{}
+		return 0, fmt.Errorf("dial: %w", err)
 	}
 	defer conn.Close()
 	if earlyConn, ok := common.Cast[N.EarlyConn](conn); ok && earlyConn.NeedHandshake() {
@@ -68,7 +73,7 @@ func Run(ctx context.Context, out A.Outbound, probeURL string, timeout time.Dura
 
 	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, probeURL, nil)
 	if err != nil {
-		return Result{}
+		return 0, fmt.Errorf("new request: %w", err)
 	}
 	if tp := linkURL.Query().Get("tp"); tp != "" {
 		req.Header.Set("traceparent", tp)
@@ -91,10 +96,10 @@ func Run(ctx context.Context, out A.Outbound, probeURL string, timeout time.Dura
 	defer client.CloseIdleConnections()
 	resp, err := client.Do(req)
 	if err != nil {
-		return Result{}
+		return 0, fmt.Errorf("do request: %w", err)
 	}
 	io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 
-	return Result{Success: true, Delay: time.Since(start)}
+	return time.Since(start), nil
 }

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -1,0 +1,100 @@
+// Package probe dials an outbound and completes one HTTP request through it,
+// timed.
+package probe
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	A "github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing/common"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+	"github.com/sagernet/sing/common/ntp"
+)
+
+// Result is one attempt's outcome. Delay is meaningful only when Success: it
+// spans the handshake and the request, plus the dial for an outbound that does
+// not defer its handshake to first use.
+type Result struct {
+	Success bool
+	Delay   time.Duration
+}
+
+// Run dials out and completes an HTTP GET to probeURL over that one
+// connection, discarding the body. Success means the request completed,
+// whatever status it returned; when probeURL's handler confirms receipt, it
+// also means the handler was reached.
+//
+// timeout bounds the whole attempt: a non-positive timeout, or a probeURL that
+// is empty or unparsable, fails without dialing. The connection is closed
+// before Run returns.
+func Run(ctx context.Context, out A.Outbound, probeURL string, timeout time.Duration) Result {
+	if probeURL == "" || timeout <= 0 {
+		return Result{}
+	}
+	linkURL, err := url.Parse(probeURL)
+	if err != nil {
+		return Result{}
+	}
+	hostname := linkURL.Hostname()
+	port := linkURL.Port()
+	if port == "" {
+		switch linkURL.Scheme {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		}
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	start := time.Now()
+	conn, err := out.DialContext(probeCtx, "tcp", M.ParseSocksaddrHostPortStr(hostname, port))
+	if err != nil {
+		return Result{}
+	}
+	defer conn.Close()
+	if earlyConn, ok := common.Cast[N.EarlyConn](conn); ok && earlyConn.NeedHandshake() {
+		start = time.Now()
+	}
+
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, probeURL, nil)
+	if err != nil {
+		return Result{}
+	}
+	if tp := linkURL.Query().Get("tp"); tp != "" {
+		req.Header.Set("traceparent", tp)
+	}
+
+	client := http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return conn, nil
+			},
+			TLSClientConfig: &tls.Config{
+				Time:    ntp.TimeFuncFromContext(probeCtx),
+				RootCAs: A.RootPoolFromContext(probeCtx),
+			},
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	defer client.CloseIdleConnections()
+	resp, err := client.Do(req)
+	if err != nil {
+		return Result{}
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	return Result{Success: true, Delay: time.Since(start)}
+}

--- a/internal/probe/probe_test.go
+++ b/internal/probe/probe_test.go
@@ -66,11 +66,11 @@ func TestRun_SuccessMeasuresDelayAndClosesConn(t *testing.T) {
 	var conns []*trackedConn
 	out := &stubOutbound{dial: dialerFor(addr, &conns)}
 
-	res := Run(context.Background(), out, srv.URL, 5*time.Second)
+	delay, err := Run(context.Background(), out, srv.URL, 5*time.Second)
 
-	assert.True(t, res.Success)
-	assert.Positive(t, res.Delay)
-	assert.Less(t, res.Delay, 5*time.Second)
+	require.NoError(t, err)
+	assert.Positive(t, delay)
+	assert.Less(t, delay, 5*time.Second)
 	assert.Equal(t, addr, out.dest, "the URL's host and port are what gets dialed")
 	require.Len(t, conns, 1)
 	assert.True(t, conns[0].closed.Load(), "Run closes what it dials")
@@ -85,9 +85,9 @@ func TestRun_CompletedRequestSucceedsWhateverTheStatus(t *testing.T) {
 	var conns []*trackedConn
 	out := &stubOutbound{dial: dialerFor(strings.TrimPrefix(srv.URL, "http://"), &conns)}
 
-	res := Run(context.Background(), out, srv.URL, 5*time.Second)
+	_, err := Run(context.Background(), out, srv.URL, 5*time.Second)
 
-	assert.True(t, res.Success, "a 500 still proves the request completed")
+	assert.NoError(t, err, "a 500 still proves the request completed")
 }
 
 func TestRun_UnusableInputNeverDials(t *testing.T) {
@@ -98,6 +98,9 @@ func TestRun_UnusableInputNeverDials(t *testing.T) {
 	}{
 		{"empty URL", "", time.Second},
 		{"unparsable URL", "http://[::1", time.Second},
+		{"no scheme", "//probe.test/x", time.Second},
+		{"unsupported scheme", "ftp://probe.test/x", time.Second},
+		{"no host", "http:///x", time.Second},
 		{"zero timeout", "http://probe.test/", 0},
 		{"negative timeout", "http://probe.test/", -time.Second},
 	} {
@@ -106,23 +109,25 @@ func TestRun_UnusableInputNeverDials(t *testing.T) {
 				return nil, errors.New("must not dial")
 			}}
 
-			res := Run(context.Background(), out, tc.probeURL, tc.timeout)
+			_, err := Run(context.Background(), out, tc.probeURL, tc.timeout)
 
-			assert.False(t, res.Success)
+			assert.ErrorIs(t, err, ErrUnusableInput)
 			assert.Zero(t, out.dials.Load())
 		})
 	}
 }
 
-func TestRun_DialFailureIsAFailedProbe(t *testing.T) {
+func TestRun_DialFailureWrapsTheOutboundsError(t *testing.T) {
+	denied := errors.New("dial denied")
 	out := &stubOutbound{dial: func(context.Context) (net.Conn, error) {
-		return nil, errors.New("dial denied")
+		return nil, denied
 	}}
 
-	res := Run(context.Background(), out, "http://probe.test/", time.Second)
+	delay, err := Run(context.Background(), out, "http://probe.test/", time.Second)
 
-	assert.False(t, res.Success)
-	assert.Zero(t, res.Delay)
+	assert.ErrorIs(t, err, denied)
+	assert.NotErrorIs(t, err, ErrUnusableInput, "the dial happened; it failed")
+	assert.Zero(t, delay)
 }
 
 func TestRun_TimeoutBoundsTheAttempt(t *testing.T) {
@@ -136,10 +141,10 @@ func TestRun_TimeoutBoundsTheAttempt(t *testing.T) {
 
 	const timeout = 100 * time.Millisecond
 	start := time.Now()
-	res := Run(context.Background(), out, srv.URL, timeout)
+	_, err := Run(context.Background(), out, srv.URL, timeout)
 	elapsed := time.Since(start)
 
-	assert.False(t, res.Success, "a request that never completes is not a success")
+	assert.ErrorIs(t, err, context.DeadlineExceeded, "a request that never completes is not a success")
 	assert.Less(t, elapsed, 5*time.Second, "the per-probe timeout, not the caller's patience, ends it")
 	require.Len(t, conns, 1)
 	assert.True(t, conns[0].closed.Load())
@@ -152,9 +157,9 @@ func TestRun_CanceledContextIsAFailedProbe(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	res := Run(ctx, out, "http://probe.test/", time.Second)
+	_, err := Run(ctx, out, "http://probe.test/", time.Second)
 
-	assert.False(t, res.Success)
+	assert.ErrorIs(t, err, context.Canceled)
 }
 
 func TestRun_ForwardsTraceparentFromQuery(t *testing.T) {
@@ -168,9 +173,9 @@ func TestRun_ForwardsTraceparentFromQuery(t *testing.T) {
 	var conns []*trackedConn
 	out := &stubOutbound{dial: dialerFor(strings.TrimPrefix(srv.URL, "http://"), &conns)}
 
-	res := Run(context.Background(), out, srv.URL+"?tp="+tp, 5*time.Second)
+	_, err := Run(context.Background(), out, srv.URL+"?tp="+tp, 5*time.Second)
 
-	require.True(t, res.Success)
+	require.NoError(t, err)
 	assert.Equal(t, tp, <-got)
 }
 
@@ -198,14 +203,14 @@ func TestRun_DelayExcludesTheDialWhenTheHandshakeIsDeferred(t *testing.T) {
 	}
 
 	deferred := &stubOutbound{dial: slowDial(func(c net.Conn) net.Conn { return earlyConn{c} })}
-	res := Run(context.Background(), deferred, srv.URL, 5*time.Second)
-	require.True(t, res.Success)
-	assert.Less(t, res.Delay, dialCost, "the timer restarts once a dial has only queued the handshake")
+	delay, err := Run(context.Background(), deferred, srv.URL, 5*time.Second)
+	require.NoError(t, err)
+	assert.Less(t, delay, dialCost, "the timer restarts once a dial has only queued the handshake")
 
 	eager := &stubOutbound{dial: slowDial(func(c net.Conn) net.Conn { return c })}
-	res = Run(context.Background(), eager, srv.URL, 5*time.Second)
-	require.True(t, res.Success)
-	assert.GreaterOrEqual(t, res.Delay, dialCost, "a conn that handshook while dialing is timed from before it")
+	delay, err = Run(context.Background(), eager, srv.URL, 5*time.Second)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, delay, dialCost, "a conn that handshook while dialing is timed from before it")
 }
 
 func TestRun_DerivesPortFromScheme(t *testing.T) {

--- a/internal/probe/probe_test.go
+++ b/internal/probe/probe_test.go
@@ -1,0 +1,231 @@
+package probe
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	M "github.com/sagernet/sing/common/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubOutbound struct {
+	adapter.Outbound
+	dials atomic.Int32
+	dest  string
+	dial  func(ctx context.Context) (net.Conn, error)
+}
+
+func (s *stubOutbound) Tag() string { return "stub" }
+
+func (s *stubOutbound) DialContext(ctx context.Context, network string, dest M.Socksaddr) (net.Conn, error) {
+	s.dials.Add(1)
+	s.dest = dest.String()
+	return s.dial(ctx)
+}
+
+type trackedConn struct {
+	net.Conn
+	closed atomic.Bool
+}
+
+func (c *trackedConn) Close() error {
+	c.closed.Store(true)
+	return c.Conn.Close()
+}
+
+// dialerFor dials the server directly, standing in for an outbound that
+// tunnels there.
+func dialerFor(addr string, conns *[]*trackedConn) func(context.Context) (net.Conn, error) {
+	return func(ctx context.Context) (net.Conn, error) {
+		c, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+		tracked := &trackedConn{Conn: c}
+		*conns = append(*conns, tracked)
+		return tracked, nil
+	}
+}
+
+func TestRun_SuccessMeasuresDelayAndClosesConn(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+	addr := strings.TrimPrefix(srv.URL, "http://")
+
+	var conns []*trackedConn
+	out := &stubOutbound{dial: dialerFor(addr, &conns)}
+
+	res := Run(context.Background(), out, srv.URL, 5*time.Second)
+
+	assert.True(t, res.Success)
+	assert.Positive(t, res.Delay)
+	assert.Less(t, res.Delay, 5*time.Second)
+	assert.Equal(t, addr, out.dest, "the URL's host and port are what gets dialed")
+	require.Len(t, conns, 1)
+	assert.True(t, conns[0].closed.Load(), "Run closes what it dials")
+}
+
+func TestRun_CompletedRequestSucceedsWhateverTheStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	var conns []*trackedConn
+	out := &stubOutbound{dial: dialerFor(strings.TrimPrefix(srv.URL, "http://"), &conns)}
+
+	res := Run(context.Background(), out, srv.URL, 5*time.Second)
+
+	assert.True(t, res.Success, "a 500 still proves the request completed")
+}
+
+func TestRun_UnusableInputNeverDials(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		probeURL string
+		timeout  time.Duration
+	}{
+		{"empty URL", "", time.Second},
+		{"unparsable URL", "http://[::1", time.Second},
+		{"zero timeout", "http://probe.test/", 0},
+		{"negative timeout", "http://probe.test/", -time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := &stubOutbound{dial: func(context.Context) (net.Conn, error) {
+				return nil, errors.New("must not dial")
+			}}
+
+			res := Run(context.Background(), out, tc.probeURL, tc.timeout)
+
+			assert.False(t, res.Success)
+			assert.Zero(t, out.dials.Load())
+		})
+	}
+}
+
+func TestRun_DialFailureIsAFailedProbe(t *testing.T) {
+	out := &stubOutbound{dial: func(context.Context) (net.Conn, error) {
+		return nil, errors.New("dial denied")
+	}}
+
+	res := Run(context.Background(), out, "http://probe.test/", time.Second)
+
+	assert.False(t, res.Success)
+	assert.Zero(t, res.Delay)
+}
+
+func TestRun_TimeoutBoundsTheAttempt(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	var conns []*trackedConn
+	out := &stubOutbound{dial: dialerFor(strings.TrimPrefix(srv.URL, "http://"), &conns)}
+
+	const timeout = 100 * time.Millisecond
+	start := time.Now()
+	res := Run(context.Background(), out, srv.URL, timeout)
+	elapsed := time.Since(start)
+
+	assert.False(t, res.Success, "a request that never completes is not a success")
+	assert.Less(t, elapsed, 5*time.Second, "the per-probe timeout, not the caller's patience, ends it")
+	require.Len(t, conns, 1)
+	assert.True(t, conns[0].closed.Load())
+}
+
+func TestRun_CanceledContextIsAFailedProbe(t *testing.T) {
+	out := &stubOutbound{dial: func(ctx context.Context) (net.Conn, error) {
+		return nil, ctx.Err()
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	res := Run(ctx, out, "http://probe.test/", time.Second)
+
+	assert.False(t, res.Success)
+}
+
+func TestRun_ForwardsTraceparentFromQuery(t *testing.T) {
+	const tp = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+	got := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got <- r.Header.Get("traceparent")
+	}))
+	defer srv.Close()
+
+	var conns []*trackedConn
+	out := &stubOutbound{dial: dialerFor(strings.TrimPrefix(srv.URL, "http://"), &conns)}
+
+	res := Run(context.Background(), out, srv.URL+"?tp="+tp, 5*time.Second)
+
+	require.True(t, res.Success)
+	assert.Equal(t, tp, <-got)
+}
+
+// earlyConn reports a handshake that has not run yet, the way a lazily
+// connecting outbound's conn does.
+type earlyConn struct{ net.Conn }
+
+func (earlyConn) NeedHandshake() bool { return true }
+
+func TestRun_DelayExcludesTheDialWhenTheHandshakeIsDeferred(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	const dialCost = 250 * time.Millisecond
+
+	slowDial := func(wrap func(net.Conn) net.Conn) func(context.Context) (net.Conn, error) {
+		return func(ctx context.Context) (net.Conn, error) {
+			time.Sleep(dialCost)
+			c, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+			if err != nil {
+				return nil, err
+			}
+			return wrap(c), nil
+		}
+	}
+
+	deferred := &stubOutbound{dial: slowDial(func(c net.Conn) net.Conn { return earlyConn{c} })}
+	res := Run(context.Background(), deferred, srv.URL, 5*time.Second)
+	require.True(t, res.Success)
+	assert.Less(t, res.Delay, dialCost, "the timer restarts once a dial has only queued the handshake")
+
+	eager := &stubOutbound{dial: slowDial(func(c net.Conn) net.Conn { return c })}
+	res = Run(context.Background(), eager, srv.URL, 5*time.Second)
+	require.True(t, res.Success)
+	assert.GreaterOrEqual(t, res.Delay, dialCost, "a conn that handshook while dialing is timed from before it")
+}
+
+func TestRun_DerivesPortFromScheme(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		probeURL string
+		want     string
+	}{
+		{"http defaults to 80", "http://probe.test/x", "probe.test:80"},
+		{"https defaults to 443", "https://probe.test/x", "probe.test:443"},
+		{"an explicit port wins", "http://probe.test:8080/x", "probe.test:8080"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := &stubOutbound{dial: func(context.Context) (net.Conn, error) {
+				return nil, errors.New("dial denied")
+			}}
+
+			Run(context.Background(), out, tc.probeURL, time.Second)
+
+			assert.Equal(t, tc.want, out.dest)
+		})
+	}
+}

--- a/protocol/group/mock_outbound_test.go
+++ b/protocol/group/mock_outbound_test.go
@@ -16,7 +16,7 @@ type mockOutbound struct {
 	typeName string
 	networks []string
 	// dial, when set, supersedes the mock expectation so each call gets
-	// its own conn; runProbe closes what it dials, so a shared one breaks
+	// its own conn; probe.Run closes what it dials, so a shared one breaks
 	// on the second probe. It receives the caller's context so a stub can
 	// honor the probe deadline the way a real outbound does.
 	dial func(context.Context) (net.Conn, error)

--- a/protocol/group/mutableautoselect_probe.go
+++ b/protocol/group/mutableautoselect_probe.go
@@ -26,13 +26,15 @@ func probeMember(
 	if beh.excludeFromPool {
 		return probeResult{tag: tag}
 	}
-	res := probe.Run(ctx, out, probeURL, beh.probeTimeout)
-	if !res.Success {
+	delay, err := probe.Run(ctx, out, probeURL, beh.probeTimeout)
+	if err != nil {
+		// Every failure is reported as a failed probe, an unusable probe
+		// URL included: separating those would change which members demote.
 		return probeResult{tag: tag}
 	}
 	// 1ms floor so a sub-millisecond probe isn't reported as 0; rank
 	// treats delay==0 as "no recent success" and would drop the winner.
-	delayMs := uint32(res.Delay / time.Millisecond)
+	delayMs := uint32(delay / time.Millisecond)
 	if delayMs == 0 {
 		delayMs = 1
 	}

--- a/protocol/group/mutableautoselect_probe.go
+++ b/protocol/group/mutableautoselect_probe.go
@@ -2,19 +2,12 @@ package group
 
 import (
 	"context"
-	"crypto/tls"
-	"io"
-	"net"
-	"net/http"
-	"net/url"
 	"sync"
 	"time"
 
 	A "github.com/sagernet/sing-box/adapter"
-	"github.com/sagernet/sing/common"
-	M "github.com/sagernet/sing/common/metadata"
-	N "github.com/sagernet/sing/common/network"
-	"github.com/sagernet/sing/common/ntp"
+
+	"github.com/getlantern/lantern-box/internal/probe"
 )
 
 type probeResult struct {
@@ -23,81 +16,23 @@ type probeResult struct {
 	delayMs uint32
 }
 
-// runProbe issues an HTTP GET through out to probeURL under the
-// per-protocol timeout. Success implies a completed handshake; for
-// bandit-supplied URLs it also implies the callback handler received the
-// request.
-func runProbe(
+func probeMember(
 	ctx context.Context,
 	out A.Outbound,
 	probeURL string,
 	beh protocolBehavior,
 ) probeResult {
 	tag := out.Tag()
-	if beh.excludeFromPool || probeURL == "" {
+	if beh.excludeFromPool {
 		return probeResult{tag: tag}
 	}
-	linkURL, err := url.Parse(probeURL)
-	if err != nil {
+	res := probe.Run(ctx, out, probeURL, beh.probeTimeout)
+	if !res.Success {
 		return probeResult{tag: tag}
 	}
-	hostname := linkURL.Hostname()
-	port := linkURL.Port()
-	if port == "" {
-		switch linkURL.Scheme {
-		case "http":
-			port = "80"
-		case "https":
-			port = "443"
-		}
-	}
-
-	probeCtx, cancel := context.WithTimeout(ctx, beh.probeTimeout)
-	defer cancel()
-
-	start := time.Now()
-	conn, err := out.DialContext(probeCtx, "tcp", M.ParseSocksaddrHostPortStr(hostname, port))
-	if err != nil {
-		return probeResult{tag: tag}
-	}
-	defer conn.Close()
-	if earlyConn, ok := common.Cast[N.EarlyConn](conn); ok && earlyConn.NeedHandshake() {
-		start = time.Now()
-	}
-
-	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, probeURL, nil)
-	if err != nil {
-		return probeResult{tag: tag}
-	}
-	if tp := linkURL.Query().Get("tp"); tp != "" {
-		req.Header.Set("traceparent", tp)
-	}
-
-	client := http.Client{
-		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				return conn, nil
-			},
-			TLSClientConfig: &tls.Config{
-				Time:    ntp.TimeFuncFromContext(probeCtx),
-				RootCAs: A.RootPoolFromContext(probeCtx),
-			},
-		},
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-	defer client.CloseIdleConnections()
-	resp, err := client.Do(req)
-	if err != nil {
-		return probeResult{tag: tag}
-	}
-	io.Copy(io.Discard, resp.Body)
-	resp.Body.Close()
-
 	// 1ms floor so a sub-millisecond probe isn't reported as 0; rank
 	// treats delay==0 as "no recent success" and would drop the winner.
-	delayMs := uint32(time.Since(start) / time.Millisecond)
+	delayMs := uint32(res.Delay / time.Millisecond)
 	if delayMs == 0 {
 		delayMs = 1
 	}
@@ -124,7 +59,7 @@ func (s *MutableAutoSelect) probeAll(
 	for range workers {
 		wg.Go(func() {
 			for j := range queue {
-				res := runProbe(ctx, j.outbound, j.probeURL, j.beh)
+				res := probeMember(ctx, j.outbound, j.probeURL, j.beh)
 				// Batch cancellation (shutdown or ladder budget) is not member
 				// evidence. Per-probe timeouts use a child context, so the
 				// batch ctx remains live and the failure still counts.


### PR DESCRIPTION
Moves the dial-and-complete-one-GET probe out of `protocol/group` into a new `internal/probe` package, so the selection path and future callers share one definition of a successful dial. Groundwork; nothing new consumes it yet.

## What moved

`runProbe` becomes `probe.Run(ctx, out, probeURL, timeout) Result`, with `Result{Success bool, Delay time.Duration}`. The body is carried over unchanged: URL parsing with scheme-default ports, `DialContext`, the `EarlyConn` handshake timing reset, the single-conn pinned transport with the NTP time func and `RootPoolFromContext`, `traceparent` from the `tp` query param, no-redirect policy, body drained and closed.

`protocol/group` keeps a `probeMember` adapter for what is selection policy rather than measurement:

- the `excludeFromPool` skip — belt-and-braces, since `collectProbeJobsLocked` already filters those members
- `probeResult` tag wrapping
- the 1&nbsp;ms delay floor, because `rank` reads `delay == 0` as "no recent success" and would drop the winner

## Behavior

`MutableAutoSelect` is unchanged. `probeAll` is untouched apart from its call site, so worker count, unbuffered queue, serial `onSuccess`, batch-cancel skip and enqueue-cancellation paths all stay as they were, and the delay is still sampled immediately after the response body is closed.

One deliberate divergence: `probe.Run` returns without dialing when `timeout <= 0`, where the old code built an already-expired child context and dialed anyway. Unreachable from `MutableAutoSelect` — every protocol with a probe path has a positive `probeTimeout`, and the two that do not (`TypeTor`, `TypeUnbounded`) set `excludeFromPool` and short-circuit in `probeMember` first.

`N.EarlyConn` is deprecated upstream in favor of `N.NeedHandshakeForWrite`, but that is deliberately left alone: `NeedHandshakeForWrite` uses a direct type assertion while `common.Cast` recurses through `Upstream()`/`NetConn()`, and it also honors `EarlyWriter`. Neither check dominates the other, so swapping them would shift probe timings for wrapped conns — a behavior change that does not belong in a move.

## Verification

- `go build ./...`, `gofmt`, `go vet` clean
- `go test -race -count=2 ./internal/probe/...` and `go test -race ./protocol/group/...` pass, the auto-select tests unmodified
- new package suite covers what the group tests never asserted: dial destination and scheme-default ports, conn close, a completed request at any status, dial failure, request timeout, canceled context, `traceparent` forwarding, and the deferred-versus-eager handshake timing split
- unrelated pre-existing failure in a full `go test ./...`: `otel.TestInitTelemetry` panics in testcontainers' `MustExtractDockerHost` without a Docker host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Outbound connectivity probes now report response delay alongside success or failure.
  * Probes support time limits, context cancellation, trace propagation, and scheme-based port selection.
  * Probe results no longer depend on HTTP status codes.

* **Bug Fixes**
  * Invalid URLs, unavailable connections, timeouts, and canceled requests now return clear failures.
  * Probe connections are reliably closed after completion.
  * Unusable probe inputs are handled consistently during member selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->