### PR TITLE
twiddle: take the full-handshake carrier, and choose the opening per connection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395
 	github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb
-	github.com/getlantern/twiddle v0.0.0-20260903233256-43f3d2d3b625
+	github.com/getlantern/twiddle v0.0.0-20260904230617-6b9909c5c8d9
 	github.com/gobwas/ws v1.4.0
 	github.com/pion/transport/v4 v4.0.1
 	github.com/refraction-networking/water v0.7.1-alpha

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/getlantern/sing-box-minimal v1.13.19-lantern h1:dwVCskH9N3Q5a2wVELdyG
 github.com/getlantern/sing-box-minimal v1.13.19-lantern/go.mod h1:4E8WvF7Vi60N1NtPw1CeG994J/yiJZZkty5dKKwG+V0=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5 h1:6ITBYqNkLbVZ1tQNXwmH8N80rZtvyW6IZa8L6EAhBQo=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5/go.mod h1:gx3dPUhZtQszPX5C+TshhxPXQHlY5t4gMnOOMA+viPA=
-github.com/getlantern/twiddle v0.0.0-20260903233256-43f3d2d3b625 h1:Q0yR4Upu295nNEInvs8eikg4c2rSxWNXwH2I70ZeO5E=
-github.com/getlantern/twiddle v0.0.0-20260903233256-43f3d2d3b625/go.mod h1:aU9c2/kcZhCxXCOZMN/Vulc+baDNHecqlvgLXOIeyOY=
+github.com/getlantern/twiddle v0.0.0-20260904230617-6b9909c5c8d9 h1:dQJXsvNVHweJLaQ3QbBapDk6+fU41s0F3T0Alrf+0Sk=
+github.com/getlantern/twiddle v0.0.0-20260904230617-6b9909c5c8d9/go.mod h1:aU9c2/kcZhCxXCOZMN/Vulc+baDNHecqlvgLXOIeyOY=
 github.com/getlantern/water v0.7.1-alpha.0.20260309190745-bd547c14b4aa h1:goZee1cURbWPiqX1xyjfwLB/zByQ50hEwonnnyLmcJQ=
 github.com/getlantern/water v0.7.1-alpha.0.20260309190745-bd547c14b4aa/go.mod h1:Yo6Yk++Q9HRaCT+6/eYk3elNoNtjlJ3V5FufHY6ezto=
 github.com/getlantern/wazero v1.11.0-water.1 h1:mzUlaOoQKMDd16yL3mBIFrzg2nEK+gw7mdQgff1nOPQ=

