### PR TITLE
deps: bump Twiddle to merged transcript-binding fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395
 	github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb
-	github.com/getlantern/twiddle v0.0.0-20260905105024-c78665a55653
+	github.com/getlantern/twiddle v0.0.0-20260907083007-7261fa53edc2
 	github.com/gobwas/ws v1.4.0
 	github.com/hashicorp/yamux v0.1.2
 	github.com/pion/transport/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/getlantern/sing-box-minimal v1.13.19-lantern h1:dwVCskH9N3Q5a2wVELdyG
 github.com/getlantern/sing-box-minimal v1.13.19-lantern/go.mod h1:4E8WvF7Vi60N1NtPw1CeG994J/yiJZZkty5dKKwG+V0=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5 h1:6ITBYqNkLbVZ1tQNXwmH8N80rZtvyW6IZa8L6EAhBQo=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5/go.mod h1:gx3dPUhZtQszPX5C+TshhxPXQHlY5t4gMnOOMA+viPA=
-github.com/getlantern/twiddle v0.0.0-20260905105024-c78665a55653 h1:UvPP70jRX0tZ4VK2x/KyYquFWtWDFLHa8ngT+D6KuKc=
-github.com/getlantern/twiddle v0.0.0-20260905105024-c78665a55653/go.mod h1:aU9c2/kcZhCxXCOZMN/Vulc+baDNHecqlvgLXOIeyOY=
+github.com/getlantern/twiddle v0.0.0-20260907083007-7261fa53edc2 h1:Mgux29TDxuOXbpJ8Zza3q4pm+ARSqcmkoyhIxqOW+3E=
+github.com/getlantern/twiddle v0.0.0-20260907083007-7261fa53edc2/go.mod h1:aU9c2/kcZhCxXCOZMN/Vulc+baDNHecqlvgLXOIeyOY=
 github.com/getlantern/water v0.7.1-alpha.0.20260309190745-bd547c14b4aa h1:goZee1cURbWPiqX1xyjfwLB/zByQ50hEwonnnyLmcJQ=
 github.com/getlantern/water v0.7.1-alpha.0.20260309190745-bd547c14b4aa/go.mod h1:Yo6Yk++Q9HRaCT+6/eYk3elNoNtjlJ3V5FufHY6ezto=
 github.com/getlantern/wazero v1.11.0-water.1 h1:mzUlaOoQKMDd16yL3mBIFrzg2nEK+gw7mdQgff1nOPQ=

