### PR TITLE
meek: a broken upstream is not an end of stream

### DIFF
--- a/protocol/meek/client.go
+++ b/protocol/meek/client.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -48,8 +49,12 @@ const (
 	// bytes — see roundtrip / the server's seq handling.
 	defaultMaxPollRetries = 4
 	retryBaseBackoff      = 250 * time.Millisecond
-	headerSeq             = "X-Meek-Seq"
-	headerMaxBody         = "X-Meek-Max-Body"
+	// statusReasonCap bounds how much of a non-200 body is quoted back in the
+	// error. The server's reasons are a few words; anything longer is a peer
+	// being unhelpful, and is not worth carrying into a log line.
+	statusReasonCap = 256
+	headerSeq       = "X-Meek-Seq"
+	headerMaxBody   = "X-Meek-Max-Body"
 )
 
 // Config is the runtime configuration for a meek Conn.
@@ -428,6 +433,18 @@ func (c *Conn) roundtrip() error {
 		// Read surfaces a proper end-of-stream.
 		if resp.StatusCode == http.StatusGone {
 			return &permanentError{io.EOF}
+		}
+		// Carry the server's reason. Every non-200 path writes a short fixed
+		// string, and without it the two 502s -- a failed upstream read and a
+		// failed upstream write -- are indistinguishable to anyone reading a log,
+		// which is most of the value of separating them in the first place.
+		//
+		// Bounded and quoted: it is remote input, so it is capped at
+		// statusReasonCap bytes and rendered with %q rather than pasted into the
+		// message raw.
+		reason, _ := io.ReadAll(io.LimitReader(resp.Body, statusReasonCap))
+		if detail := strings.TrimSpace(string(reason)); detail != "" {
+			return &permanentError{fmt.Errorf("meek: status %d: %q", resp.StatusCode, detail)}
 		}
 		return &permanentError{fmt.Errorf("meek: status %d", resp.StatusCode)}
 	}

--- a/protocol/meek/retry_integrity_test.go
+++ b/protocol/meek/retry_integrity_test.go
@@ -260,3 +260,51 @@ func TestBrokenUpstreamIsNotReportedAsCleanEOF(t *testing.T) {
 		t.Fatalf("got %v, want it to wrap both errUpstreamBroken and the read failure", err)
 	}
 }
+
+// The two 502 paths must be distinguishable to whoever reads the log.
+//
+// Separating a failed upstream READ from a failed upstream WRITE is only worth
+// anything if the difference survives to the caller. Both are 502, so without
+// the server's reason the distinction dies at the status line -- which is
+// exactly the position we were in when a CI failure said only "meek: status
+// 502" and could have been either.
+func TestClientCarriesTheServerReason(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		reason string
+	}{
+		{"broken read", "upstream failed"},
+		{"failed write", "upstream write"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, tc.reason, http.StatusBadGateway)
+			}))
+			defer hs.Close()
+
+			conn, err := Dial(context.Background(), Config{
+				URL: hs.URL, InnerHost: "test", HTTPClient: hs.Client(),
+				PollInterval: 5 * time.Millisecond,
+			})
+			if err != nil {
+				// A 502 on the very first poll can fail the dial; that error must
+				// carry the reason too.
+				if !bytes.Contains([]byte(err.Error()), []byte(tc.reason)) {
+					t.Fatalf("dial error %q does not name the reason %q", err, tc.reason)
+				}
+				return
+			}
+			defer conn.Close()
+
+			buf := make([]byte, 1)
+			_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+			_, err = conn.Read(buf)
+			if err == nil {
+				t.Fatal("a 502 was not surfaced as an error")
+			}
+			if !bytes.Contains([]byte(err.Error()), []byte(tc.reason)) {
+				t.Fatalf("error %q does not name the reason %q; the two 502 paths are indistinguishable", err, tc.reason)
+			}
+		})
+	}
+}

