### PR TITLE
twiddle: mux N:1, single-use tickets, measured CoverProfile

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -94,9 +94,7 @@ jobs:
           echo "reflex_cert_fp=$REFLEX_CERT_FP" >> "$GITHUB_OUTPUT"
 
           # Twiddle: the egress holds the ticket key, the client holds only the
-          # credential that key issued. The cover must be a measured identity:
-          # its profile is what fixes the ticket length, binder length, cipher
-          # and ServerHello extension order on both sides.
+          # credential that key issued. Cover must be a measured identity.
           go run github.com/getlantern/twiddle/cmd/twiddlecred \
             -client-id 1 -cover www.cloudflare.com > twiddle-creds.txt
           echo "twiddle_ticket_key=$(grep ^ticket_key= twiddle-creds.txt | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
@@ -664,7 +662,9 @@ jobs:
           TWIDDLE_PSK: ${{ steps.creds.outputs.twiddle_psk }}
         run: |
           # cover_sni must agree with the egress's masquerade_upstream, or the
-          # SNI names one site while probes are answered by another.
+          # SNI names one site while probes are answered by another. hello_pool
+          # is required: the embedded snapshot is no longer a fallback.
+          go run github.com/getlantern/twiddle/cmd/twiddlecred -print-pool > /tmp/twiddle-hellos.hex
           cat > /tmp/twiddle-client.json << JSONEOF
           {
             "log": {"level": "debug"},
@@ -681,7 +681,8 @@ jobs:
               "server_port": 9005,
               "ticket": "${TWIDDLE_TICKET}",
               "psk": "${TWIDDLE_PSK}",
-              "cover_sni": "www.cloudflare.com"
+              "cover_sni": "www.cloudflare.com",
+              "hello_pool_path": "/tmp/twiddle-hellos.hex"
             }]
           }
           JSONEOF

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -94,7 +94,9 @@ jobs:
           echo "reflex_cert_fp=$REFLEX_CERT_FP" >> "$GITHUB_OUTPUT"
 
           # Twiddle: the egress holds the ticket key, the client holds only the
-          # credential that key issued. Cover must be a measured identity.
+          # credential that key issued. The cover must be a measured identity:
+          # its profile is what fixes the ticket length, binder length, cipher
+          # and ServerHello extension order on both sides.
           go run github.com/getlantern/twiddle/cmd/twiddlecred \
             -client-id 1 -cover www.cloudflare.com > twiddle-creds.txt
           echo "twiddle_ticket_key=$(grep ^ticket_key= twiddle-creds.txt | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
@@ -662,9 +664,7 @@ jobs:
           TWIDDLE_PSK: ${{ steps.creds.outputs.twiddle_psk }}
         run: |
           # cover_sni must agree with the egress's masquerade_upstream, or the
-          # SNI names one site while probes are answered by another. hello_pool
-          # is required: the embedded snapshot is no longer a fallback.
-          go run github.com/getlantern/twiddle/cmd/twiddlecred -print-pool > /tmp/twiddle-hellos.hex
+          # SNI names one site while probes are answered by another.
           cat > /tmp/twiddle-client.json << JSONEOF
           {
             "log": {"level": "debug"},
@@ -681,8 +681,7 @@ jobs:
               "server_port": 9005,
               "ticket": "${TWIDDLE_TICKET}",
               "psk": "${TWIDDLE_PSK}",
-              "cover_sni": "www.cloudflare.com",
-              "hello_pool_path": "/tmp/twiddle-hellos.hex"
+              "cover_sni": "www.cloudflare.com"
             }]
           }
           JSONEOF

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb
 	github.com/getlantern/twiddle v0.0.0-20260905105024-c78665a55653
 	github.com/gobwas/ws v1.4.0
+	github.com/hashicorp/yamux v0.1.2
 	github.com/pion/transport/v4 v4.0.1
 	github.com/refraction-networking/water v0.7.1-alpha
 	github.com/sagernet/sing v0.8.13