--- a/protocol/meek/retry_integrity_test.go
+++ b/protocol/meek/retry_integrity_test.go
@@ -74,6 +74,7 @@ func newMeekTestStack(t *testing.T, upstream string, dropEvery int64) (*Conn, *f
 // byte — a gap (lost-after-drain) or dup would fail the compare.
 func TestMeekRetryDownloadIntegrity(t *testing.T) {
 	const size = 2 << 20
+	const trigger = "go"
 	payload := make([]byte, size)
 	if _, err := rand.Read(payload); err != nil {
 		t.Fatal(err)
@@ -91,14 +92,20 @@ func TestMeekRetryDownloadIntegrity(t *testing.T) {
 			}
 			go func(c net.Conn) {
 				defer c.Close()
-				go io.Copy(io.Discard, c) // drain the client's trigger byte(s)
+				_ = c.SetDeadline(time.Now().Add(10 * time.Second))
+				// Consume the trigger before sending and closing. Racing Close
+				// against a background drain can leave unread input, causing a
+				// TCP reset that truncates the queued download on Linux.
+				if _, err := io.CopyN(io.Discard, c, int64(len(trigger))); err != nil {
+					return
+				}
 				_, _ = c.Write(payload)
 			}(c)
 		}
 	}()
 
 	conn, ft := newMeekTestStack(t, ln.Addr().String(), 4)
-	if _, err := conn.Write([]byte("go")); err != nil { // trigger upstream
+	if _, err := conn.Write([]byte(trigger)); err != nil { // trigger upstream
 		t.Fatal(err)
 	}
 	_ = conn.SetReadDeadline(time.Now().Add(20 * time.Second))


### PR DESCRIPTION
Bump `github.com/getlantern/twiddle` from `v0.0.0-20260905105024-c78665a55653` to `v0.0.0-20260907083007-7261fa53edc2`, the current merged `main` revision. The previous pin already included Twiddle PRs #1–#3; this picks up [getlantern/twiddle#4](https://github.com/getlantern/twiddle/pull/4).

The update binds opening payloads to traffic-key derivation, so modifying ServerHello fields causes authentication to fail. Plaintext record headers remain excluded, preserving tolerated record-version changes. Both lantern-box adapters already call the high-level Twiddle API, so no adapter changes are needed. Ran `go mod tidy`; only the Twiddle requirement and its two checksum entries changed.

The flow below uses lantern-box adapter lines from this branch and Twiddle lines from the pinned revision. It highlights the upstream omission this bump fixes.

```mermaid
sequenceDiagram
    autonumber
    participant O as Outbound<br/>outbound.go
    participant C as Client<br/>handshake.go
    participant S as Server<br/>handshake.go
    participant I as Inbound<br/>inbound.go
    O->>C: outbound.go:246<br/>tw.Client
    I->>S: inbound.go:109<br/>tw.Server
    C->>S: handshake.go:178<br/>ClientHello
    S->>C: handshake.go:316<br/>ServerHello
    S->>C: handshake.go:319<br/>ChangeCipherSpec
    Note over C,S: handshake.go:206,328<br/>Opening payloads now determine traffic keys ⚠️
    rect rgba(255, 200, 200, 0.3)
        Note over C: handshake.go:205<br/>Former derivation omitted the opening 🐛<br/>The pinned fix binds received payloads
    end
    S->>C: handshake.go:351<br/>Encrypted remainder
    Note over C: handshake.go:222<br/>Modified payloads produce different keys<br/>Record authentication fails
```

The PR also stabilizes the Meek download-retry test fixture. Its upstream previously wrote 2 MiB and closed while a background goroutine was still consuming the client trigger. On Linux, closing with unread input can reset the socket and truncate the queued download. The fixture now consumes the two-byte trigger synchronously before writing, with a deadline to bound the wait. Production Meek behavior is unchanged.

```mermaid
sequenceDiagram
    autonumber
    participant C as Client<br/>client.go
    participant M as Meek<br/>server.go
    participant U as Fixture<br/>retry_integrity_test.go
    C->>M: client.go:423<br/>POST trigger bytes
    M->>U: server.go:452<br/>Write trigger upstream
    rect rgba(255, 200, 200, 0.3)
        Note over U: retry_integrity_test.go:94<br/>Former bug: Close raced the background drain 🐛<br/>Unread input could reset the download
    end
    Note over U: retry_integrity_test.go:99<br/>Now consume the entire trigger before sending ⚠️
    U->>M: retry_integrity_test.go:102<br/>Write complete payload
    Note over U: retry_integrity_test.go:94<br/>Close after trigger consumption and payload write
    Note over M: server.go:463<br/>Read payload to clean EOF
```

Validation:

- `make test` passed, including `TestTwiddleCarriesTCPAndUDPOverOneTunnel`.
- `go test -count=1 -race ./protocol/twiddle` passed.
- Built `./cmd` and confirmed with `go version -m` that the binary embeds `v0.0.0-20260907083007-7261fa53edc2`.
- `go mod tidy` and `git diff --check` passed.
- Reproduced the original Meek fixture failure in Linux. The fixed download test passed 100 consecutive Linux runs.
- `go test -count=1 -race ./protocol/meek` and `go vet ./protocol/meek` passed.

**Wire compatibility:** client and server must both use the new derivation. A peer using the previous pin cannot decrypt traffic from the new version. Coordinate both ends when rolling out the resulting lantern-box release. This PR updates the dependency and a test fixture; it does not deploy either endpoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