--- a/protocol/meek/retry_integrity_test.go
+++ b/protocol/meek/retry_integrity_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -180,4 +182,81 @@ func TestMeekRetryUploadNoDuplication(t *testing.T) {
 		t.Fatal("test ineffective: no responses were dropped")
 	}
 	t.Logf("upload intact (exactly %d bytes) across %d dropped+retried responses", size, atomic.LoadInt64(&ft.dropped))
+}
+
+// brokenUpstream serves some bytes and then fails the read, which is what an
+// RST or an I/O error on the origin looks like to the session's read pump.
+type brokenUpstream struct {
+	net.Conn
+	remaining int
+	failure   error
+}
+
+func (c *brokenUpstream) Read(b []byte) (int, error) {
+	if c.remaining <= 0 {
+		return 0, c.failure
+	}
+	n := len(b)
+	if n > c.remaining {
+		n = c.remaining
+	}
+	for i := range b[:n] {
+		b[i] = 0x5a
+	}
+	c.remaining -= n
+	return n, nil
+}
+
+func (c *brokenUpstream) Write(b []byte) (int, error) { return len(b), nil }
+func (c *brokenUpstream) Close() error                { return nil }
+
+// A truncated download must not reach the caller as a clean end of stream.
+//
+// readPump ends on any upstream read error, and closing upstreamDone is what
+// the session reads as "closed with nothing left" -- so before this was split
+// out, a failed read became a 410, which the client maps to io.EOF. The caller
+// could not tell a finished transfer from a broken one, and the tail of the
+// byte stream vanished silently. Everything else in this package is careful
+// about exactly that (see the over-cap check in client.go), so it should be
+// careful here too.
+func TestBrokenUpstreamIsNotReportedAsCleanEOF(t *testing.T) {
+	const served = 4096
+	failure := errors.New("upstream exploded")
+
+	sess := &session{
+		id:           "t",
+		upstream:     &brokenUpstream{remaining: served, failure: failure},
+		readWakeCh:   make(chan struct{}, 1),
+		upstreamDone: make(chan struct{}),
+	}
+	sess.drainCond = sync.NewCond(&sess.mu)
+	go sess.readPump(1 << 20)
+
+	// Drain what the upstream did deliver.
+	var got int
+	for got < served {
+		resp, err := sess.serveRequest(true, uint64(got), nil, 1024, 20*time.Millisecond)
+		if err != nil {
+			t.Fatalf("failed while bytes were still buffered, at %d/%d: %v", got, served, err)
+		}
+		if len(resp) == 0 {
+			continue
+		}
+		got += len(resp)
+	}
+
+	// The upstream is now finished, and it finished badly.
+	var err error
+	for i := 0; i < 50 && err == nil; i++ {
+		_, err = sess.serveRequest(true, uint64(served+i+1), nil, 1024, 20*time.Millisecond)
+	}
+	if err == nil {
+		t.Fatal("a broken upstream never ended the session")
+	}
+	if errors.Is(err, errUpstreamClosed) {
+		t.Fatal("a broken upstream reported a clean end of stream; the client would surface io.EOF and the caller would read a short, apparently complete stream")
+	}
+	if !errors.Is(err, errUpstreamBroken) || !errors.Is(err, failure) {
+		t.Fatalf("got %v, want it to wrap both errUpstreamBroken and the read failure", err)
+	}
 }