--- a/option/twiddle.go
+++ b/option/twiddle.go
@@ -51,7 +51,8 @@ type TwiddleOutboundOptions struct {
 	// docs/full-handshake-carrier.md.
 	//
 	// Optional, and absence degrades rather than fails, because provisioning
-	// gained this field after clients were already deployed with the two above.
+	// gained this field after clients were already deployed with ticket and psk
+	// alone.
 	FullTicket string `json:"full_ticket,omitempty"`
 
 	// PSK is the pre-shared key paired with Ticket, 32 bytes hex-encoded. The

--- a/option/twiddle.go
+++ b/option/twiddle.go
@@ -42,7 +42,20 @@ type TwiddleOutboundOptions struct {
 	// one the egress issues in each connection's flight.
 	Ticket string `json:"ticket"`
 
-	// PSK is the pre-shared key paired with Ticket, 32 bytes hex-encoded.
+	// FullTicket is the full-handshake companion to Ticket, base64, minted over
+	// the same client and psk at the same instant.
+	//
+	// Without it this client is RESUMPTION-ONLY: every opening it emits carries
+	// pre_shared_key, and only about 4% of real browsing connections do, so it
+	// sits permanently in a rare bucket. See the twiddle module's
+	// docs/full-handshake-carrier.md.
+	//
+	// Optional, and absence degrades rather than fails, because provisioning
+	// gained this field after clients were already deployed with the two above.
+	FullTicket string `json:"full_ticket,omitempty"`
+
+	// PSK is the pre-shared key paired with Ticket, 32 bytes hex-encoded. The
+	// same psk backs FullTicket.
 	PSK string `json:"psk"`
 
 	// CoverSNI is the domain this egress masquerades as. It must be a measured
@@ -76,6 +89,16 @@ type TwiddleOutboundOptions struct {
 	// first. A tapped hello names a site the user actually visited, and a
 	// resumption hello also carries that site's session ticket.
 	HelloPoolDevicePath string `json:"hello_pool_device_path,omitempty"`
+
+	// DisableFullHandshake turns off the full-handshake opening even when
+	// everything needed for it is present.
+	//
+	// It exists as a kill switch that costs no release. The opening shape is
+	// the most censor-visible thing this transport does, and if a full-handshake
+	// opening ever turns out to be the more detectable of the two in some
+	// region, the reaction should be a config push rather than a rebuild --
+	// the same reasoning that keeps the hello pool as data.
+	DisableFullHandshake bool `json:"disable_full_handshake,omitempty"`
 
 	ConnectTimeout string `json:"connect_timeout,omitempty"`
 }

--- a/protocol/twiddle/outbound.go
+++ b/protocol/twiddle/outbound.go
@@ -73,7 +73,16 @@ func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogge
 	if err != nil {
 		return nil, fmt.Errorf("twiddle: bad psk: %w", err)
 	}
-	cred, err := tw.CredentialFromWire(ticket, psk)
+	// Optional: provisioning gained full_ticket after clients were already
+	// deployed with ticket and psk alone, and a nil companion degrades to
+	// resumption-only rather than failing.
+	var fullTicket []byte
+	if options.FullTicket != "" {
+		if fullTicket, err = base64.StdEncoding.DecodeString(options.FullTicket); err != nil {
+			return nil, fmt.Errorf("twiddle: bad full_ticket: %w", err)
+		}
+	}
+	cred, err := tw.CredentialFromWireFull(ticket, fullTicket, psk)
 	if err != nil {
 		return nil, err
 	}
@@ -130,6 +139,22 @@ func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogge
 		return nil, err
 	}
 
+	// The contact memory decides the opening shape per connection: full on
+	// first contact with an egress, resumed afterwards, full again once a
+	// censor can no longer be assumed to remember. Nil disables it entirely and
+	// restores resumption-only behaviour.
+	//
+	// Safe to enable before anything else is ready. It degrades to resumption
+	// unless ALL THREE of a probed full profile, a pool hello whose ECH payload
+	// can carry the ticket, and a companion ticket are present -- and the cover
+	// table ships no full profile at all, so today it always degrades. That is
+	// deliberate: when per-egress probing and full_ticket provisioning land, the
+	// path activates without another lantern-box release.
+	var contacts *tw.ContactMemory
+	if !options.DisableFullHandshake {
+		contacts = tw.NewContactMemory(0, 0)
+	}
+
 	return &Outbound{
 		Adapter:    outbound.NewAdapterWithDialerOptions(constant.TypeTwiddle, tag, []string{N.NetworkTCP}, options.DialerOptions),
 		logger:     lg,
@@ -140,9 +165,10 @@ func NewOutbound(ctx context.Context, router adapter.Router, lg log.ContextLogge
 		creds:      []*tw.Credential{cred},
 		poolOrigin: pool.Origin,
 		cfg: tw.ClientConfig{
-			Pool:   pool.Hellos,
-			Cover:  cover,
-			Shaper: tw.BrowsingShaper(false),
+			Pool:     pool.Hellos,
+			Cover:    cover,
+			Shaper:   tw.BrowsingShaper(false),
+			Contacts: contacts,
 		},
 	}, nil
 }

--- a/protocol/twiddle/twiddle_test.go
+++ b/protocol/twiddle/twiddle_test.go
@@ -518,3 +518,98 @@ func TestCoverProfileReachesServerConfig(t *testing.T) {
 		t.Errorf("google profile not applied: %+v", got)
 	}
 }
