### PR TITLE
Collect optional coarse traffic counters for usage evaluation

### DIFF
--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	runtimeDebug "runtime/debug"
+	"strings"
 	"syscall"
 	"time"
 
@@ -95,8 +96,11 @@ func create(configPath string, datacapURL string) (*box.Box, context.CancelFunc,
 		log.Info("Datacap enabled. Creating tracker...")
 		datacapTracker, err := datacap.NewDatacapTracker(
 			datacap.Options{
-				URL:            datacapURL,
-				ReportInterval: "10s",
+				URL:               datacapURL,
+				TrafficCategories: os.Getenv("LANTERN_TRAFFIC_CATEGORIES") == "1",
+				LanternHosts:      strings.Split(os.Getenv("LANTERN_TRAFFIC_SERVICE_HOSTS"), ","),
+				ProbeHosts:        strings.Split(os.Getenv("LANTERN_TRAFFIC_PROBE_HOSTS"), ","),
+				ReportInterval:    "10s",
 			},
 			log.StdLogger(),
 		)

--- a/tracker/datacap/TRAFFIC.md
+++ b/tracker/datacap/TRAFFIC.md
@@ -1,0 +1,36 @@
+# Coarse traffic reporting
+
+Datacap tracking can optionally classify traffic locally into `lantern`, `probe`,
+`other`, and `unknown`, using the requested hostname available at routing time.
+Reports contain byte counters and bidirectional TCP connection counts only; no
+destination hostnames, IPs, URLs or content are added to the reporting payload.
+This collection does not gate connections or change throttling.
+
+Enable `LANTERN_TRAFFIC_CATEGORIES=1` on a proxy already using `--datacap-url`.
+The default is off. Deploy a sidecar supporting the additive `trafficUsage`
+JSON field before enabling it: older sidecars reject unknown JSON fields.
+The companion lantern-cloud implementation forwards these counters and can
+retain them under `datacap_usage_history_enabled`, which also defaults off.
+
+`LANTERN_TRAFFIC_SERVICE_HOSTS` and `LANTERN_TRAFFIC_PROBE_HOSTS` are optional
+comma-separated additions to the built-in exact-match host lists. Embedders
+can configure the equivalent `TrafficCategories`, `LanternHosts` and
+`ProbeHosts` options. Case and a final dot are normalized. No suffix matching,
+DNS resolution or HTTPS inspection is performed.
+
+API and callback traffic sharing a Lantern hostname is classified as `lantern`.
+`probe` means a known probe hostname, not a verified probe request: that host
+may also serve other content. Unlisted service hosts may appear as `other`,
+which also includes automated traffic and is not evidence of humanity.
+IP-only destinations are unknown. UDP associations can contain several
+destinations and report unknown bytes, without connection counts.
+
+A TCP connection contributes a connection count only once after bytes have
+been read and written, on a report acknowledged by the sidecar. Failed reports
+retain the pending count for retry. An acknowledgement lost after ingestion
+can still cause duplication because the existing datacap protocol reports
+deltas without stable report IDs. Bidirectional bytes do not establish
+application success. Connections without client-context metadata and Pro
+clients retain the existing datacap exclusion behavior.
+
+Verify with `go test -race -timeout=180s ./tracker/datacap`.

--- a/tracker/datacap/client.go
+++ b/tracker/datacap/client.go
@@ -77,10 +77,11 @@ type DataCapStatus struct {
 
 // DataCapReport represents the request body for POST /data-cap/ endpoint.
 type DataCapReport struct {
-	DeviceID    string `json:"deviceId"`
-	CountryCode string `json:"countryCode"`
-	Platform    string `json:"platform"`
-	BytesUsed   int64  `json:"bytesUsed"`
+	DeviceID     string        `json:"deviceId"`
+	CountryCode  string        `json:"countryCode"`
+	Platform     string        `json:"platform"`
+	BytesUsed    int64         `json:"bytesUsed"`
+	TrafficUsage *TrafficUsage `json:"trafficUsage,omitempty"`
 }
 
 func (c *Client) GetDataCapStatus(ctx context.Context, deviceID string) (*DataCapStatus, error) {

--- a/tracker/datacap/conn.go
+++ b/tracker/datacap/conn.go
@@ -23,6 +23,10 @@ const (
 
 // Conn wraps a net.Conn and tracks data consumption for datacap reporting.
 type Conn struct {
+	trafficCategory       string
+	hasRead               atomic.Bool
+	hasWritten            atomic.Bool
+	bidirectionalReported bool // Guarded by reportMutex.
 	net.Conn
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -47,12 +51,13 @@ type Conn struct {
 
 // ConnConfig holds configuration for creating a datacap-tracked connection.
 type ConnConfig struct {
-	Conn           net.Conn
-	Client         *Client
-	Logger         log.ContextLogger
-	ClientInfo     clientcontext.ClientInfo
-	ReportInterval time.Duration
-	Throttler      *Throttler // Shared throttler from registry
+	TrafficCategory string
+	Conn            net.Conn
+	Client          *Client
+	Logger          log.ContextLogger
+	ClientInfo      clientcontext.ClientInfo
+	ReportInterval  time.Duration
+	Throttler       *Throttler // Shared throttler from registry
 }
 
 // NewConn creates a new datacap-tracked connection wrapper.
@@ -71,14 +76,15 @@ func NewConn(config ConnConfig) *Conn {
 	}
 
 	conn := &Conn{
-		Conn:         config.Conn,
-		ctx:          ctx,
-		cancel:       cancel,
-		client:       config.Client,
-		logger:       config.Logger,
-		clientInfo:   config.ClientInfo,
-		reportTicker: time.NewTicker(config.ReportInterval),
-		throttler:    throttler,
+		trafficCategory: config.TrafficCategory,
+		Conn:            config.Conn,
+		ctx:             ctx,
+		cancel:          cancel,
+		client:          config.Client,
+		logger:          config.Logger,
+		clientInfo:      config.ClientInfo,
+		reportTicker:    time.NewTicker(config.ReportInterval),
+		throttler:       throttler,
 	}
 
 	// Start periodic reporting goroutine
@@ -92,6 +98,7 @@ func NewConn(config ConnConfig) *Conn {
 func (c *Conn) Read(b []byte) (n int, err error) {
 	n, err = c.Conn.Read(b)
 	if n > 0 {
+		c.hasRead.Store(true)
 		c.bytesReceived.Add(int64(n))
 
 		// Apply throttling after read (token bucket wait)
@@ -110,6 +117,7 @@ func (c *Conn) Read(b []byte) (n int, err error) {
 func (c *Conn) Write(b []byte) (n int, err error) {
 	n, err = c.Conn.Write(b)
 	if n > 0 {
+		c.hasWritten.Store(true)
 		c.bytesSent.Add(int64(n))
 
 		// Apply throttling after write (token bucket wait)
@@ -181,6 +189,9 @@ func (c *Conn) sendReport() {
 		BytesUsed:   delta,
 	}
 
+	bidirectional := c.hasRead.Load() && c.hasWritten.Load() && !c.bidirectionalReported
+	report.TrafficUsage = trafficReport(c.trafficCategory, delta, bidirectional)
+
 	timeout := c.client.httpClient.Timeout
 	if timeout == 0 {
 		timeout = 10 * time.Second
@@ -195,6 +206,9 @@ func (c *Conn) sendReport() {
 		c.bytesReceived.Add(received)
 		c.logger.Debug("failed to report datacap consumption (will retry): ", err)
 	} else {
+		if bidirectional {
+			c.bidirectionalReported = true
+		}
 		c.logger.Debug("reported datacap delta: ", delta, " bytes (sent: ", sent, ", received: ", received, ") for device ", c.clientInfo.DeviceID)
 		if status != nil {
 			c.updateThrottleState(status)

--- a/tracker/datacap/conn.go
+++ b/tracker/datacap/conn.go
@@ -98,7 +98,9 @@ func NewConn(config ConnConfig) *Conn {
 func (c *Conn) Read(b []byte) (n int, err error) {
 	n, err = c.Conn.Read(b)
 	if n > 0 {
-		c.hasRead.Store(true)
+		if c.trafficCategory != "" {
+			c.hasRead.Store(true)
+		}
 		c.bytesReceived.Add(int64(n))
 
 		// Apply throttling after read (token bucket wait)
@@ -117,7 +119,9 @@ func (c *Conn) Read(b []byte) (n int, err error) {
 func (c *Conn) Write(b []byte) (n int, err error) {
 	n, err = c.Conn.Write(b)
 	if n > 0 {
-		c.hasWritten.Store(true)
+		if c.trafficCategory != "" {
+			c.hasWritten.Store(true)
+		}
 		c.bytesSent.Add(int64(n))
 
 		// Apply throttling after write (token bucket wait)
@@ -189,7 +193,7 @@ func (c *Conn) sendReport() {
 		BytesUsed:   delta,
 	}
 
-	bidirectional := c.hasRead.Load() && c.hasWritten.Load() && !c.bidirectionalReported
+	bidirectional := c.trafficCategory != "" && c.hasRead.Load() && c.hasWritten.Load() && !c.bidirectionalReported
 	report.TrafficUsage = trafficReport(c.trafficCategory, delta, bidirectional)
 
 	timeout := c.client.httpClient.Timeout

--- a/tracker/datacap/packet_conn.go
+++ b/tracker/datacap/packet_conn.go
@@ -16,6 +16,7 @@ import (
 
 // PacketConn wraps a sing-box network.PacketConn and tracks data consumption for datacap reporting.
 type PacketConn struct {
+	trafficCategories bool
 	N.PacketConn
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -40,12 +41,13 @@ type PacketConn struct {
 
 // PacketConnConfig holds configuration for creating a datacap-tracked packet connection.
 type PacketConnConfig struct {
-	Conn           N.PacketConn
-	Client         *Client
-	Logger         log.ContextLogger
-	ClientInfo     clientcontext.ClientInfo
-	ReportInterval time.Duration
-	Throttler      *Throttler // Shared throttler from registry
+	TrafficCategories bool
+	Conn              N.PacketConn
+	Client            *Client
+	Logger            log.ContextLogger
+	ClientInfo        clientcontext.ClientInfo
+	ReportInterval    time.Duration
+	Throttler         *Throttler // Shared throttler from registry
 }
 
 // NewPacketConn creates a new datacap-tracked packet connection wrapper.
@@ -64,14 +66,15 @@ func NewPacketConn(config PacketConnConfig) *PacketConn {
 	}
 
 	conn := &PacketConn{
-		PacketConn:   config.Conn,
-		ctx:          ctx,
-		cancel:       cancel,
-		client:       config.Client,
-		logger:       config.Logger,
-		clientInfo:   config.ClientInfo,
-		reportTicker: time.NewTicker(config.ReportInterval),
-		throttler:    throttler,
+		trafficCategories: config.TrafficCategories,
+		PacketConn:        config.Conn,
+		ctx:               ctx,
+		cancel:            cancel,
+		client:            config.Client,
+		logger:            config.Logger,
+		clientInfo:        config.ClientInfo,
+		reportTicker:      time.NewTicker(config.ReportInterval),
+		throttler:         throttler,
 	}
 
 	// Start periodic reporting goroutine
@@ -178,6 +181,11 @@ func (c *PacketConn) sendReport() {
 		BytesUsed:   delta,
 	}
 
+	// A UDP association can carry several destinations; do not apply one
+	// connection-level hostname to all packets. No UDP connection count is inferred.
+	if c.trafficCategories {
+		report.TrafficUsage = trafficReport("unknown", delta, false)
+	}
 	timeout := c.client.httpClient.Timeout
 	if timeout == 0 {
 		timeout = 10 * time.Second

--- a/tracker/datacap/tracker.go
+++ b/tracker/datacap/tracker.go
@@ -16,6 +16,7 @@ import (
 var _ (adapter.ConnectionTracker) = (*DatacapTracker)(nil)
 
 type DatacapTracker struct {
+	classify         func(string) string
 	client           *Client
 	logger           log.ContextLogger
 	reportInterval   time.Duration
@@ -23,9 +24,12 @@ type DatacapTracker struct {
 }
 
 type Options struct {
-	URL            string `json:"url,omitempty"`
-	ReportInterval string `json:"report_interval,omitempty"`
-	HTTPTimeout    string `json:"http_timeout,omitempty"`
+	TrafficCategories bool     `json:"traffic_categories,omitempty"`
+	LanternHosts      []string `json:"lantern_hosts,omitempty"`
+	ProbeHosts        []string `json:"probe_hosts,omitempty"`
+	URL               string   `json:"url,omitempty"`
+	ReportInterval    string   `json:"report_interval,omitempty"`
+	HTTPTimeout       string   `json:"http_timeout,omitempty"`
 }
 
 func NewDatacapTracker(options Options, logger log.ContextLogger) (*DatacapTracker, error) {
@@ -50,7 +54,12 @@ func NewDatacapTracker(options Options, logger log.ContextLogger) (*DatacapTrack
 		}
 		httpTimeout = timeout
 	}
+	var classify func(string) string
+	if options.TrafficCategories {
+		classify = newTrafficClassifier(options.LanternHosts, options.ProbeHosts)
+	}
 	return &DatacapTracker{
+		classify:         classify,
 		client:           NewClient(options.URL, httpTimeout),
 		reportInterval:   reportInterval,
 		throttleRegistry: NewThrottleRegistry(),
@@ -69,13 +78,18 @@ func (t *DatacapTracker) RoutedConnection(ctx context.Context, conn net.Conn, me
 		t.logger.Debug("skipping datacap: client is pro ", info.DeviceID)
 		return conn
 	}
+	category := ""
+	if t.classify != nil {
+		category = t.classify(metadata.Destination.Fqdn)
+	}
 	return NewConn(ConnConfig{
-		Conn:           conn,
-		Client:         t.client,
-		Logger:         t.logger,
-		ClientInfo:     info,
-		ReportInterval: t.reportInterval,
-		Throttler:      t.throttleRegistry.GetOrCreate(info.DeviceID),
+		TrafficCategory: category,
+		Conn:            conn,
+		Client:          t.client,
+		Logger:          t.logger,
+		ClientInfo:      info,
+		ReportInterval:  t.reportInterval,
+		Throttler:       t.throttleRegistry.GetOrCreate(info.DeviceID),
 	})
 }
 func (t *DatacapTracker) RoutedPacketConnection(ctx context.Context, conn N.PacketConn, metadata adapter.InboundContext, matchedRule adapter.Rule, matchOutbound adapter.Outbound) N.PacketConn {
@@ -90,11 +104,12 @@ func (t *DatacapTracker) RoutedPacketConnection(ctx context.Context, conn N.Pack
 		return conn
 	}
 	return NewPacketConn(PacketConnConfig{
-		Conn:           conn,
-		Client:         t.client,
-		Logger:         t.logger,
-		ClientInfo:     info,
-		ReportInterval: t.reportInterval,
-		Throttler:      t.throttleRegistry.GetOrCreate(info.DeviceID),
+		TrafficCategories: t.classify != nil,
+		Conn:              conn,
+		Client:            t.client,
+		Logger:            t.logger,
+		ClientInfo:        info,
+		ReportInterval:    t.reportInterval,
+		Throttler:         t.throttleRegistry.GetOrCreate(info.DeviceID),
 	})
 }

--- a/tracker/datacap/traffic.go
+++ b/tracker/datacap/traffic.go
@@ -1,0 +1,78 @@
+package datacap
+
+import (
+	"net/netip"
+	"strings"
+)
+
+// TrafficUsage carries only coarse counters to the sidecar. A bidirectional
+// connection is evidence of exchanged bytes, not application success or humanity.
+type TrafficUsage struct {
+	LanternBytes       int64 `json:"lanternBytes,omitempty"`
+	ProbeBytes         int64 `json:"probeBytes,omitempty"`
+	OtherBytes         int64 `json:"otherBytes,omitempty"`
+	UnknownBytes       int64 `json:"unknownBytes,omitempty"`
+	LanternConnections int64 `json:"lanternConnections,omitempty"`
+	ProbeConnections   int64 `json:"probeConnections,omitempty"`
+	OtherConnections   int64 `json:"otherConnections,omitempty"`
+	UnknownConnections int64 `json:"unknownConnections,omitempty"`
+}
+
+func trafficReport(category string, bytes int64, bidirectional bool) *TrafficUsage {
+	if category == "" {
+		return nil
+	}
+	u := &TrafficUsage{}
+	var count int64
+	if bidirectional {
+		count = 1
+	}
+	switch category {
+	case "lantern":
+		u.LanternBytes, u.LanternConnections = bytes, count
+	case "probe":
+		u.ProbeBytes, u.ProbeConnections = bytes, count
+	case "other":
+		u.OtherBytes, u.OtherConnections = bytes, count
+	default:
+		u.UnknownBytes, u.UnknownConnections = bytes, count
+	}
+	return u
+}
+
+// Only the requested hostname is examined, locally. This never resolves DNS,
+// inspects TLS/HTTP contents, or retains destinations in reports or labels.
+// Exact host matches deliberately avoid classifying unrelated subdomains.
+func newTrafficClassifier(extraLantern, extraProbes []string) func(string) string {
+	lantern := map[string]bool{}
+	probes := map[string]bool{}
+	for _, host := range append([]string{"api.iantem.io", "df.iantem.io", "api.getiantem.org", "api.lantern.io", "api.lantr.net"}, extraLantern...) {
+		lantern[normalizeHost(host)] = true
+	}
+	for _, host := range append([]string{"www.gstatic.com", "connectivitycheck.gstatic.com", "connectivitycheck.android.com", "captive.apple.com", "www.msftconnecttest.com", "dns.msftncsi.com", "cp.cloudflare.com"}, extraProbes...) {
+		probes[normalizeHost(host)] = true
+	}
+	return func(host string) string {
+		host = normalizeHost(host)
+		if host == "" {
+			return "unknown"
+		}
+		if _, err := netip.ParseAddr(host); err == nil {
+			return "unknown"
+		}
+		if strings.ContainsAny(host, ":/[]@ \\?\t\r\n") {
+			return "unknown"
+		}
+		if lantern[host] {
+			return "lantern"
+		}
+		if probes[host] {
+			return "probe"
+		}
+		return "other"
+	}
+}
+
+func normalizeHost(host string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+}

--- a/tracker/datacap/traffic_test.go
+++ b/tracker/datacap/traffic_test.go
@@ -1,0 +1,89 @@
+package datacap
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/getlantern/lantern-box/tracker/clientcontext"
+	"github.com/sagernet/sing-box/adapter"
+	M "github.com/sagernet/sing/common/metadata"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrafficClassifier(t *testing.T) {
+	classify := newTrafficClassifier([]string{"api.custom.example"}, []string{"probe.custom.example"})
+	for host, want := range map[string]string{
+		"api.iantem.io": "lantern", "API.GETIANTEM.ORG.": "lantern", "api.custom.example": "lantern",
+		"www.gstatic.com": "probe", "probe.custom.example": "probe", "news.example": "other",
+		"api.iantem.io.evil.example": "other", "fonts.gstatic.com": "other",
+		"": "unknown", "192.0.2.1": "unknown", "2001:db8::1": "unknown", "https://api.iantem.io/path": "unknown",
+	} {
+		require.Equal(t, want, classify(host), host)
+	}
+}
+
+func TestTrafficReportsBidirectionalOnceAndOmitsDestinations(t *testing.T) {
+	var reports []DataCapReport
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NotContains(t, string(body), "news.example")
+		var report DataCapReport
+		require.NoError(t, json.Unmarshal(body, &report))
+		reports = append(reports, report)
+		if len(reports) == 2 {
+			http.Error(w, "retry", 503)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"throttle":false}`))
+	}))
+	defer srv.Close()
+	tracker, err := NewDatacapTracker(Options{URL: srv.URL, TrafficCategories: true, ReportInterval: "1h"}, noopLogger)
+	require.NoError(t, err)
+	ctx := clientcontext.ContextWithClientInfo(context.Background(), clientcontext.ClientInfo{DeviceID: "device", CountryCode: "IR", Platform: "android"})
+	conn := tracker.RoutedConnection(ctx, newMockConn([]byte("read")), adapter.InboundContext{Destination: M.ParseSocksaddr("news.example:443")}, nil, nil).(*Conn)
+	defer conn.Close()
+	_, err = conn.Read(make([]byte, 4))
+	require.NoError(t, err)
+	conn.sendReport()
+	_, err = conn.Write([]byte("ok"))
+	require.NoError(t, err)
+	conn.sendReport() // rejected; restore the bytes and retain pending connection evidence
+	conn.sendReport()
+	_, err = conn.Write([]byte("!"))
+	require.NoError(t, err)
+	conn.sendReport()
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, reports, 4)
+	require.EqualValues(t, 4, reports[0].TrafficUsage.OtherBytes)
+	require.Zero(t, reports[0].TrafficUsage.OtherConnections)
+	for _, i := range []int{1, 2} {
+		require.EqualValues(t, 2, reports[i].TrafficUsage.OtherBytes)
+		require.EqualValues(t, 1, reports[i].TrafficUsage.OtherConnections)
+	}
+	require.EqualValues(t, 1, reports[3].TrafficUsage.OtherBytes)
+	require.Zero(t, reports[3].TrafficUsage.OtherConnections)
+}
+
+func TestTrafficCollectionDefaultsOff(t *testing.T) {
+	tracker, err := NewDatacapTracker(Options{URL: "http://127.0.0.1:1"}, noopLogger)
+	require.NoError(t, err)
+	require.Nil(t, tracker.classify)
+	encoded, err := json.Marshal(DataCapReport{DeviceID: "device", BytesUsed: 123, TrafficUsage: trafficReport("", 123, true)})
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "trafficUsage")
+	// UDP associations have no inferred bidirectional TCP connection count.
+	unknown := trafficReport("unknown", 123, false)
+	require.EqualValues(t, 123, unknown.UnknownBytes)
+	require.Zero(t, unknown.UnknownConnections)
+}


### PR DESCRIPTION
Add opt-in proxy traffic counters so we can evaluate sustained usage as a signal for future protected-track admission. Classify requested hostnames locally into Lantern, probe, other and unknown traffic; send only byte totals and bidirectional TCP connection counts to the datacap sidecar. UDP bytes remain unknown. No destination names, IPs, URLs or content are added to reports.

Collection defaults off (`LANTERN_TRAFFIC_CATEGORIES=1` enables it). Deploy the companion getlantern/lantern-cloud#3334 API/sidecar support before enabling reporters, because older sidecars reject the additive JSON field. This is observation only: it does not grant access or change throttling. Other traffic is not proof of humanity, and existing delta-retry duplication remains a limitation.

Validation: `go test -race -timeout=180s ./tracker/datacap`, command-package compilation, gofmt and diff checks pass.

Related: getlantern/engineering#3880.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional traffic categorization for datacap reporting: Lantern, probe, other, and unknown.
  * Reports can include coarse byte totals and bidirectional TCP connection counts without destination hostnames, URLs, IPs, or content.
  * Added support for configuring service and probe host lists through environment variables.
  * UDP traffic reports bytes but does not infer connection counts.
  * Traffic categorization remains disabled by default.

* **Documentation**
  * Added guidance on configuration, reporting behavior, privacy, compatibility, and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->