--- a/protocol/meek/server.go
+++ b/protocol/meek/server.go
@@ -179,7 +179,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	downstream, err := sess.serveRequest(hasSeq, seq, body, respCap, s.cfg.ResponseHoldoff)
 	if err != nil {
 		s.dropSession(sid)
-		if errors.Is(err, errUpstreamClosed) {
+		if errors.Is(err, errUpstreamBroken) {
+			// The upstream ended with a read failure, not an end of stream. This
+			// must not be a 410: the client maps 410 to io.EOF, so a truncated
+			// tunnel would reach the caller as a clean finish and the tail of the
+			// byte stream would vanish silently.
+			s.cfg.Logger.Debug("meek server: upstream failed; closing session", slog.String("sid", sid), slog.Any("error", err))
+			http.Error(w, "upstream failed", http.StatusBadGateway)
+		} else if errors.Is(err, errUpstreamClosed) {
 			// Clean end-of-stream: upstream closed with nothing left. 410 tells the
 			// client the session is gone so its Conn surfaces EOF instead of polling forever.
 			s.cfg.Logger.Debug("meek server: upstream closed; ending session", slog.String("sid", sid))
@@ -313,6 +320,11 @@ type session struct {
 	last         time.Time
 	readWakeCh   chan struct{}
 	upstreamDone chan struct{}
+	// upstreamErr is the non-EOF error that ended readPump, if any. It is what
+	// separates "upstream finished" from "upstream broke": both close
+	// upstreamDone, but only the first is an end of stream the client may
+	// report as io.EOF.
+	upstreamErr error
 	// drainCond wakes a readPump paused because pending is at cap, when
 	// takeLocked frees space or the session closes.
 	drainCond *sync.Cond
@@ -330,6 +342,12 @@ type session struct {
 // errUpstreamClosed signals that the upstream is closed with nothing left to
 // send, so ServeHTTP should drop the session and tell the client to tear down.
 var errUpstreamClosed = errors.New("meek: upstream closed")
+
+// errUpstreamBroken signals that the upstream ended with a read failure rather
+// than an end of stream. It must NOT become a 410: the client maps 410 to
+// io.EOF, which would report a truncated tunnel to the caller as a clean
+// finish. Anything else is surfaced as an error, which is the honest answer.
+var errUpstreamBroken = errors.New("meek: upstream failed")
 
 func newSession(id string, upstream net.Conn) *session {
 	s := &session{
@@ -358,8 +376,13 @@ func (s *session) serveRequest(hasSeq bool, seq uint64, body []byte, respCap int
 			}
 		}
 		resp := s.takeDownstream(respCap, holdoff)
-		if len(resp) == 0 && s.upstreamFinished() {
-			return nil, errUpstreamClosed
+		if len(resp) == 0 {
+			if done, upErr := s.upstreamFinished(); done {
+				if upErr != nil {
+					return nil, fmt.Errorf("%w: %w", errUpstreamBroken, upErr)
+				}
+				return nil, errUpstreamClosed
+			}
 		}
 		return resp, nil
 	}
@@ -375,8 +398,13 @@ func (s *session) serveRequest(hasSeq bool, seq uint64, body []byte, respCap int
 		}
 	}
 	resp := s.takeDownstream(respCap, holdoff)
-	if len(resp) == 0 && s.upstreamFinished() {
-		return nil, errUpstreamClosed
+	if len(resp) == 0 {
+		if done, upErr := s.upstreamFinished(); done {
+			if upErr != nil {
+				return nil, fmt.Errorf("%w: %w", errUpstreamBroken, upErr)
+			}
+			return nil, errUpstreamClosed
+		}
 	}
 	s.haveSeq = true
 	s.lastSeq = seq
@@ -388,15 +416,18 @@ func (s *session) serveRequest(hasSeq bool, seq uint64, body []byte, respCap int
 // downstream bytes have been drained — i.e. there is nothing left to ever send,
 // so the session should end and the client tear down (otherwise a read-only
 // client would poll forever on empty 200s, never seeing EOF).
-func (s *session) upstreamFinished() bool {
+func (s *session) upstreamFinished() (bool, error) {
 	select {
 	case <-s.upstreamDone:
 	default:
-		return false
+		return false, nil
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return len(s.pending) == 0
+	if len(s.pending) > 0 {
+		return false, nil
+	}
+	return true, s.upstreamErr
 }
 
 func (s *session) lastSeen() time.Time {
@@ -448,6 +479,11 @@ func (s *session) readPump(cap int) {
 			s.signalWake()
 		}
 		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				s.mu.Lock()
+				s.upstreamErr = err
+				s.mu.Unlock()
+			}
 			return
 		}
 	}


### PR DESCRIPTION
`readPump` returns on **any** upstream read error, and that return closes `upstreamDone` — the signal the session reads as *"upstream closed with nothing left."* So a failed read was laundered into a clean end of stream.

```mermaid
sequenceDiagram
    autonumber
    participant U as upstream<br/>server.go
    participant P as readPump<br/>server.go:459
    participant S as serveRequest<br/>server.go:371
    participant H as ServeHTTP<br/>server.go:124
    participant C as client<br/>client.go:429

    U-->>P: server.go:463<br/>Read fails — RST, I/O error, timeout
    rect rgba(255, 200, 200, 0.3)
        Note over P: server.go:481<br/>BEFORE: returned on ANY error, closing upstreamDone 🐛
    end
    Note over S: upstreamFinished — indistinguishable from a clean close ⚠️
    S-->>H: errUpstreamClosed
    H-->>C: 410 Gone
    Note over C: client.go:429<br/>410 maps to permanentError io.EOF
    C-->>C: Conn.Read returns io.EOF on a TRUNCATED stream
```

The caller could not tell a finished transfer from a broken one, and the tail of the tunneled byte stream disappeared without a word.

What makes this read as an oversight rather than a decision: the same hazard is guarded deliberately twenty lines away in `client.go`, which rejects an over-cap response rather than truncating — *"which would corrupt the tunneled byte stream."*

### The change

- `readPump` records a non-EOF failure in `session.upstreamErr`
- `upstreamFinished()` returns `(done bool, err error)` so callers can tell the two apart
- the handler answers **502** for a broken upstream and keeps **410** for a genuine end of stream

The client maps any non-410 status to `permanentError`, so a truncated tunnel now surfaces as an **error** rather than a short, apparently complete stream.

It also now **quotes the server's reason**. Both failure paths are 502 — a failed upstream read and a failed upstream write — so without it the distinction dies at the status line, which is worth nothing. That bit immediately: the first CI run on this branch reported `meek: status 502` and I could not tell which path produced it. The reason is remote input, so it is capped at 256 bytes and rendered with `%q`.

### Tests

`TestBrokenUpstreamIsNotReportedAsCleanEOF` drives a `brokenUpstream` that serves 4 KiB and then fails the read, drains what arrived, and requires the session to end with `errUpstreamBroken` wrapping the cause. Reverting just the EOF check in `readPump` fails it with:

```
retry_integrity_test.go:257: a broken upstream reported a clean end of stream;
the client would surface io.EOF and the caller would read a short, apparently
complete stream
```

`go build ./...`, `go vet ./...`, `go test ./...` and `go test -race ./protocol/meek/` are clean.

### How it was found, and what it does not settle

`TestMeekRetryDownloadIntegrity` has failed CI **six times today** across #319 and #321 with `read err at 195584/2097152 bytes: EOF`, while passing ~100 local runs including under `-cpu=1` scheduling pressure. It only became visible at all because #321's `.PHONY: test` fix made CI execute the Go suite — before that, `make test` matched the `test/` directory and ran nothing.

**I could not reproduce that CI failure locally, so this is not confirmed to be its cause.** What it is: the mechanism that turns any upstream read failure into exactly that symptom. With this change the same event reports a 502 and its cause rather than a bare `EOF`.

**The first CI run on this branch settled it.** The same test failed, but differently:

| | byte count | error |
|---|---|---|
| before | 195584 / 2097152 | `EOF` |
| after | 128000 / 2097152 | `meek: status 502` |

So there *is* a genuine upstream failure on CI, and the old code was turning it into a clean end of stream. This was never a flaky test — it was a real fault reported dishonestly, and the test was right to fail all along.

**It still fails.** What this PR changes is that it has stopped lying about why. With the reason now carried through, the next run should name which of the two 502 paths it is — and those point at different bugs. Diagnosing the underlying upstream failure is follow-up work, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gn6KuHUL766qQNn8m1fu1