+
+// fullCreds returns a provisioned credential including the full-handshake
+// companion, as lantern-cloud will emit once it provisions full_ticket.
+func fullCreds(t *testing.T) (ticketB64, fullTicketB64, pskHex string) {
+	t.Helper()
+	k, err := tw.NewTicketKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := k.Issue(1, tw.DefaultTicketLen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c.FullTicket) != tw.FullTicketLen {
+		t.Fatalf("issued credential has a %d-byte companion, want %d", len(c.FullTicket), tw.FullTicketLen)
+	}
+	return base64.StdEncoding.EncodeToString(c.Ticket),
+		base64.StdEncoding.EncodeToString(c.FullTicket),
+		hex.EncodeToString(c.PSK[:])
+}
+
+// full_ticket has to survive the config round trip into the credential. If it
+// silently did not, the client would be resumption-only and nothing would say
+// so -- the failure is invisible, because resumption-only still works.
+func TestOutboundCarriesTheFullHandshakeCompanion(t *testing.T) {
+	ticket, fullTicket, psk := fullCreds(t)
+	ob, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleOutboundOptions{
+			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
+			Ticket:        ticket, FullTicket: fullTicket, PSK: psk,
+			CoverSNI: "www.cloudflare.com",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	o := ob.(*Outbound)
+	if len(o.creds) != 1 {
+		t.Fatalf("outbound holds %d credentials, want 1", len(o.creds))
+	}
+	if got := len(o.creds[0].FullTicket); got != tw.FullTicketLen {
+		t.Errorf("credential carries a %d-byte companion, want %d; the client would be resumption-only",
+			got, tw.FullTicketLen)
+	}
+	if o.cfg.Contacts == nil {
+		t.Error("no contact memory, so every opening would be a resumption")
+	}
+}
+
+// Provisioning gained full_ticket after clients were deployed with ticket and
+// psk alone, so its absence must degrade rather than fail.
+func TestOutboundWithoutAFullTicketIsResumptionOnly(t *testing.T) {
+	_, ticket, psk := creds(t)
+	ob, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleOutboundOptions{
+			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
+			Ticket:        ticket, PSK: psk, CoverSNI: "www.cloudflare.com",
+		})
+	if err != nil {
+		t.Fatalf("a config without full_ticket was rejected: %v", err)
+	}
+	if o := ob.(*Outbound); o.creds[0].FullTicket != nil {
+		t.Error("a companion ticket appeared from nowhere")
+	}
+}
+
+func TestOutboundRejectsABadFullTicket(t *testing.T) {
+	_, ticket, psk := creds(t)
+	for _, bad := range []string{"not base64!!", base64.StdEncoding.EncodeToString([]byte("short"))} {
+		_, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+			option.TwiddleOutboundOptions{
+				ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
+				Ticket:        ticket, FullTicket: bad, PSK: psk, CoverSNI: "www.cloudflare.com",
+			})
+		if err == nil {
+			t.Errorf("outbound accepted a bad full_ticket %q", bad)
+		}
+	}
+}
+
+// The kill switch has to actually reach the client config, or it is decoration.
+func TestOutboundDisableFullHandshakeDropsTheContactMemory(t *testing.T) {
+	ticket, fullTicket, psk := fullCreds(t)
+	ob, err := NewOutbound(context.Background(), nil, log.NewNOPFactory().Logger(), "t",
+		option.TwiddleOutboundOptions{
+			ServerOptions: boxoption.ServerOptions{Server: "127.0.0.1", ServerPort: 443},
+			Ticket:        ticket, FullTicket: fullTicket, PSK: psk,
+			CoverSNI: "www.cloudflare.com", DisableFullHandshake: true,
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o := ob.(*Outbound); o.cfg.Contacts != nil {
+		t.Error("disable_full_handshake left the contact memory in place")
+	}
+}


### PR DESCRIPTION
## Why

`v0.0.122` pinned twiddle at `43f3d2d` — main *before* the full-handshake carrier landed — so the released binary can only emit resumption hellos. This bumps to `6b9909c` (getlantern/twiddle#3) and wires up what that merge added.

Every opening twiddle emits today carries `pre_shared_key`. Only ~4% of real browsing connections do:

| capture | connections | resumed | share |
|---|---|---|---|
| 16 pages, 6 revisits | 636 | 26 | **4.1%** |
| cold, per-process | 485 | 13 | **2.7%** |

So the transport sits permanently in a rare bucket — a censor filtering on `pre_shared_key` shrinks its candidate set ~25× for free. And the sharper form: a resumption to an address the client was never seen completing a full handshake with is structurally impossible in real TLS.

## What this adds

- **`full_ticket`** — the provisioned companion to `ticket`, sealed over the same client and psk at the same instant. Without it a client is resumption-only. **Optional**, because provisioning gained the field after clients were already deployed with `ticket` and `psk` alone, so its absence degrades rather than fails.
- **A `ContactMemory`** deciding the shape per connection: full on first contact with an egress, resumed afterwards, full again past a horizon beyond which a censor can no longer be assumed to remember.
- **`disable_full_handshake`** — a kill switch that costs no release.

## This changes no behaviour yet, deliberately

The contact memory degrades to resumption unless **all three** of a probed full profile, a pool hello whose ECH payload can carry the ticket, and a companion ticket are present. The cover table ships no full profile at all, so today it always degrades.

That is the point: when per-egress probing and `full_ticket` provisioning land, the path activates **without another lantern-box release**.

## The kill switch

The opening shape is the most censor-visible thing this transport does. If the full-handshake opening ever turns out to be the more detectable of the two in some region, the reaction should be a config push rather than a rebuild — the same reasoning that keeps the hello pool as data rather than compiling it in.

## Testing

Four new tests, and the two that matter were mutation-tested, because both failures are otherwise invisible — a resumption-only client still works, and a kill switch that does nothing looks identical to one that was never used:

- decoding `full_ticket` and then dropping it → fails `TestOutboundCarriesTheFullHandshakeCompanion`
- ignoring `disable_full_handshake` → fails `TestOutboundDisableFullHandshakeDropsTheContactMemory`

Built with the e2e job's full tag set. `go mod tidy` run, with `go.mod` and `go.sum` in the same commit as the bump.

## Not in this PR

Per-egress startup probing to fill `FullRemainder`, which is what actually activates the path. Note it cannot be inherited or shipped in config: probing from two vantage points on the same day, google served a `[2619]` certificate flight to a laptop and `[3921]` to a GitHub runner, while cloudflare and microsoft agreed at both. Each egress must probe the cover it impersonates itself.

lantern-cloud#3291 must also emit `full_ticket` alongside `ticket` and `psk`, or provisioned clients stay resumption-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Twiddle outbound connections now support optional full-handshake tickets.
  - Added an option to disable full-handshake support when needed.
  - Connections without a full-handshake ticket continue in resumption-only mode.
  - Contact memory is used automatically to support full-handshake connections when enabled.

- **Bug Fixes**
  - Malformed full-handshake tickets are now rejected with validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->