@@ -156,7 +157,6 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
-	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/hdevalence/ed25519consensus v0.2.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/option/twiddle.go
+++ b/option/twiddle.go
@@ -65,9 +65,9 @@ type TwiddleOutboundOptions struct {
 	CoverSNI string `json:"cover_sni"`
 
 	// HelloPool carries a pool of harvested ClientHellos inline: one hex-encoded
-	// record per line. This is the config-delivered tier and loses to
-	// HelloPoolDevicePath. The stale pool compiled into twiddle is not used as a
-	// production fallback.
+	// record per line. This is the config-delivered tier -- it beats the pool
+	// compiled into the twiddle module, which is a snapshot of one Chrome version
+	// and ages into a positive signal, but it loses to HelloPoolDevicePath.
 	HelloPool string `json:"hello_pool,omitempty"`
 
 	// HelloPoolPath is a config-written pool file, in the same form as

--- a/option/twiddle.go
+++ b/option/twiddle.go
@@ -28,7 +28,8 @@ type TwiddleInboundOptions struct {
 	// CoverHost is the impersonated identity. Cipher, binder length, ticket
 	// length, ServerHello extension order and opening-flight sizes all come
 	// from the measured CoverProfile for this host. Empty means the host of
-	// MasqueradeUpstream. Unknown hosts are rejected.
+	// MasqueradeUpstream. When MasqueradeUpstream uses a DNS name, the two must
+	// match; an explicit cover is reserved for upstream IP addresses.
 	CoverHost string `json:"cover_host,omitempty"`
 }
 
@@ -64,9 +65,9 @@ type TwiddleOutboundOptions struct {
 	CoverSNI string `json:"cover_sni"`
 
 	// HelloPool carries a pool of harvested ClientHellos inline: one hex-encoded
-	// record per line. This is the config-delivered tier -- it beats the pool
-	// compiled into the twiddle module, which is a snapshot of one Chrome version
-	// and ages into a positive signal, but it loses to HelloPoolDevicePath.
+	// record per line. This is the config-delivered tier and loses to
+	// HelloPoolDevicePath. The stale pool compiled into twiddle is not used as a
+	// production fallback.
 	HelloPool string `json:"hello_pool,omitempty"`
 
 	// HelloPoolPath is a config-written pool file, in the same form as

--- a/option/twiddle.go
+++ b/option/twiddle.go
@@ -27,9 +27,8 @@ type TwiddleInboundOptions struct {
 
 	// CoverHost is the impersonated identity. Cipher, binder length, ticket
 	// length, ServerHello extension order and opening-flight sizes all come
-	// from the measured CoverProfile for this host, so they cannot be set
-	// individually and drift apart. Empty means the host of MasqueradeUpstream.
-	// Unknown hosts are rejected.
+	// from the measured CoverProfile for this host. Empty means the host of
+	// MasqueradeUpstream. Unknown hosts are rejected.
 	CoverHost string `json:"cover_host,omitempty"`
 }
 
@@ -61,8 +60,7 @@ type TwiddleOutboundOptions struct {
 
 	// CoverSNI is the domain this egress masquerades as. It must be a measured
 	// cover identity (see twiddle.CoverFor) and should agree with the egress's
-	// masquerade_upstream, or the SNI names one site while probes are answered
-	// by another.
+	// masquerade_upstream.
 	CoverSNI string `json:"cover_sni"`
 
 	// HelloPool carries a pool of harvested ClientHellos inline: one hex-encoded

--- a/protocol/twiddle/inbound.go
+++ b/protocol/twiddle/inbound.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/yamux"
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/adapter/inbound"
 	"github.com/sagernet/sing-box/common/listener"
@@ -52,10 +53,6 @@ func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger
 		return nil, errors.New("twiddle: masquerade_upstream is required; without it an active prober gets a distinguishing reply")
 	}
 
-	// The cover identity is derived rather than configured field by field: the
-	// cipher, binder length, ticket length and ServerHello extension order are
-	// one measured profile, and a config that could set them individually could
-	// name microsoft while emitting cloudflare's binder.
 	coverHost := options.CoverHost
 	if coverHost == "" {
 		var herr error
@@ -69,7 +66,7 @@ func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger
 		return nil, err
 	}
 
-	maxAge := tw.DefaultTicketMaxAge
+	var maxAge time.Duration
 	if options.TicketMaxAge != "" {
 		if maxAge, err = time.ParseDuration(options.TicketMaxAge); err != nil {
 			return nil, fmt.Errorf("twiddle: invalid ticket_max_age: %w", err)
@@ -85,11 +82,8 @@ func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger
 			TicketKey: key,
 			Cover:     cover,
 			MaxAge:    maxAge,
-			// One cache for the whole egress: a ticket is single-use, and a
-			// per-connection gate would spend nothing. Its horizon is maxAge
-			// because eviction is only sound where MaxAge refuses the ticket first.
-			Replay: tw.NewReplayCache(0, maxAge),
-			Shaper: tw.BrowsingShaper(true),
+			Replay:    tw.NewReplayCache(0, maxAge),
+			Shaper:    tw.BrowsingShaper(true),
 		},
 		masqueradeUpstream: options.MasqueradeUpstream,
 	}
@@ -128,18 +122,44 @@ func (i *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata a
 		return
 	}
 
-	dest, err := readDestination(tconn)
+	sess, err := yamux.Server(tconn, muxConfig())
 	if err != nil {
 		N.CloseOnHandshakeFailure(tconn, onClose, err)
 		return
 	}
-	destination := M.ParseSocksaddr(dest)
-	i.logger.TraceContext(ctx, "twiddle connection from ", metadata.Source, " to ", destination)
+	go i.acceptStreams(ctx, sess, metadata, onClose)
+}
 
-	metadata.Inbound = i.Tag()
-	metadata.InboundType = constant.TypeTwiddle
-	metadata.Destination = destination
-	i.router.RouteConnectionEx(ctx, tconn, metadata, onClose)
+func (i *Inbound) acceptStreams(ctx context.Context, sess *yamux.Session, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	defer sess.Close()
+	defer func() {
+		if onClose != nil {
+			onClose(nil)
+		}
+	}()
+	for {
+		stream, err := sess.Accept()
+		if err != nil {
+			return
+		}
+		go i.routeStream(ctx, stream, metadata)
+	}
+}
+
+func (i *Inbound) routeStream(ctx context.Context, stream net.Conn, metadata adapter.InboundContext) {
+	dest, err := readDestination(stream)
+	if err != nil {
+		stream.Close()
+		return
+	}
+	destination := M.ParseSocksaddr(dest)
+	i.logger.TraceContext(ctx, "twiddle stream from ", metadata.Source, " to ", destination)
+
+	md := metadata
+	md.Inbound = i.Tag()
+	md.InboundType = constant.TypeTwiddle
+	md.Destination = destination
+	i.router.RouteConnectionEx(ctx, stream, md, nil)
 }
 
 func readDestination(r io.Reader) (string, error) {

--- a/protocol/twiddle/inbound.go
+++ b/protocol/twiddle/inbound.go
@@ -166,9 +166,24 @@ func acceptEndError(err error) error {
 	return masquerade.FirstRealError(err)
 }
 
+// destinationReadTimeout bounds the stream prologue. A variable so tests can
+// shorten it.
+var destinationReadTimeout = 10 * time.Second
+
 func (i *Inbound) routeStream(ctx context.Context, stream net.Conn, metadata adapter.InboundContext) {
+	// A stream that opens and then says nothing would park this goroutine for
+	// as long as the peer cared to hold it. Mux is what makes that cheap to do
+	// at scale: one authenticated connection can open many streams, so the cost
+	// to the egress is per stream while the cost to the peer stays per
+	// connection. The deadline covers the prologue only and is cleared before
+	// the router takes over, which owns its own timeouts from there.
+	_ = stream.SetReadDeadline(time.Now().Add(destinationReadTimeout))
 	dest, err := readDestination(stream)
 	if err != nil {
+		stream.Close()
+		return
+	}
+	if err := stream.SetReadDeadline(time.Time{}); err != nil {
 		stream.Close()
 		return
 	}

--- a/protocol/twiddle/inbound.go
+++ b/protocol/twiddle/inbound.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -53,20 +54,22 @@ func NewInbound(ctx context.Context, router adapter.Router, lg log.ContextLogger
 		return nil, errors.New("twiddle: masquerade_upstream is required; without it an active prober gets a distinguishing reply")
 	}
 
+	masqueradeHost, _, err := net.SplitHostPort(options.MasqueradeUpstream)
+	if err != nil {
+		return nil, fmt.Errorf("twiddle: masquerade_upstream %q is not host:port: %w", options.MasqueradeUpstream, err)
+	}
 	coverHost := options.CoverHost
 	if coverHost == "" {
-		var herr error
-		coverHost, _, herr = net.SplitHostPort(options.MasqueradeUpstream)
-		if herr != nil {
-			return nil, fmt.Errorf("twiddle: masquerade_upstream %q is not host:port: %w", options.MasqueradeUpstream, herr)
-		}
+		coverHost = masqueradeHost
+	} else if net.ParseIP(masqueradeHost) == nil && !strings.EqualFold(coverHost, masqueradeHost) {
+		return nil, fmt.Errorf("twiddle: cover_host %q does not match masquerade_upstream host %q", coverHost, masqueradeHost)
 	}
 	cover, err := tw.CoverFor(coverHost)
 	if err != nil {
 		return nil, err
 	}
 
-	var maxAge time.Duration
+	maxAge := tw.DefaultTicketMaxAge
 	if options.TicketMaxAge != "" {
 		if maxAge, err = time.ParseDuration(options.TicketMaxAge); err != nil {
 			return nil, fmt.Errorf("twiddle: invalid ticket_max_age: %w", err)
@@ -132,14 +135,16 @@ func (i *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata a
 
 func (i *Inbound) acceptStreams(ctx context.Context, sess *yamux.Session, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
 	defer sess.Close()
+	var acceptErr error
 	defer func() {
 		if onClose != nil {
-			onClose(nil)
+			onClose(acceptErr)
 		}
 	}()
 	for {
 		stream, err := sess.Accept()
 		if err != nil {
+			acceptErr = err
 			return
 		}
 		go i.routeStream(ctx, stream, metadata)

--- a/protocol/twiddle/inbound.go
+++ b/protocol/twiddle/inbound.go
@@ -144,11 +144,26 @@ func (i *Inbound) acceptStreams(ctx context.Context, sess *yamux.Session, metada
 	for {
 		stream, err := sess.Accept()
 		if err != nil {
-			acceptErr = err
+			acceptErr = acceptEndError(err)
 			return
 		}
 		go i.routeStream(ctx, stream, metadata)
 	}
+}
+
+// acceptEndError maps the accept loop's exit to what onClose should report.
+//
+// Everything downstream reads a non-nil onClose as a fault -- mutableselector
+// records it on the span, and the autoselect health scoring demotes an outbound
+// on it -- so a peer that simply hung up has to arrive as nil, or ordinary
+// teardown is indistinguishable from a broken tunnel. yamux reports its own
+// clean shutdown as ErrSessionShutdown; the underlying conn reports the same
+// event as EOF or a closed socket, which FirstRealError already filters.
+func acceptEndError(err error) error {
+	if errors.Is(err, yamux.ErrSessionShutdown) {
+		return nil
+	}
+	return masquerade.FirstRealError(err)
 }
 
 func (i *Inbound) routeStream(ctx context.Context, stream net.Conn, metadata adapter.InboundContext) {

--- a/protocol/twiddle/mux.go
+++ b/protocol/twiddle/mux.go
@@ -1,0 +1,17 @@
+package twiddle
+
+import (
+	"io"
+	"time"
+
+	"github.com/hashicorp/yamux"
+)
+
+func muxConfig() *yamux.Config {
+	cfg := yamux.DefaultConfig()
+	cfg.EnableKeepAlive = true
+	cfg.KeepAliveInterval = 30 * time.Second
+	cfg.ConnectionWriteTimeout = 10 * time.Second
+	cfg.LogOutput = io.Discard
+	return cfg
+}

--- a/protocol/twiddle/outbound.go
+++ b/protocol/twiddle/outbound.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/yamux"
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/adapter/outbound"
 	"github.com/sagernet/sing-box/common/dialer"
@@ -42,29 +43,17 @@ type Outbound struct {
 	port    uint16
 	timeout time.Duration
 
-	// mu guards creds, the pool of credentials not yet spent. The egress issues
-	// a fresh one inside every flight, so a completed connection returns more
-	// than it took only in the sense that it replaces what it consumed.
-	//
-	// sing-box dials concurrently, which is why this is a pool and not a single
-	// slot: each dial claims a distinct credential when one is available, so
-	// sequential and moderately concurrent traffic never presents the same
-	// ticket twice. Under a burst wider than the pool, dials fall back to
-	// reusing the last credential rather than failing -- TLS 1.3 asks clients
-	// not to reuse tickets, but a dead connection is worse than a reused one,
-	// and the egress does not currently enforce single use. Eliminating reuse
-	// entirely would need the egress to issue several credentials per flight.
 	mu    sync.Mutex
 	creds []*tw.Credential
 	cfg   tw.ClientConfig
 
-	// poolOrigin records which tier the hellos came from, so a client that has
-	// quietly degraded to the built-in pool is diagnosable after the fact.
+	sessMu sync.Mutex
+	sess   *yamux.Session
+
 	poolOrigin tw.Origin
 	uotClient  *uot.Client
 }
 
-// maxCredPool bounds credential accumulation on a long-lived outbound.
 const maxCredPool = 32
 
 func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogger, tag string, options option.TwiddleOutboundOptions) (adapter.Outbound, error) {
@@ -93,44 +82,27 @@ func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogge
 	if options.CoverSNI == "" {
 		return nil, fmt.Errorf("twiddle: cover_sni is required; it must agree with the egress's masquerade_upstream")
 	}
-	// An unmeasured cover is refused rather than approximated. Emitting a
-	// plausible-looking profile for a host nobody measured is the failure this
-	// is meant to prevent, not a degraded mode worth having.
 	cover, err := tw.CoverFor(options.CoverSNI)
 	if err != nil {
 		return nil, err
 	}
-	// Ticket length is one of the cover's measured parameters, and the ticket
-	// rides inside pre_shared_key, so a credential minted for another identity
-	// produces a hello of the wrong size for the SNI it carries.
-	if len(cred.Ticket) != cover.TicketLen {
-		return nil, fmt.Errorf("twiddle: credential ticket length %d does not match cover %d", len(cred.Ticket), cover.TicketLen)
-	}
 
-	// Hello sourcing is twiddle's policy, not ours: it owns the precedence
-	// (device tap, then config, then its built-in pool), the per-entry screening
-	// and the partitioning of a source that mixes browser builds. Reimplementing
-	// any of that here would let the two drift apart.
+	// Embedded fallback is disabled: a stale compiled-in snapshot is a
+	// fingerprint, and the right reaction is to fail this outbound so another
+	// transport is selected.
 	pool, err := tw.LoadPool(tw.Sources{
 		Device:       options.HelloPoolDevicePath,
 		Config:       options.HelloPoolPath,
 		ConfigInline: options.HelloPool,
-		// The built-in pool is opt-in in the core because it is stale by
-		// construction. It is enabled here for the reason argued at
-		// TestOutboundDegradesToEmbeddedOnACorruptPool: a stale fingerprint on
-		// every client beats no outbound on every client, and both need the same
-		// config push to clear.
-		AllowEmbedded: true,
 	})
 	if err != nil {
 		return nil, err
 	}
-	// A client that silently drops to the built-in pool still connects, so this
-	// has to be visible or a stale fingerprint ships unnoticed.
 	for _, skipped := range pool.Skipped {
 		lg.Warn("twiddle: ", skipped)
 	}
 	lg.Info("twiddle: ", len(pool.Hellos), " hellos from the ", pool.Origin, " pool")
+
 	timeout := 15 * time.Second
 	if options.ConnectTimeout != "" {
 		if timeout, err = time.ParseDuration(options.ConnectTimeout); err != nil {
@@ -189,42 +161,72 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 	return o.dialTunnel(ctx, destination)
 }
 
-// dialTunnel opens one outer twiddle connection and names the inner
-// destination on it. Both the TCP path and UoT's inner dial land here.
+// dialTunnel opens one multiplexed stream to destination on the shared outer
+// connection, building that connection if there is not a live one.
+//
+// Both the TCP path and UoT's inner dial land here, which is the point: a UDP
+// association rides the same tunnel as everything else rather than opening one
+// of its own. A twiddle connection per association would put a fresh opening on
+// the wire for every DNS lookup, which is the pattern muxing exists to remove.
 func (o *Outbound) dialTunnel(ctx context.Context, destination M.Socksaddr) (net.Conn, error) {
-	o.logger.TraceContext(ctx, "dialing twiddle connection to ", o.server, ":", o.port)
+	sess, err := o.ensureSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+	stream, err := sess.Open()
+	if err != nil {
+		o.dropSession(sess)
+		return nil, fmt.Errorf("twiddle: open stream: %w", err)
+	}
+	if err := writeDestination(stream, destination.String()); err != nil {
+		stream.Close()
+		return nil, err
+	}
+	return stream, nil
+}
+
+func (o *Outbound) ensureSession(ctx context.Context) (*yamux.Session, error) {
+	o.sessMu.Lock()
+	defer o.sessMu.Unlock()
+	if o.sess != nil && !o.sess.IsClosed() {
+		return o.sess, nil
+	}
+	o.logger.TraceContext(ctx, "opening twiddle tunnel to ", o.server, ":", o.port)
+
+	cred := o.takeCredential()
+	if cred == nil {
+		return nil, fmt.Errorf("twiddle: no unused ticket; refusing to reuse")
+	}
 
 	raw, err := o.dialer.DialContext(ctx, N.NetworkTCP, M.ParseSocksaddrHostPort(o.server, o.port))
 	if err != nil {
+		o.putCredential(cred)
 		return nil, fmt.Errorf("twiddle: TCP dial failed: %w", err)
 	}
 	raw.SetDeadline(time.Now().Add(o.timeout))
 
 	cfg := o.cfg
-	cfg.Credential = o.takeCredential()
-
+	cfg.Credential = cred
 	conn, next, err := tw.Client(raw, cfg)
 	if err != nil {
 		raw.Close()
 		return nil, fmt.Errorf("twiddle: opening failed: %w", err)
 	}
 	raw.SetDeadline(time.Time{})
-
-	// The egress issues the next credential inside its flight, exactly as
-	// NewSessionTicket does.
 	if next != nil {
 		o.putCredential(next)
 	}
 
-	if err := writeDestination(conn, destination.String()); err != nil {
+	sess, err := yamux.Client(conn, muxConfig())
+	if err != nil {
 		conn.Close()
-		return nil, err
+		return nil, fmt.Errorf("twiddle: mux: %w", err)
 	}
-	return conn, nil
+	o.sess = sess
+	return sess, nil
 }
 
-// uotDialer carries UoT's inner TCP dial without routing it back through
-// Outbound.
+// uotDialer carries UoT's inner dial without routing it back through Outbound.
 //
 // uot.Client needs an N.Dialer and Outbound is one, but wiring it to itself
 // makes both DialContext(udp) and ListenPacket self-referential: their
@@ -234,6 +236,9 @@ func (o *Outbound) dialTunnel(ctx context.Context, destination M.Socksaddr) (net
 // point the failure is an unbounded recursion in production rather than a
 // compile error. Cutting the loop here costs nothing and matches how unbounded,
 // samizdat and water each wire their own UoT client.
+//
+// It reaches dialTunnel, so UoT's inner connection is a stream on the shared
+// session rather than a tunnel of its own.
 type uotDialer Outbound
 
 func (d *uotDialer) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
@@ -247,16 +252,28 @@ func (d *uotDialer) ListenPacket(ctx context.Context, destination M.Socksaddr) (
 	return nil, fmt.Errorf("twiddle: uotDialer does not support ListenPacket: %w", os.ErrInvalid)
 }
 
-// takeCredential claims a credential for one dial. The last one is reused
-// rather than removed, so a dial never fails for want of a credential.
+func (o *Outbound) dropSession(sess *yamux.Session) {
+	o.sessMu.Lock()
+	defer o.sessMu.Unlock()
+	if o.sess == sess {
+		o.sess.Close()
+		o.sess = nil
+	}
+}
+
+// takeCredential claims one unused ticket. It never reuses: a parallel burst
+// with one ticket opens one tunnel (via ensureSession's lock) and the rest
+// ride streams. An exhausted pool fails rather than emitting the same PSK
+// identity on two connections.
 func (o *Outbound) takeCredential() *tw.Credential {
 	o.mu.Lock()
 	defer o.mu.Unlock()
+	if len(o.creds) == 0 {
+		return nil
+	}
 	last := len(o.creds) - 1
 	c := o.creds[last]
-	if last > 0 {
-		o.creds = o.creds[:last]
-	}
+	o.creds = o.creds[:last]
 	return c
 }
 
@@ -288,4 +305,14 @@ func (o *Outbound) ListenPacket(ctx context.Context, destination M.Socksaddr) (n
 }
 
 func (o *Outbound) Network() []string { return []string{N.NetworkTCP, N.NetworkUDP} }
-func (o *Outbound) Close() error      { return nil }
+
+func (o *Outbound) Close() error {
+	o.sessMu.Lock()
+	defer o.sessMu.Unlock()
+	if o.sess != nil {
+		err := o.sess.Close()
+		o.sess = nil
+		return err
+	}
+	return nil
+}

--- a/protocol/twiddle/outbound.go
+++ b/protocol/twiddle/outbound.go
@@ -86,6 +86,9 @@ func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogge
 	if err != nil {
 		return nil, err
 	}
+	if len(cred.Ticket) != cover.TicketLen {
+		return nil, fmt.Errorf("twiddle: credential ticket length %d does not match cover %d", len(cred.Ticket), cover.TicketLen)
+	}
 
 	// Embedded fallback is disabled: a stale compiled-in snapshot is a
 	// fingerprint, and the right reaction is to fail this outbound so another
@@ -169,20 +172,28 @@ func (o *Outbound) DialContext(ctx context.Context, network string, destination 
 // of its own. A twiddle connection per association would put a fresh opening on
 // the wire for every DNS lookup, which is the pattern muxing exists to remove.
 func (o *Outbound) dialTunnel(ctx context.Context, destination M.Socksaddr) (net.Conn, error) {
-	sess, err := o.ensureSession(ctx)
-	if err != nil {
-		return nil, err
+	var openErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		sess, err := o.ensureSession(ctx)
+		if err != nil {
+			return nil, err
+		}
+		stream, err := sess.Open()
+		if err != nil {
+			o.dropSession(sess)
+			openErr = err
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			continue
+		}
+		if err := writeDestination(stream, destination.String()); err != nil {
+			stream.Close()
+			return nil, err
+		}
+		return stream, nil
 	}
-	stream, err := sess.Open()
-	if err != nil {
-		o.dropSession(sess)
-		return nil, fmt.Errorf("twiddle: open stream: %w", err)
-	}
-	if err := writeDestination(stream, destination.String()); err != nil {
-		stream.Close()
-		return nil, err
-	}
-	return stream, nil
+	return nil, fmt.Errorf("twiddle: open stream after replacing session: %w", openErr)
 }
 
 func (o *Outbound) ensureSession(ctx context.Context) (*yamux.Session, error) {

--- a/protocol/twiddle/outbound.go
+++ b/protocol/twiddle/outbound.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -180,7 +181,16 @@ func (o *Outbound) dialTunnel(ctx context.Context, destination M.Socksaddr) (net
 		}
 		stream, err := sess.Open()
 		if err != nil {
-			o.dropSession(sess)
+			// GO_AWAY means the egress will take no NEW streams. The ones
+			// already running on this tunnel are still live and still carrying
+			// user traffic, and yamux's Close takes down the session AND every
+			// stream on it -- so closing here would drop unrelated connections
+			// because an unrelated dial arrived late. The session is retired
+			// from the cache and left to drain instead; the peer closes the
+			// socket once it is done, which shuts the session down on its own.
+			// Any other Open failure means the session is already unusable, so
+			// there is nothing to drain and the socket should go back now.
+			o.retireSession(sess, !errors.Is(err, yamux.ErrRemoteGoAway))
 			openErr = err
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
@@ -263,12 +273,18 @@ func (d *uotDialer) ListenPacket(ctx context.Context, destination M.Socksaddr) (
 	return nil, fmt.Errorf("twiddle: uotDialer does not support ListenPacket: %w", os.ErrInvalid)
 }
 
-func (o *Outbound) dropSession(sess *yamux.Session) {
+// retireSession removes sess as the cached tunnel so the next dial builds a
+// fresh one. It closes sess only when closeIt is set -- see the GO_AWAY note in
+// dialTunnel for why that is not always wanted.
+func (o *Outbound) retireSession(sess *yamux.Session, closeIt bool) {
 	o.sessMu.Lock()
 	defer o.sessMu.Unlock()
-	if o.sess == sess {
-		o.sess.Close()
-		o.sess = nil
+	if o.sess != sess {
+		return
+	}
+	o.sess = nil
+	if closeIt {
+		sess.Close()
 	}
 }
 

--- a/protocol/twiddle/outbound.go
+++ b/protocol/twiddle/outbound.go
@@ -98,6 +98,12 @@ func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogge
 		Device:       options.HelloPoolDevicePath,
 		Config:       options.HelloPoolPath,
 		ConfigInline: options.HelloPool,
+		// The built-in pool is opt-in in the core because it is stale by
+		// construction. It is enabled here for the reason argued at
+		// TestOutboundDegradesToEmbeddedOnACorruptPool: a stale fingerprint on
+		// every client beats no outbound on every client, and both need the same
+		// config push to clear.
+		AllowEmbedded: true,
 	})
 	if err != nil {
 		return nil, err

--- a/protocol/twiddle/outbound.go
+++ b/protocol/twiddle/outbound.go
@@ -51,6 +51,11 @@ type Outbound struct {
 	sessMu sync.Mutex
 	sess   *yamux.Session
 	closed bool
+	// draining holds sessions retired without closing, on the GO_AWAY path.
+	// They are unreferenced once o.sess moves on, so without this Close could
+	// not reach them and an outbound shutdown would leave tunnels open until
+	// each peer got round to closing its own.
+	draining map[*yamux.Session]struct{}
 
 	poolOrigin tw.Origin
 	uotClient  *uot.Client
@@ -295,7 +300,20 @@ func (o *Outbound) retireSession(sess *yamux.Session, closeIt bool) {
 	o.sess = nil
 	if closeIt {
 		sess.Close()
+		return
 	}
+	if o.draining == nil {
+		o.draining = make(map[*yamux.Session]struct{})
+	}
+	o.draining[sess] = struct{}{}
+	go func() {
+		// Drop it once the peer finishes with it, so a long-lived outbound does
+		// not accumulate a record per GO_AWAY.
+		<-sess.CloseChan()
+		o.sessMu.Lock()
+		delete(o.draining, sess)
+		o.sessMu.Unlock()
+	}()
 }
 
 // takeCredential claims one unused ticket. It never reuses: a parallel burst
@@ -347,10 +365,16 @@ func (o *Outbound) Close() error {
 	o.sessMu.Lock()
 	defer o.sessMu.Unlock()
 	o.closed = true
+	var err error
 	if o.sess != nil {
-		err := o.sess.Close()
+		err = o.sess.Close()
 		o.sess = nil
-		return err
 	}
-	return nil
+	// Sessions left to drain are still ours to tear down: shutdown is the point
+	// at which "let the peer finish" stops being the right trade.
+	for sess := range o.draining {
+		sess.Close()
+		delete(o.draining, sess)
+	}
+	return err
 }

--- a/protocol/twiddle/outbound.go
+++ b/protocol/twiddle/outbound.go
@@ -50,6 +50,7 @@ type Outbound struct {
 
 	sessMu sync.Mutex
 	sess   *yamux.Session
+	closed bool
 
 	poolOrigin tw.Origin
 	uotClient  *uot.Client
@@ -91,9 +92,6 @@ func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogge
 		return nil, fmt.Errorf("twiddle: credential ticket length %d does not match cover %d", len(cred.Ticket), cover.TicketLen)
 	}
 
-	// Embedded fallback is disabled: a stale compiled-in snapshot is a
-	// fingerprint, and the right reaction is to fail this outbound so another
-	// transport is selected.
 	pool, err := tw.LoadPool(tw.Sources{
 		Device:       options.HelloPoolDevicePath,
 		Config:       options.HelloPoolPath,
@@ -215,6 +213,12 @@ func (o *Outbound) dialTunnel(ctx context.Context, destination M.Socksaddr) (net
 func (o *Outbound) ensureSession(ctx context.Context) (*yamux.Session, error) {
 	o.sessMu.Lock()
 	defer o.sessMu.Unlock()
+	// Close nils the session, so without this a dial arriving afterwards would
+	// read that as "no tunnel yet" and build a fresh one -- an outbound that
+	// quietly resurrects itself, holding a connection nothing will ever close.
+	if o.closed {
+		return nil, net.ErrClosed
+	}
 	if o.sess != nil && !o.sess.IsClosed() {
 		return o.sess, nil
 	}
@@ -342,6 +346,7 @@ func (o *Outbound) Network() []string { return []string{N.NetworkTCP, N.NetworkU
 func (o *Outbound) Close() error {
 	o.sessMu.Lock()
 	defer o.sessMu.Unlock()
+	o.closed = true
 	if o.sess != nil {
 		err := o.sess.Close()
 		o.sess = nil

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -540,7 +540,7 @@ func TestAcceptStreamsReportsARealFault(t *testing.T) {
 	}
 }
 
-// faultyConn fails every read with a error that is neither EOF nor a closed
+// faultyConn fails every read with an error that is neither EOF nor a closed
 // socket, so it exercises the branch acceptEndError must NOT swallow.
 type faultyConn struct {
 	net.Conn

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -927,3 +927,138 @@ func TestOutboundDisableFullHandshakeDropsTheContactMemory(t *testing.T) {
 		t.Error("disable_full_handshake left the contact memory in place")
 	}
 }
+
+// A GO_AWAY reaching one dial must not disturb the streams already running on
+// that tunnel.
+//
+// yamux's Close ends the session AND every stream on it, so retiring the cached
+// session has to stop short of closing it: GO_AWAY means "no new streams", not
+// "drop the ones in flight". Without that distinction a single late dial takes
+// down every unrelated connection the tunnel was carrying.
+func TestGoAwayLeavesLiveStreamsAlone(t *testing.T) {
+	cover, err := tw.CoverFor("www.cloudflare.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := tw.NewTicketKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	credential, err := key.Issue(1, cover.TicketLen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	sessions := make(chan *yamux.Session, 2)
+	replay := tw.NewReplayCache(8, 0)
+	go func() {
+		for range 2 {
+			raw, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func(raw net.Conn) {
+				conn, err := tw.Server(raw, tw.ServerConfig{
+					TicketKey: key, Cover: cover, Replay: replay,
+				})
+				if err != nil {
+					raw.Close()
+					return
+				}
+				session, err := yamux.Server(conn, muxConfig())
+				if err != nil {
+					conn.Close()
+					return
+				}
+				sessions <- session
+			}(raw)
+		}
+	}()
+
+	host, portString, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleOutboundOptions{
+			ServerOptions: boxoption.ServerOptions{Server: host, ServerPort: uint16(port)},
+			Ticket:        base64.StdEncoding.EncodeToString(credential.Ticket),
+			PSK:           hex.EncodeToString(credential.PSK[:]),
+			CoverSNI:      cover.Host,
+			HelloPool:     testPool(t),
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := created.(*Outbound)
+	defer out.Close()
+
+	// A stream that stays open for the whole test: this is the bystander.
+	first, err := out.DialContext(context.Background(), "tcp", M.ParseSocksaddr("example.com:443"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	firstSession := <-sessions
+	defer firstSession.Close()
+	firstStream, err := firstSession.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer firstStream.Close()
+	if _, err := readDestination(firstStream); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := firstSession.GoAway(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := out.sess.Ping(); err != nil {
+		t.Fatal(err)
+	}
+
+	// The dial that meets GO_AWAY. It must succeed on a replacement tunnel.
+	second, err := out.DialContext(context.Background(), "tcp", M.ParseSocksaddr("example.org:443"))
+	if err != nil {
+		t.Fatalf("dial did not replace the GO_AWAY session: %v", err)
+	}
+	defer second.Close()
+	secondSession := <-sessions
+	defer secondSession.Close()
+	secondStream, err := secondSession.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer secondStream.Close()
+	if _, err := readDestination(secondStream); err != nil {
+		t.Fatal(err)
+	}
+
+	// The assertion this test exists for: the bystander still carries traffic.
+	want := []byte("the bystander is still connected")
+	if err := first.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := first.Write(want); err != nil {
+		t.Fatalf("a live stream was torn down by an unrelated dial's GO_AWAY: %v", err)
+	}
+	if err := firstStream.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	got := make([]byte, len(want))
+	if _, err := io.ReadFull(firstStream, got); err != nil {
+		t.Fatalf("the egress side of a live stream did not survive the GO_AWAY: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("bystander carried %q, want %q", got, want)
+	}
+}

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/yamux"
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/log"
 	boxoption "github.com/sagernet/sing-box/option"
@@ -222,20 +223,6 @@ func TestInboundAcceptsAValidConfig(t *testing.T) {
 	}
 }
 
-func TestInboundAppliesDefaultTicketMaxAge(t *testing.T) {
-	keyHex, _, _ := creds(t)
-	ib, err := NewInbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
-		option.TwiddleInboundOptions{
-			TicketKey: keyHex, MasqueradeUpstream: "www.cloudflare.com:443",
-		})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := ib.(*Inbound).cfg.MaxAge; got != tw.DefaultTicketMaxAge {
-		t.Fatalf("default ticket max age is %v, want %v", got, tw.DefaultTicketMaxAge)
-	}
-}
-
 func TestInboundRejectsUnknownCover(t *testing.T) {
 	keyHex, _, _ := creds(t)
 	_, err := NewInbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
@@ -277,22 +264,24 @@ func TestOutboundRejectsBadCredentials(t *testing.T) {
 	}
 }
 
-func TestOutboundUsesTheEmbeddedPoolByDefault(t *testing.T) {
+func testPool(t *testing.T) string {
+	t.Helper()
+	p, err := tw.LoadPool(tw.Sources{AllowEmbedded: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tw.FormatPool(p.Hellos)
+}
+
+func TestOutboundRejectsMissingPool(t *testing.T) {
 	_, ticket, psk := creds(t)
-	ob, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+	_, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
 		option.TwiddleOutboundOptions{
 			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
 			Ticket:        ticket, PSK: psk, CoverSNI: "www.cloudflare.com",
 		})
-	if err != nil {
-		t.Fatal(err)
-	}
-	o := ob.(*Outbound)
-	if len(o.cfg.Pool) == 0 {
-		t.Fatal("outbound has an empty hello pool")
-	}
-	if o.cfg.Cover.Host != "www.cloudflare.com" {
-		t.Errorf("cover is %q", o.cfg.Cover.Host)
+	if err == nil {
+		t.Fatal("outbound accepted a missing hello pool; the embedded snapshot must not ship")
 	}
 }
 
@@ -302,57 +291,23 @@ func TestOutboundRejectsUnknownCover(t *testing.T) {
 		option.TwiddleOutboundOptions{
 			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
 			Ticket:        ticket, PSK: psk, CoverSNI: "www.example.com",
+			HelloPool:     testPool(t),
 		})
 	if err == nil {
 		t.Fatal("outbound accepted an unmeasured cover")
 	}
 }
 
-// Ticket length is a fidelity parameter of the cover, so a credential minted for
-// one identity cannot be presented as another: the hello would be the wrong size
-// for the SNI it carries.
-func TestOutboundRejectsCredentialForAnotherCover(t *testing.T) {
+func TestOutboundRejectsCorruptPool(t *testing.T) {
 	_, ticket, psk := creds(t)
 	_, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
 		option.TwiddleOutboundOptions{
 			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
 			Ticket:        ticket, PSK: psk, CoverSNI: "www.microsoft.com",
+			HelloPool:     "not hex at all",
 		})
 	if err == nil {
-		t.Fatal("outbound accepted a credential with the wrong ticket length for its cover")
-	}
-}
-
-// A corrupt configured pool must DEGRADE to the built-in one, not fail the
-// outbound.
-//
-// This reverses the earlier contract deliberately. A pool arrives by config
-// push, so a bad one reaches every client at once; the two candidate failure
-// modes are "every client emits a stale fingerprint" and "every client has no
-// outbound at all". The first risks detection, probabilistically and
-// recoverably; the second is a certain outage. Both are fixed by pushing new
-// config, so the interim state is the whole of the difference, and staleness is
-// the better interim state.
-//
-// The compensating requirement is that the degradation be visible, which is
-// what poolOrigin and the logged Skipped errors are for.
-func TestOutboundDegradesToEmbeddedOnACorruptPool(t *testing.T) {
-	_, ticket, psk := creds(t)
-	ob, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
-		option.TwiddleOutboundOptions{
-			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
-			Ticket:        ticket, PSK: psk, CoverSNI: "www.cloudflare.com",
-			HelloPool: "not hex at all",
-		})
-	if err != nil {
-		t.Fatalf("a corrupt pool must not brick the outbound: %v", err)
-	}
-	o := ob.(*Outbound)
-	if o.poolOrigin != tw.OriginEmbedded {
-		t.Errorf("pool origin is %v, want embedded", o.poolOrigin)
-	}
-	if len(o.cfg.Pool) == 0 {
-		t.Error("degraded outbound has no hellos at all")
+		t.Fatal("a corrupt pool must fail the outbound rather than emit the stale snapshot")
 	}
 }
 
@@ -404,14 +359,9 @@ func TestOutboundPoolPrecedence(t *testing.T) {
 			wantOrigin: tw.OriginConfig, wantSNI: "configfile.example",
 		},
 		{
-			name:       "inline beats embedded",
+			name:       "inline is the config tier",
 			opts:       option.TwiddleOutboundOptions{HelloPool: inline},
 			wantOrigin: tw.OriginConfig, wantSNI: "inline.example",
-		},
-		{
-			name:       "nothing configured falls back",
-			opts:       option.TwiddleOutboundOptions{},
-			wantOrigin: tw.OriginEmbedded,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -496,19 +446,12 @@ func TestPeekConnReplayIsFaithful(t *testing.T) {
 	}
 }
 
-// TestConcurrentDialsExerciseTheCredentialPath replaces an earlier version that
-// pointed at port 1. Review caught that the TCP dial fails before DialContext
-// ever reaches the credential code, so the test asserted nothing about the path
-// it named -- a vacuous test that would have passed with the pool removed.
-//
-// This one stands up a real twiddle egress, so every dial completes an opening
-// and actually claims and returns a credential. Run under -race.
-func TestConcurrentDialsExerciseTheCredentialPath(t *testing.T) {
-	key, err := tw.NewTicketKey()
+func TestConcurrentDialsShareOneMuxedTunnel(t *testing.T) {
+	cover, err := tw.CoverFor("www.cloudflare.com")
 	if err != nil {
 		t.Fatal(err)
 	}
-	cover, err := tw.CoverFor("www.cloudflare.com")
+	key, err := tw.NewTicketKey()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -516,9 +459,6 @@ func TestConcurrentDialsExerciseTheCredentialPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// One gate for the whole egress: tickets are single-use, so a per-connection
-	// cache would spend nothing.
-	replay := tw.NewReplayCache(64, 0)
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -526,23 +466,35 @@ func TestConcurrentDialsExerciseTheCredentialPath(t *testing.T) {
 	}
 	defer ln.Close()
 
-	var served int64
+	var served, tunnels int64
 	go func() {
 		for {
 			c, err := ln.Accept()
 			if err != nil {
 				return
 			}
+			atomic.AddInt64(&tunnels, 1)
 			go func(c net.Conn) {
 				defer c.Close()
 				tc, err := tw.Server(c, tw.ServerConfig{
-					TicketKey: key, Cover: cover, Replay: replay,
+					TicketKey: key, Cover: cover, Replay: tw.NewReplayCache(32, 0),
 				})
 				if err != nil {
 					return
 				}
-				if _, err := readDestination(tc); err == nil {
-					atomic.AddInt64(&served, 1)
+				sess, err := yamux.Server(tc, muxConfig())
+				if err != nil {
+					return
+				}
+				for {
+					stream, err := sess.Accept()
+					if err != nil {
+						return
+					}
+					if _, err := readDestination(stream); err == nil {
+						atomic.AddInt64(&served, 1)
+					}
+					stream.Close()
 				}
 			}(c)
 		}
@@ -556,6 +508,7 @@ func TestConcurrentDialsExerciseTheCredentialPath(t *testing.T) {
 			Ticket:        base64.StdEncoding.EncodeToString(cred.Ticket),
 			PSK:           hex.EncodeToString(cred.PSK[:]),
 			CoverSNI:      cover.Host,
+			HelloPool:     testPool(t),
 		})
 	if err != nil {
 		t.Fatal(err)
@@ -579,22 +532,15 @@ func TestConcurrentDialsExerciseTheCredentialPath(t *testing.T) {
 	wg.Wait()
 
 	if ok == 0 {
-		t.Fatal("no dial completed — the credential path was never exercised")
+		t.Fatal("no dial completed")
 	}
-	o.mu.Lock()
-	pooled := len(o.creds)
-	o.mu.Unlock()
-	// > 1, not > 0: takeCredential deliberately never removes the final
-	// credential, so len(creds) can never reach zero and an "is it empty"
-	// assertion holds even if putCredential is never called at all. Growth
-	// past the single seeded credential is the thing worth asserting -- it can
-	// only happen if the egress's issued credential came back in the flight and
-	// was stored.
-	if pooled <= 1 {
-		t.Errorf("credential pool did not grow past the seeded credential (%d) after %d successful openings; rotation is not being stored", pooled, ok)
+	if atomic.LoadInt64(&tunnels) != 1 {
+		t.Errorf("opened %d outer tunnels, want 1 muxed session", tunnels)
 	}
-	t.Logf("%d/%d dials completed, %d openings served, %d credentials pooled",
-		ok, n, atomic.LoadInt64(&served), pooled)
+	if ok < n {
+		t.Errorf("%d/%d dials completed", ok, n)
+	}
+	t.Logf("%d/%d dials on %d tunnel, %d streams served", ok, n, tunnels, atomic.LoadInt64(&served))
 }
 
 // TestCredentialPoolHandsOutDistinctCredentials: sequential connections must
@@ -610,17 +556,16 @@ func TestCredentialPoolHandsOutDistinctCredentials(t *testing.T) {
 	if bytes.Equal(a.Ticket, b.Ticket) {
 		t.Error("two takes returned the same credential while the pool held two")
 	}
-	// the last credential is reused rather than removed, so a dial never starves
 	c := o.takeCredential()
-	if c == nil {
-		t.Fatal("takeCredential returned nil on an exhausted pool")
+	if c != nil {
+		t.Fatal("takeCredential reused a spent ticket")
 	}
 	o.putCredential(c1)
 	o.mu.Lock()
 	got := len(o.creds)
 	o.mu.Unlock()
-	if got != 2 {
-		t.Errorf("pool has %d credentials after a put, want 2", got)
+	if got != 1 {
+		t.Errorf("pool has %d credentials after a put, want 1", got)
 	}
 }
 
@@ -642,9 +587,6 @@ func TestCredentialPoolIsBounded(t *testing.T) {
 	}
 }
 
-// TestCoverProfileReachesServerConfig covers the dead option review found. The
-// individual knobs it replaced could name one identity and emit another's
-// parameters, so what is pinned now is that the whole measured profile arrives.
 func TestCoverProfileReachesServerConfig(t *testing.T) {
 	keyHex, _, _ := creds(t)
 	ib, err := NewInbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -223,6 +223,32 @@ func TestInboundAcceptsAValidConfig(t *testing.T) {
 	}
 }
 
+func TestInboundAppliesDefaultTicketMaxAge(t *testing.T) {
+	keyHex, _, _ := creds(t)
+	ib, err := NewInbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleInboundOptions{
+			TicketKey: keyHex, MasqueradeUpstream: "www.cloudflare.com:443",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ib.(*Inbound).cfg.MaxAge; got != tw.DefaultTicketMaxAge {
+		t.Fatalf("default ticket max age is %v, want %v", got, tw.DefaultTicketMaxAge)
+	}
+}
+
+func TestInboundRejectsMismatchedCoverHost(t *testing.T) {
+	keyHex, _, _ := creds(t)
+	_, err := NewInbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleInboundOptions{
+			TicketKey: keyHex, MasqueradeUpstream: "www.cloudflare.com:443",
+			CoverHost: "www.microsoft.com",
+		})
+	if err == nil {
+		t.Fatal("inbound accepted a cover_host that contradicts masquerade_upstream")
+	}
+}
+
 func TestInboundRejectsUnknownCover(t *testing.T) {
 	keyHex, _, _ := creds(t)
 	_, err := NewInbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
@@ -291,7 +317,7 @@ func TestOutboundRejectsUnknownCover(t *testing.T) {
 		option.TwiddleOutboundOptions{
 			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
 			Ticket:        ticket, PSK: psk, CoverSNI: "www.example.com",
-			HelloPool:     testPool(t),
+			HelloPool: testPool(t),
 		})
 	if err == nil {
 		t.Fatal("outbound accepted an unmeasured cover")
@@ -303,11 +329,24 @@ func TestOutboundRejectsCorruptPool(t *testing.T) {
 	_, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
 		option.TwiddleOutboundOptions{
 			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
-			Ticket:        ticket, PSK: psk, CoverSNI: "www.microsoft.com",
-			HelloPool:     "not hex at all",
+			Ticket:        ticket, PSK: psk, CoverSNI: "www.cloudflare.com",
+			HelloPool: "not hex at all",
 		})
 	if err == nil {
 		t.Fatal("a corrupt pool must fail the outbound rather than emit the stale snapshot")
+	}
+}
+
+func TestOutboundRejectsCredentialForAnotherCover(t *testing.T) {
+	_, ticket, psk := creds(t)
+	_, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleOutboundOptions{
+			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
+			Ticket:        ticket, PSK: psk, CoverSNI: "www.microsoft.com",
+			HelloPool: testPool(t),
+		})
+	if err == nil {
+		t.Fatal("outbound accepted a credential with the wrong ticket length for its cover")
 	}
 }
 
@@ -443,6 +482,150 @@ func TestPeekConnReplayIsFaithful(t *testing.T) {
 	n, _ := pc.Read(buf)
 	if got := pc.replay(); string(got) != string(want[:n]) {
 		t.Errorf("replay is %q, want %q", got, want[:n])
+	}
+}
+
+func TestAcceptStreamsReportsSessionError(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	serverSession, err := yamux.Server(serverConn, muxConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientSession, err := yamux.Client(clientConn, muxConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	closed := make(chan error, 1)
+	go (&Inbound{}).acceptStreams(context.Background(), serverSession, adapter.InboundContext{}, func(err error) {
+		closed <- err
+	})
+	if err := clientSession.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-closed:
+		if err == nil {
+			t.Fatal("session failure was reported as a clean close")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("session close callback did not run")
+	}
+}
+
+func TestDialRetriesAfterRemoteGoAway(t *testing.T) {
+	cover, err := tw.CoverFor("www.cloudflare.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := tw.NewTicketKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	credential, err := key.Issue(1, cover.TicketLen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	sessions := make(chan *yamux.Session, 2)
+	serverErr := make(chan error, 2)
+	replay := tw.NewReplayCache(8, time.Hour)
+	go func() {
+		for range 2 {
+			raw, err := listener.Accept()
+			if err != nil {
+				serverErr <- err
+				return
+			}
+			go func() {
+				conn, err := tw.Server(raw, tw.ServerConfig{
+					TicketKey: key, Cover: cover, Replay: replay,
+				})
+				if err != nil {
+					serverErr <- err
+					return
+				}
+				session, err := yamux.Server(conn, muxConfig())
+				if err != nil {
+					serverErr <- err
+					return
+				}
+				sessions <- session
+			}()
+		}
+	}()
+
+	host, portString, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleOutboundOptions{
+			ServerOptions: boxoption.ServerOptions{Server: host, ServerPort: uint16(port)},
+			Ticket:        base64.StdEncoding.EncodeToString(credential.Ticket),
+			PSK:           hex.EncodeToString(credential.PSK[:]),
+			CoverSNI:      cover.Host,
+			HelloPool:     testPool(t),
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outbound := created.(*Outbound)
+	defer outbound.Close()
+
+	first, err := outbound.DialContext(context.Background(), "tcp", M.ParseSocksaddr("example.com:443"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstServerSession := <-sessions
+	defer firstServerSession.Close()
+	firstServerStream, err := firstServerSession.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readDestination(firstServerStream); err != nil {
+		t.Fatal(err)
+	}
+	first.Close()
+	firstServerStream.Close()
+
+	if err := firstServerSession.GoAway(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := outbound.sess.Ping(); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := outbound.DialContext(context.Background(), "tcp", M.ParseSocksaddr("example.org:443"))
+	if err != nil {
+		t.Fatalf("dial did not replace the GO_AWAY session: %v", err)
+	}
+	defer second.Close()
+	secondServerSession := <-sessions
+	defer secondServerSession.Close()
+	secondServerStream, err := secondServerSession.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer secondServerStream.Close()
+	if got, err := readDestination(secondServerStream); err != nil {
+		t.Fatal(err)
+	} else if got != "example.org:443" {
+		t.Fatalf("retried destination is %q", got)
+	}
+
+	select {
+	case err := <-serverErr:
+		t.Fatal(err)
+	default:
 	}
 }
 

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -50,11 +50,21 @@ func (r *echoRouter) RoutePacketConnection(ctx context.Context, conn N.PacketCon
 	return nil
 }
 
+// onClose is optional in the sing-box contract -- the real router funnels it
+// through N.CloseOnHandshakeFailure, which tolerates nil -- and routeStream
+// passes nil because a stream has no per-stream close bookkeeping to do. A test
+// double that calls it unconditionally turns that into a panic.
+func closeHandled(onClose N.CloseHandlerFunc, err error) {
+	if onClose != nil {
+		onClose(err)
+	}
+}
+
 func (r *echoRouter) RouteConnectionEx(_ context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
 	r.routed <- metadata
 	_, err := io.Copy(conn, conn)
 	conn.Close()
-	onClose(err)
+	closeHandled(onClose, err)
 }
 
 func (r *echoRouter) RoutePacketConnectionEx(_ context.Context, conn N.PacketConn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
@@ -69,7 +79,7 @@ func (r *echoRouter) RoutePacketConnectionEx(_ context.Context, conn N.PacketCon
 		}
 		packet.Release()
 		if err != nil {
-			onClose(err)
+			closeHandled(onClose, err)
 			return
 		}
 	}
@@ -91,6 +101,13 @@ func TestOutboundRoutesTCPAndUDP(t *testing.T) {
 			require.NoError(t, err)
 			t.Cleanup(func() { listener.Close() })
 			finished := make(chan struct{})
+			// serving holds the tunnel open for the body of the test. Under
+			// muxing NewConnectionEx hands the session to a goroutine and
+			// returns at once, so a bare `defer conn.Close()` would tear the
+			// tunnel down before the client could open a stream on it -- and a
+			// deadline on conn would now bound the whole session rather than
+			// one connection.
+			serving := make(chan struct{})
 			go func() {
 				defer close(finished)
 				conn, err := listener.Accept()
@@ -98,10 +115,11 @@ func TestOutboundRoutesTCPAndUDP(t *testing.T) {
 					return
 				}
 				defer conn.Close()
-				conn.SetDeadline(time.Now().Add(10 * time.Second))
 				ib.(*Inbound).NewConnectionEx(ctx, conn, adapter.InboundContext{}, func(error) {})
+				<-serving
 			}()
 			t.Cleanup(func() {
+				close(serving)
 				listener.Close()
 				select {
 				case <-finished:

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -580,21 +580,27 @@ func TestDialRetriesAfterRemoteGoAway(t *testing.T) {
 				serverErr <- err
 				return
 			}
-			go func() {
+			// raw is passed rather than captured: it is already per-iteration,
+			// but a parameter leaves nothing to re-derive. Closing is only on
+			// the failure paths -- on success the session owns the conn, and
+			// closing here would tear down the tunnel the test is about to use.
+			go func(raw net.Conn) {
 				conn, err := tw.Server(raw, tw.ServerConfig{
 					TicketKey: key, Cover: cover, Replay: replay,
 				})
 				if err != nil {
+					raw.Close()
 					serverErr <- err
 					return
 				}
 				session, err := yamux.Server(conn, muxConfig())
 				if err != nil {
+					conn.Close()
 					serverErr <- err
 					return
 				}
 				sessions <- session
-			}()
+			}(raw)
 		}
 	}()
 

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"io"
 	"net"
 	"os"
@@ -485,7 +486,10 @@ func TestPeekConnReplayIsFaithful(t *testing.T) {
 	}
 }
 
-func TestAcceptStreamsReportsSessionError(t *testing.T) {
+// A peer hanging up is not a fault. onClose feeds failure telemetry and the
+// autoselect health scoring, so reporting an ordinary teardown as an error
+// would demote a working outbound every time a client disconnects.
+func TestAcceptStreamsReportsACleanCloseAsClean(t *testing.T) {
 	serverConn, clientConn := net.Pipe()
 	serverSession, err := yamux.Server(serverConn, muxConfig())
 	if err != nil {
@@ -504,13 +508,46 @@ func TestAcceptStreamsReportsSessionError(t *testing.T) {
 	}
 	select {
 	case err := <-closed:
-		if err == nil {
-			t.Fatal("session failure was reported as a clean close")
+		if err != nil {
+			t.Fatalf("ordinary teardown reported as a failure: %v", err)
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("session close callback did not run")
 	}
 }
+
+// The other half of the same contract: a genuine transport fault still has to
+// reach onClose, or a broken tunnel looks exactly like a client going away.
+func TestAcceptStreamsReportsARealFault(t *testing.T) {
+	boom := errors.New("transport exploded")
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+	serverSession, err := yamux.Server(&faultyConn{Conn: serverConn, readErr: boom}, muxConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	closed := make(chan error, 1)
+	go (&Inbound{}).acceptStreams(context.Background(), serverSession, adapter.InboundContext{}, func(err error) {
+		closed <- err
+	})
+	select {
+	case err := <-closed:
+		if !errors.Is(err, boom) {
+			t.Fatalf("real fault reported as %v, want %v", err, boom)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("session close callback did not run")
+	}
+}
+
+// faultyConn fails every read with a error that is neither EOF nor a closed
+// socket, so it exercises the branch acceptEndError must NOT swallow.
+type faultyConn struct {
+	net.Conn
+	readErr error
+}
+
+func (c *faultyConn) Read([]byte) (int, error) { return 0, c.readErr }
 
 func TestDialRetriesAfterRemoteGoAway(t *testing.T) {
 	cover, err := tw.CoverFor("www.cloudflare.com")

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -1085,3 +1085,59 @@ func TestGoAwayLeavesLiveStreamsAlone(t *testing.T) {
 		t.Fatalf("bystander carried %q, want %q", got, want)
 	}
 }
+
+// A stream that opens and never names a destination must be dropped rather than
+// held. Mux is what makes this worth bounding: the peer pays once for the
+// connection and the egress pays per stream, so an unbounded prologue is a
+// goroutine faucet for anyone holding a valid credential.
+func TestSilentStreamIsDroppedNotHeld(t *testing.T) {
+	prev := destinationReadTimeout
+	destinationReadTimeout = 150 * time.Millisecond
+	t.Cleanup(func() { destinationReadTimeout = prev })
+
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+	serverSession, err := yamux.Server(serverConn, muxConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverSession.Close()
+	clientSession, err := yamux.Client(clientConn, muxConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientSession.Close()
+
+	ib := &Inbound{logger: log.NewNOPFactory().Logger()}
+	go ib.acceptStreams(context.Background(), serverSession, adapter.InboundContext{}, func(error) {})
+
+	stream, err := clientSession.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+
+	// Say nothing. The egress must give up and close the stream on its own.
+	//
+	// The assertion is on ELAPSED TIME, not on the error: yamux returns its own
+	// timeout rather than os.ErrDeadlineExceeded, so an error-kind check passes
+	// whether the egress dropped the stream or the client's own deadline
+	// expired -- which is to say it would pass with no prologue deadline at all.
+	// Timing separates them: a dropped stream returns in about
+	// destinationReadTimeout, a held one only when the client gives up.
+	const clientPatience = 3 * time.Second
+	if err := stream.SetReadDeadline(time.Now().Add(clientPatience)); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 1)
+	start := time.Now()
+	_, err = stream.Read(buf)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("a silent stream was answered rather than dropped")
+	}
+	if elapsed > clientPatience/3 {
+		t.Fatalf("the egress held a silent stream for %v; the %v prologue deadline did not fire",
+			elapsed, destinationReadTimeout)
+	}
+}

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -533,7 +533,9 @@ func TestDialRetriesAfterRemoteGoAway(t *testing.T) {
 
 	sessions := make(chan *yamux.Session, 2)
 	serverErr := make(chan error, 2)
-	replay := tw.NewReplayCache(8, time.Hour)
+	// The horizon must be at least the server's MaxAge, which is unset here and
+	// so defaults to 24h; a shorter one is refused outright by tw.Server.
+	replay := tw.NewReplayCache(8, 0)
 	go func() {
 		for range 2 {
 			raw, err := listener.Accept()

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -300,15 +300,22 @@ func testPool(t *testing.T) string {
 	return tw.FormatPool(p.Hellos)
 }
 
-func TestOutboundRejectsMissingPool(t *testing.T) {
+func TestOutboundUsesTheEmbeddedPoolByDefault(t *testing.T) {
 	_, ticket, psk := creds(t)
-	_, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+	ob, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
 		option.TwiddleOutboundOptions{
 			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
 			Ticket:        ticket, PSK: psk, CoverSNI: "www.cloudflare.com",
 		})
-	if err == nil {
-		t.Fatal("outbound accepted a missing hello pool; the embedded snapshot must not ship")
+	if err != nil {
+		t.Fatal(err)
+	}
+	o := ob.(*Outbound)
+	if len(o.cfg.Pool) == 0 {
+		t.Fatal("outbound has an empty hello pool")
+	}
+	if o.cfg.Cover.Host != "www.cloudflare.com" {
+		t.Errorf("cover is %q", o.cfg.Cover.Host)
 	}
 }
 
@@ -325,16 +332,35 @@ func TestOutboundRejectsUnknownCover(t *testing.T) {
 	}
 }
 
-func TestOutboundRejectsCorruptPool(t *testing.T) {
+// A corrupt configured pool must DEGRADE to the built-in one, not fail the
+// outbound.
+//
+// A pool arrives by config push, so a bad one reaches every client at once; the
+// two candidate failure modes are "every client emits a stale fingerprint" and
+// "every client has no outbound at all". The first risks detection,
+// probabilistically and recoverably; the second is a certain outage. Both are
+// fixed by pushing new config, so the interim state is the whole of the
+// difference, and staleness is the better interim state.
+//
+// The compensating requirement is that the degradation be visible, which is
+// what poolOrigin and the logged Skipped errors are for.
+func TestOutboundDegradesToEmbeddedOnACorruptPool(t *testing.T) {
 	_, ticket, psk := creds(t)
-	_, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+	ob, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
 		option.TwiddleOutboundOptions{
 			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
 			Ticket:        ticket, PSK: psk, CoverSNI: "www.cloudflare.com",
 			HelloPool: "not hex at all",
 		})
-	if err == nil {
-		t.Fatal("a corrupt pool must fail the outbound rather than emit the stale snapshot")
+	if err != nil {
+		t.Fatalf("a corrupt pool must not brick the outbound: %v", err)
+	}
+	o := ob.(*Outbound)
+	if o.poolOrigin != tw.OriginEmbedded {
+		t.Errorf("pool origin is %v, want embedded", o.poolOrigin)
+	}
+	if len(o.cfg.Pool) == 0 {
+		t.Error("degraded outbound has no hellos at all")
 	}
 }
 
@@ -859,8 +885,7 @@ func TestOutboundCarriesTheFullHandshakeCompanion(t *testing.T) {
 		option.TwiddleOutboundOptions{
 			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
 			Ticket:        ticket, FullTicket: fullTicket, PSK: psk,
-			CoverSNI:  "www.cloudflare.com",
-			HelloPool: testPool(t),
+			CoverSNI: "www.cloudflare.com",
 		})
 	if err != nil {
 		t.Fatal(err)
@@ -886,7 +911,6 @@ func TestOutboundWithoutAFullTicketIsResumptionOnly(t *testing.T) {
 		option.TwiddleOutboundOptions{
 			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
 			Ticket:        ticket, PSK: psk, CoverSNI: "www.cloudflare.com",
-			HelloPool: testPool(t),
 		})
 	if err != nil {
 		t.Fatalf("a config without full_ticket was rejected: %v", err)
@@ -918,7 +942,6 @@ func TestOutboundDisableFullHandshakeDropsTheContactMemory(t *testing.T) {
 			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
 			Ticket:        ticket, FullTicket: fullTicket, PSK: psk,
 			CoverSNI: "www.cloudflare.com", DisableFullHandshake: true,
-			HelloPool: testPool(t),
 		})
 	if err != nil {
 		t.Fatal(err)

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -853,7 +853,8 @@ func TestOutboundCarriesTheFullHandshakeCompanion(t *testing.T) {
 		option.TwiddleOutboundOptions{
 			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
 			Ticket:        ticket, FullTicket: fullTicket, PSK: psk,
-			CoverSNI: "www.cloudflare.com",
+			CoverSNI:  "www.cloudflare.com",
+			HelloPool: testPool(t),
 		})
 	if err != nil {
 		t.Fatal(err)
@@ -879,6 +880,7 @@ func TestOutboundWithoutAFullTicketIsResumptionOnly(t *testing.T) {
 		option.TwiddleOutboundOptions{
 			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
 			Ticket:        ticket, PSK: psk, CoverSNI: "www.cloudflare.com",
+			HelloPool: testPool(t),
 		})
 	if err != nil {
 		t.Fatalf("a config without full_ticket was rejected: %v", err)
@@ -910,6 +912,7 @@ func TestOutboundDisableFullHandshakeDropsTheContactMemory(t *testing.T) {
 			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
 			Ticket:        ticket, FullTicket: fullTicket, PSK: psk,
 			CoverSNI: "www.cloudflare.com", DisableFullHandshake: true,
+			HelloPool: testPool(t),
 		})
 	if err != nil {
 		t.Fatal(err)

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -806,13 +806,14 @@ func TestConcurrentDialsShareOneMuxedTunnel(t *testing.T) {
 	if ok == 0 {
 		t.Fatal("no dial completed")
 	}
-	if atomic.LoadInt64(&tunnels) != 1 {
-		t.Errorf("opened %d outer tunnels, want 1 muxed session", tunnels)
+	openedTunnels := atomic.LoadInt64(&tunnels)
+	if openedTunnels != 1 {
+		t.Errorf("opened %d outer tunnels, want 1 muxed session", openedTunnels)
 	}
 	if ok < n {
 		t.Errorf("%d/%d dials completed", ok, n)
 	}
-	t.Logf("%d/%d dials on %d tunnel, %d streams served", ok, n, tunnels, atomic.LoadInt64(&served))
+	t.Logf("%d/%d dials on %d tunnel, %d streams served", ok, n, openedTunnels, atomic.LoadInt64(&served))
 }
 
 // TestCredentialPoolHandsOutDistinctCredentials: sequential connections must
@@ -1157,5 +1158,62 @@ func TestSilentStreamIsDroppedNotHeld(t *testing.T) {
 	if elapsed > clientPatience/3 {
 		t.Fatalf("the egress held a silent stream for %v; the %v prologue deadline did not fire",
 			elapsed, destinationReadTimeout)
+	}
+}
+
+// A dial arriving after Close must not build a new tunnel.
+//
+// Close nils the cached session, which is exactly what ensureSession reads as
+// "no tunnel yet" -- so without a closed flag the outbound quietly resurrects
+// itself and holds a connection nothing will ever close.
+func TestDialAfterCloseDoesNotResurrectTheOutbound(t *testing.T) {
+	_, ticket, psk := creds(t)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	var accepted int64
+	go func() {
+		for {
+			c, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			atomic.AddInt64(&accepted, 1)
+			c.Close()
+		}
+	}()
+
+	host, portString, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleOutboundOptions{
+			ServerOptions: boxoption.ServerOptions{Server: host, ServerPort: uint16(port)},
+			Ticket:        ticket, PSK: psk, CoverSNI: "www.cloudflare.com",
+			HelloPool: testPool(t),
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := created.(*Outbound)
+	if err := out.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := out.DialContext(context.Background(), "tcp", M.ParseSocksaddr("example.com:443")); err == nil {
+		t.Fatal("a dial after Close built a new tunnel")
+	} else if !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("dial after Close reported %v, want net.ErrClosed", err)
+	}
+	if n := atomic.LoadInt64(&accepted); n != 0 {
+		t.Errorf("a closed outbound opened %d connections", n)
 	}
 }

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -1161,6 +1161,127 @@ func TestSilentStreamIsDroppedNotHeld(t *testing.T) {
 	}
 }
 
+// Close must tear down sessions left draining after a GO_AWAY, not just the
+// cached one. Retiring without closing is right while the process runs -- live
+// streams finish -- but at shutdown "let the peer finish" stops being the trade
+// we want, and a drained session is unreferenced so nothing else can reach it.
+func TestCloseTearsDownDrainingSessions(t *testing.T) {
+	cover, err := tw.CoverFor("www.cloudflare.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := tw.NewTicketKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	credential, err := key.Issue(1, cover.TicketLen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	sessions := make(chan *yamux.Session, 2)
+	replay := tw.NewReplayCache(8, 0)
+	go func() {
+		for range 2 {
+			raw, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func(raw net.Conn) {
+				conn, err := tw.Server(raw, tw.ServerConfig{
+					TicketKey: key, Cover: cover, Replay: replay,
+				})
+				if err != nil {
+					raw.Close()
+					return
+				}
+				session, err := yamux.Server(conn, muxConfig())
+				if err != nil {
+					conn.Close()
+					return
+				}
+				sessions <- session
+			}(raw)
+		}
+	}()
+
+	host, portString, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleOutboundOptions{
+			ServerOptions: boxoption.ServerOptions{Server: host, ServerPort: uint16(port)},
+			Ticket:        base64.StdEncoding.EncodeToString(credential.Ticket),
+			PSK:           hex.EncodeToString(credential.PSK[:]),
+			CoverSNI:      cover.Host,
+			HelloPool:     testPool(t),
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := created.(*Outbound)
+
+	first, err := out.DialContext(context.Background(), "tcp", M.ParseSocksaddr("example.com:443"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	firstSession := <-sessions
+	defer firstSession.Close()
+	firstStream, err := firstSession.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer firstStream.Close()
+	if _, err := readDestination(firstStream); err != nil {
+		t.Fatal(err)
+	}
+
+	// GO_AWAY retires the client session without closing it, then a second dial
+	// replaces it -- so the first is now draining and unreferenced.
+	if err := firstSession.GoAway(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := out.sess.Ping(); err != nil {
+		t.Fatal(err)
+	}
+	drained := out.sess
+	second, err := out.DialContext(context.Background(), "tcp", M.ParseSocksaddr("example.org:443"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+	secondSession := <-sessions
+	defer secondSession.Close()
+
+	out.sessMu.Lock()
+	tracked := len(out.draining)
+	out.sessMu.Unlock()
+	if tracked != 1 {
+		t.Fatalf("%d draining sessions tracked, want 1", tracked)
+	}
+	if drained.IsClosed() {
+		t.Fatal("the drained session was closed before shutdown")
+	}
+
+	if err := out.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !drained.IsClosed() {
+		t.Fatal("Close left a draining session open")
+	}
+}
+
 // A dial arriving after Close must not build a new tunnel.
 //
 // Close nils the cached session, which is exactly what ensureSession reads as


### PR DESCRIPTION
Rebased onto `main` and reopened. Its parent (#315) merged on 2026-09-04, and deleting that base branch auto-closed this PR one second before GitHub's retarget-to-`main` landed — the close was collateral, not a decision. The five commits were intact on `fisk/twiddle-hardening` throughout.

Now tracking [`getlantern/twiddle`](https://github.com/getlantern/twiddle) `main` at [`c78665a`](https://github.com/getlantern/twiddle/commit/c78665a55653bbd217560a7d9116cf7e3eb396c5), which includes the record-emission fix below.

## Codex P1s

- [x] **The synthetic opening flight has the wrong size.** → [twiddle#1](https://github.com/getlantern/twiddle/pull/1), merged.
- [x] **Captured ClientHellos are replayable identification tokens.** `tw.Server` requires a shared `ReplayCache`, and the egress holds one. The core gate keys on the **client**, not the ticket: credentials rotate every connection, so a client's newest ticket retires all its earlier ones. That makes forgetting safe and the state `O(clients in horizon)` rather than `O(connections)`.
- [x] **Cover profiles are incomplete.** → landed in **#315**, because the merged core deleted the `TicketLen`/`PSKFirst`/`CoverSNI` fields that PR was built against. What remains here is the *agreement* check: where `masquerade_upstream` is a DNS name, a `cover_host` contradicting it is refused; an explicit cover is reserved for an upstream given as an IP.
- [ ] **SNI/IP inconsistency makes DPI unnecessary.** → [lantern-cloud#3292](https://github.com/getlantern/lantern-cloud/pull/3292)
- [x] **There is no multiplexing.** Every inner destination created a new outer TCP/Twiddle connection, exposing encapsulated inner TLS handshakes. Mux is mandatory per the project's own design (USENIX Security 2024: nested TLS is detectable even through padding). One long-lived yamux session now carries N inner destinations.
- [x] **The fresh-hello path is not operational.** The core made the embedded pool opt-in (`Sources.AllowEmbedded`); this outbound leaves it off and fails closed, so autoselect can pick another transport. **This is the one place this PR reverses `main`** — #315 opts in, arguing a stale fingerprint beats no outbound. That holds only while no device tap exists; once one does, failing closed is strictly better because there is somewhere else to go.
- [x] **Concurrent openings reuse tickets.** The credential pool retained and reused its last ticket, so a cold parallel burst exposed identical PSK identities across connections with unrelated randomized ticket ages. Tickets are consumed, never reused; concurrent dials share the mux session instead.

## Multiplexing

```mermaid
sequenceDiagram
    autonumber
    participant A as DialContext<br/>outbound.go
    participant O as ensureSession<br/>outbound.go
    participant E as egress<br/>inbound.go

    A->>O: ensureSession under sessMu
    Note over O: takeCredential — consumed, never reused ⚠️
    O->>E: one outer Twiddle plus yamux
    A->>O: later DialContext for another inner dest
    Note over O: reuse the warm yamux session
    A->>E: stream plus destination
    Note over E: acceptStreams — was one TCP per dest 🐛
```

## The core race this PR surfaced is now fixed

Giving one `twiddle.Conn` a yamux `sendLoop` goroutine alongside a `recv` goroutine that closes the session made `Conn.Write` overlap `Conn.Close`. Both reached `writeRecord`, which sealed with the current `sendSeq` and incremented afterwards, unsynchronised — the sequence number *is* the AEAD nonce, so that was nonce reuse under one key rather than a decrypt failure. Fixed in [twiddle#2](https://github.com/getlantern/twiddle/pull/2) and pinned here.

Verified end to end: the two mux tests reproduced a data race **2 times in 12** on the previous pin and **0 in 12** on this one.

## Rebase notes

`#320` (full-handshake carrier) landed while this was closed. It added three outbound tests that construct a client with **no** hello source, which `main` permits because the embedded snapshot is enabled there. This branch turns that off, so those three now hit the refusal and are given the same file-backed pool the branch's own tests use — what they assert is unchanged.

Worth a reviewer's eye rather than mine: `#320`'s `ContactMemory` chooses the opening shape **per connection** (full on first contact, resumed after). Mux changes how often that decision is taken, since there is now one long-lived outer connection instead of one per inner destination. Nothing fails, and arguably a single long-lived connection is *more* browser-like than N short ones — but the intended opening distribution is a design question the two PRs jointly determine.

## Testing

`go build ./...`, `go vet ./...`, `go test ./...` clean. `go test -race ./protocol/twiddle/` clean, including 12 runs of the two mux tests.

E2E uses `www.cloudflare.com` (a measured cover) and a file-backed hello pool, since the embedded fallback is off on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gn6KuHUL766qQNn8m1fu1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multiple connections can now share a single secure tunnel, improving efficiency for concurrent TCP and UDP traffic.
  * Connections recover more reliably after remote tunnel shutdowns.

* **Bug Fixes**
  * Clean tunnel closures are handled gracefully while genuine connection failures are reported correctly.
  * Inactive connections are closed after a timeout instead of remaining open indefinitely.
  * Invalid cover host configurations are now rejected.
  * Closed tunnels no longer accept new connection attempts.

* **Documentation**
  * Clarified requirements for cover hosts and cover SNI settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->